### PR TITLE
close #438 fixing actor.getCenter()

### DIFF
--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -622,8 +622,7 @@ module ex {
      * Get the center point of an actor
      */
     public getCenter(): Vector {
-       var anchor = this._getCalculatedAnchor();
-       return new Vector(this.x + this.getWidth() / 2 , this.y + this.getHeight() / 2);
+       return new Vector(this.x + this.getWidth() / 2 - this.anchor.x * this.getWidth() , this.y + this.getHeight() / 2 - this.anchor.y * this.getHeight());
     }
     /**
      * Gets the calculated width of an actor, factoring in scale
@@ -1101,7 +1100,7 @@ module ex {
        ctx.fill();
        ctx.save();
        ctx.translate(this.x, this.y);
-       ctx.rotate(this.rotation);     
+       ctx.rotate(this.rotation);
        // Draw child actors
        for (var i = 0; i < this.children.length; i++) {
           this.children[i].debugDraw(ctx);

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -108,15 +108,31 @@ describe("A game actor", () => {
 		actor.setWidth(50);
 
 		var center = actor.getCenter();
-		expect(center.x).toBe(25);
-		expect(center.y).toBe(50);
+		expect(center.x).toBe(0);
+		expect(center.y).toBe(0);
 
 		actor.x = 100;
 		actor.y = 100;
 
 		center = actor.getCenter();
-		expect(center.x).toBe(125);
-		expect(center.y).toBe(150);
+		expect(center.x).toBe(100);
+      expect(center.y).toBe(100);
+
+      // changing the anchor
+      actor.anchor = new ex.Point(0, 0);
+      actor.x = 0;
+      actor.y = 0;
+
+      var center = actor.getCenter();
+      expect(center.x).toBe(25);
+      expect(center.y).toBe(50);
+
+      actor.x = 100;
+      actor.y = 100;
+
+      center = actor.getCenter();
+      expect(center.x).toBe(125);
+      expect(center.y).toBe(150);
 
 	});
 


### PR DESCRIPTION
actor.getCenter() was not properly accounting for the anchor of an actor
to be anywhere other than the top left corner