### PR TITLE
Fix rotation API to re-include rotation types

### DIFF
--- a/src/engine/Actions/ActionContext.ts
+++ b/src/engine/Actions/ActionContext.ts
@@ -213,11 +213,12 @@ module ex {
        * method is part of the actor 'Action' fluent API allowing action chaining.
        * @param angleRadians  The angle to rotate to in radians
        * @param speed         The angular velocity of the rotation specified in radians per second
+       * @param rotationType  The [[RotationType]] to use for this rotation
        */
-      public rotateTo(angleRadians: number, speed: number): ActionContext {
+      public rotateTo(angleRadians: number, speed: number, rotationType?: RotationType): ActionContext {
          var i = 0, len = this._queues.length;
          for (i; i < len; i++) {
-            this._queues[i].add(new ex.Internal.Actions.RotateTo(this._actors[i], angleRadians, speed));
+             this._queues[i].add(new ex.Internal.Actions.RotateTo(this._actors[i], angleRadians, speed, rotationType));
          }
          return this;
       }
@@ -228,11 +229,12 @@ module ex {
        * of the actor 'Action' fluent API allowing action chaining.
        * @param angleRadians  The angle to rotate to in radians
        * @param time          The time it should take the actor to complete the rotation in milliseconds
+       * @param rotationType  The [[RotationType]] to use for this rotation
        */
-      public rotateBy(angleRadians: number, time: number): ActionContext {
+      public rotateBy(angleRadians: number, time: number, rotationType?: RotationType): ActionContext {
          var i = 0, len = this._queues.length;
          for (i; i < len; i++) {
-            this._queues[i].add(new ex.Internal.Actions.RotateBy(this._actors[i], angleRadians, time));
+             this._queues[i].add(new ex.Internal.Actions.RotateBy(this._actors[i], angleRadians, time, rotationType));
          }
          return this;
       }

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -239,7 +239,7 @@ describe('A game actor', () => {
    it('can be rotated to an angle at a speed via ShortestPath (default)', () => {
       expect(actor.rotation).toBe(0);
 
-      actor.rotateTo(Math.PI / 2, Math.PI / 2);
+      actor.actions.rotateTo(Math.PI / 2, Math.PI / 2);
 
       actor.update(engine, 500);
       expect(actor.rotation).toBe(Math.PI / 4);
@@ -254,7 +254,7 @@ describe('A game actor', () => {
    it('can be rotated to an angle at a speed via LongestPath', () => {
       expect(actor.rotation).toBe(0);
 
-      actor.rotateTo(Math.PI / 2, Math.PI / 2, ex.RotationType.LongestPath);
+      actor.actions.rotateTo(Math.PI / 2, Math.PI / 2, ex.RotationType.LongestPath);
 
       actor.update(engine, 1000);
       //rotation is currently incremented by rx delta ,so will be negative while moving counterclockwise
@@ -271,7 +271,7 @@ describe('A game actor', () => {
    it('can be rotated to an angle at a speed via Clockwise', () => {
       expect(actor.rotation).toBe(0);
 
-      actor.rotateTo(3 * Math.PI / 2, Math.PI / 2, ex.RotationType.Clockwise);
+      actor.actions.rotateTo(3 * Math.PI / 2, Math.PI / 2, ex.RotationType.Clockwise);
 
       actor.update(engine, 2000);
       expect(actor.rotation).toBe(Math.PI);
@@ -287,7 +287,7 @@ describe('A game actor', () => {
    it('can be rotated to an angle at a speed via CounterClockwise', () => {
       expect(actor.rotation).toBe(0);
 
-      actor.rotateTo(Math.PI / 2, Math.PI / 2, ex.RotationType.CounterClockwise);
+      actor.actions.rotateTo(Math.PI / 2, Math.PI / 2, ex.RotationType.CounterClockwise);
       actor.update(engine, 2000);
       expect(actor.rotation).toBe(-Math.PI);
 
@@ -323,7 +323,7 @@ describe('A game actor', () => {
    it('can be rotated to an angle by a certain time via ShortestPath (default)', () => {
       expect(actor.rotation).toBe(0);
 
-      actor.rotateBy(Math.PI / 2, 2000);
+      actor.actions.rotateBy(Math.PI / 2, 2000);
 
       actor.update(engine, 1000);
       expect(actor.rotation).toBe(Math.PI / 4);
@@ -338,7 +338,7 @@ describe('A game actor', () => {
    it('can be rotated to an angle by a certain time via LongestPath', () => {
       expect(actor.rotation).toBe(0);
 
-      actor.rotateBy(Math.PI / 2, 3000, ex.RotationType.LongestPath);
+      actor.actions.rotateBy(Math.PI / 2, 3000, ex.RotationType.LongestPath);
 
       actor.update(engine, 1000);
       expect(actor.rotation).toBe(-1 * Math.PI / 2);
@@ -354,7 +354,7 @@ describe('A game actor', () => {
    it('can be rotated to an angle by a certain time via Clockwise', () => {
       expect(actor.rotation).toBe(0);
 
-      actor.rotateBy(Math.PI / 2, 1000, ex.RotationType.Clockwise);
+      actor.actions.rotateBy(Math.PI / 2, 1000, ex.RotationType.Clockwise);
 
       actor.update(engine, 500);
       expect(actor.rotation).toBe(Math.PI / 4);
@@ -370,7 +370,7 @@ describe('A game actor', () => {
    it('can be rotated to an angle by a certain time via CounterClockwise', () => {
       expect(actor.rotation).toBe(0);
 
-      actor.rotateBy(Math.PI / 2, 3000, ex.RotationType.LongestPath);
+      actor.actions.rotateBy(Math.PI / 2, 3000, ex.RotationType.LongestPath);
 
       actor.update(engine, 1000);
       expect(actor.rotation).toBe(-1 * Math.PI / 2);


### PR DESCRIPTION
When the rotation api for Actors was changed from Actor.rotateTo /
Actor.rotateBy to Actor.actions.rotateTo / Actor.actions.rotateBy,
the rotation type was forgotten on the new method signatures.

closes #575