### PR TITLE
Fixes #433 actors not being cleaned up in draw tree

### DIFF
--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -578,7 +578,8 @@ module ex {
      * Actors with a higher z-index are drawn on top of actors with a lower z-index
      * @param actor The child actor to remove
      */
-    public setZIndex(newIndex: number) {
+     public setZIndex(newIndex: number) {
+       this.scene.cleanupDrawTree(this);
        this._zIndex = newIndex;
        this.scene.updateDrawTree(this);
     }

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -564,10 +564,16 @@ module ex {
       }
 
       /**
+       * Removes the given actor from the sorted drawing tree
+       */
+      public cleanupDrawTree(actor: ex.Actor) {
+         this._sortedDrawingTree.remove(actor);
+      }
+
+      /**
        * Updates the given actor's position in the sorted drawing tree
        */
       public updateDrawTree(actor: ex.Actor) {
-         this._sortedDrawingTree.remove(actor);
          this._sortedDrawingTree.add(actor);
       }
 

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -567,7 +567,7 @@ module ex {
        * Removes the given actor from the sorted drawing tree
        */
       public cleanupDrawTree(actor: ex.Actor) {
-         this._sortedDrawingTree.remove(actor);
+         this._sortedDrawingTree.removeByComparable(actor);
       }
 
       /**

--- a/src/engine/Util/SortedList.ts
+++ b/src/engine/Util/SortedList.ts
@@ -86,7 +86,7 @@ module ex {
          return false;
       }
 
-      public remove(element: any): void {
+      public removeByComparable(element: any): void {
          this._root = this._remove(this._root, element);
       }
 

--- a/src/spec/SortedListSpec.ts
+++ b/src/spec/SortedListSpec.ts
@@ -42,7 +42,7 @@ describe('A SortedList', () => {
       var element = new Mocks.MockedElement(0);
       sortedList.add(element);
       expect(sortedList.find(element)).toBe(true);
-      sortedList.remove(element);
+      sortedList.removeByComparable(element);
       expect(sortedList.find(element)).toBe(false);
    });
 
@@ -66,7 +66,7 @@ describe('A SortedList', () => {
       sortedList.add(element2);
       sortedList.add(element3);
 
-      sortedList.remove(element2);
+      sortedList.removeByComparable(element2);
       expect(sortedList.find(element1)).toBe(true);
       expect(sortedList.find(element3)).toBe(true);
 
@@ -84,7 +84,7 @@ describe('A SortedList', () => {
 
       sortedList.add(element5);
 
-      sortedList.remove(element3);
+      sortedList.removeByComparable(element3);
       expect(sortedList.find(element2)).toBe(true);
       sortedList.list();
       expect(sortedList.find(element3)).toBe(false);


### PR DESCRIPTION
I believe this is the simplest way to resolve this issue for now. We'll revisit this when the self-balancing implementation is built.