### PR TITLE
[#643] Fix Actor updates happening more than once per frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Sprite culling was double scaling calculations ([#646](https://github.com/excaliburjs/Excalibur/issues/646))
 - Fix negative zoom sprite culling ([#539](https://github.com/excaliburjs/Excalibur/issues/539))
 - Fix Actor updates happening more than once per frame, causing multiple pointer events to trigger ([#643](https://github.com/excaliburjs/Excalibur/issues/643))
-- Fix `Actor.on('pointerup')` capturePointer events opt-in on event handler. The opt-in was triggering correctly for handlerse on 'pointerdown' and 'pointermove', but not 'pointerup'.
+- Fix `Actor.on('pointerup')` capturePointer events opt-in on event handler. The opt-in was triggering correctly for handlers on 'pointerdown' and 'pointermove', but not 'pointerup'.
 
 ## [0.7.0] - 2016-08-29
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `Actor.debugDraw` now works properly for child actors ([#505](https://github.com/excaliburjs/Excalibur/issues/505), [#645](https://github.com/excaliburjs/Excalibur/issues/645))
 - Sprite culling was double scaling calculations ([#646](https://github.com/excaliburjs/Excalibur/issues/646))
 - Fix negative zoom sprite culling ([#539](https://github.com/excaliburjs/Excalibur/issues/539))
+- Fix Actor updates happening more than once per frame, causing multiple pointer events to trigger ([#643](https://github.com/excaliburjs/Excalibur/issues/643))
+- Fix `Actor.on('pointerup')` capturePointer opt-in
 
 ## [0.7.0] - 2016-08-29
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Sprite culling was double scaling calculations ([#646](https://github.com/excaliburjs/Excalibur/issues/646))
 - Fix negative zoom sprite culling ([#539](https://github.com/excaliburjs/Excalibur/issues/539))
 - Fix Actor updates happening more than once per frame, causing multiple pointer events to trigger ([#643](https://github.com/excaliburjs/Excalibur/issues/643))
-- Fix `Actor.on('pointerup')` capturePointer opt-in
+- Fix `Actor.on('pointerup')` capturePointer events opt-in on event handler. The opt-in was triggering correctly for handlerse on 'pointerdown' and 'pointermove', but not 'pointerup'.
 
 ## [0.7.0] - 2016-08-29
 ### Breaking Changes

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -151,10 +151,10 @@ module.exports = function (grunt) {
          },
 
          gitBuild: {
-            command: 'git clone -q https://github.com/excaliburjs/excalibur-dist build',
+            command: 'git clone https://github.com/excaliburjs/excalibur-dist build',
             options: {
                stdout: true,
-               failOnError: false
+               failOnError: true
             }
          }
 

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -151,10 +151,10 @@ module.exports = function (grunt) {
          },
 
          gitBuild: {
-            command: 'git clone https://github.com/excaliburjs/excalibur-dist build',
+            command: 'git clone -q https://github.com/excaliburjs/excalibur-dist build',
             options: {
                stdout: true,
-               failOnError: true
+               failOnError: false
             }
          }
 

--- a/sandbox/web/src/game.js
+++ b/sandbox/web/src/game.js
@@ -189,7 +189,7 @@ player.on('update', function () {
         }
         player.vel.x = groundSpeed;
     }
-    if (game.input.keyboard.wasPressed(ex.Input.Keys.Up)) {
+    if (game.input.keyboard.isHeld(ex.Input.Keys.Up)) {
         if (!inAir) {
             player.vel.y = -jumpSpeed;
             inAir = true;
@@ -300,7 +300,6 @@ player.on('postupdate', function (data) {
         data.target.acc.y = 800; // * data.delta/1000;
     }
     else {
-        data.target.acc.y = 0;
     }
     // Reset values because we don't know until we check the next update
     // inAir = true;

--- a/sandbox/web/src/game.js
+++ b/sandbox/web/src/game.js
@@ -189,7 +189,7 @@ player.on('update', function () {
         }
         player.vel.x = groundSpeed;
     }
-    if (game.input.keyboard.isHeld(ex.Input.Keys.Up)) {
+    if (game.input.keyboard.wasPressed(ex.Input.Keys.Up)) {
         if (!inAir) {
             player.vel.y = -jumpSpeed;
             inAir = true;

--- a/sandbox/web/src/game.ts
+++ b/sandbox/web/src/game.ts
@@ -231,7 +231,7 @@ player.on('update', () => {
       // TODO: When platform is moving in same direction, add its dx
    }
 
-   if (game.input.keyboard.isHeld(ex.Input.Keys.Up)) {
+   if (game.input.keyboard.wasPressed(ex.Input.Keys.Up)) {
       if (!inAir) {
          player.vel.y = -jumpSpeed;
          inAir = true;

--- a/sandbox/web/src/game.ts
+++ b/sandbox/web/src/game.ts
@@ -231,7 +231,7 @@ player.on('update', () => {
       // TODO: When platform is moving in same direction, add its dx
    }
 
-   if (game.input.keyboard.wasPressed(ex.Input.Keys.Up)) {
+   if (game.input.keyboard.isHeld(ex.Input.Keys.Up)) {
       if (!inAir) {
          player.vel.y = -jumpSpeed;
          inAir = true;
@@ -353,7 +353,7 @@ player.on('postupdate', (data?: ex.PostUpdateEvent) => {
    if (!isColliding) {
       data.target.acc.y = 800;// * data.delta/1000;
    } else {
-      data.target.acc.y = 0;
+      //data.target.acc.y = 0;
    }
 
    // Reset values because we don't know until we check the next update

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -690,7 +690,7 @@ module ex {
 
     private _checkForPointerOptIn(eventName: string) {
        if (eventName && (eventName.toLowerCase() === 'pointerdown' ||
-          eventName.toLowerCase() === 'pointerdown' ||
+          eventName.toLowerCase() === 'pointerup' ||
           eventName.toLowerCase() === 'pointermove')) {
           this.enableCapturePointer = true;
           if (eventName.toLowerCase() === 'pointermove') {

--- a/src/engine/Collision/Body.ts
+++ b/src/engine/Collision/Body.ts
@@ -102,6 +102,15 @@ module ex {
          }
       }
 
+      /**
+       * Updates the collision area geometry and internal caches
+       */
+      public update() {
+         if (this.collisionArea) {
+            this.collisionArea.recalc();
+         }
+      }
+
 
       /**
        * Sets up a box collision area based on the current bounds of the associated actor of this physics body.

--- a/src/engine/Collision/CollisionContact.ts
+++ b/src/engine/Collision/CollisionContact.ts
@@ -85,15 +85,20 @@ module ex {
                if (this.mtv.x !== 0) {
                   var velX = 0;
                   // both bodies are traveling in the same direction (negative or positve)
-                  if (bodyA.vel.x <= 0 && bodyB.vel.x <= 0) {
+                  if (bodyA.vel.x < 0 && bodyB.vel.x < 0) {
                      velX = Math.min(bodyA.vel.x, bodyB.vel.x);
                      velX = bodyA.vel.x + bodyA.vel.x;
-                  } else if (bodyA.vel.x >= 0 && bodyB.vel.x >= 0) {
+                  } else if (bodyA.vel.x > 0 && bodyB.vel.x > 0) {
                      velX = Math.max(bodyA.vel.x, bodyB.vel.x);
                      velX = bodyA.vel.x + bodyA.vel.x;
                   } else if (bodyB.collisionType === ex.CollisionType.Fixed) {
                      // bodies are traveling in opposite directions
-                     velX = bodyB.vel.x;
+                     if (bodyA.pos.sub(bodyB.pos).dot(bodyA.vel) > 0) {
+                        velX = bodyA.vel.x;
+                     } else {
+                        // bodyA is heading towards b
+                        velX = bodyB.vel.x;
+                     }
                   }
                   bodyA.vel.x = velX;
                }
@@ -101,17 +106,21 @@ module ex {
                
                if (this.mtv.y !== 0) {
                   var velY = 0;
-                  if (bodyB.collisionType === ex.CollisionType.Fixed) {
+                  
+                  // both bodies are traveling in the same direction (negative or positive)
+                  if (bodyA.vel.y < 0 && bodyB.vel.y < 0) {
+                     velY = Math.min(bodyA.vel.y, bodyB.vel.y);
+                  } else if (bodyA.vel.y > 0 && bodyB.vel.y > 0) {
+                     velY = Math.max(bodyA.vel.y, bodyB.vel.y);
+                  } else if (bodyB.collisionType === ex.CollisionType.Fixed) {
                      // bodies are traveling in opposite directions
-                     velY = bodyB.vel.y;
-                  } else {
-                     // both bodies are traveling in the same direction (negative or positive)
-                     if (bodyA.vel.y <= 0 && bodyB.vel.y <= 0) {
-                        velY = Math.min(bodyA.vel.y, bodyB.vel.y);
-                     } else if (bodyA.vel.y >= 0 && bodyB.vel.y >= 0) {
-                        velY = Math.max(bodyA.vel.y, bodyB.vel.y);
-                     } 
-                  }                  
+                     if (bodyA.pos.sub(bodyB.pos).dot(bodyA.vel) > 0) {
+                        velY = bodyA.vel.y;
+                     } else {
+                        // bodyA is heading towards b
+                        velY = bodyB.vel.y;
+                     }
+                  }                                    
                   
                   bodyA.vel.y = velY;
                }

--- a/src/engine/Collision/CollisionContact.ts
+++ b/src/engine/Collision/CollisionContact.ts
@@ -103,9 +103,9 @@ module ex {
                   var velY = 0;
                   // both bodies are traveling in the same direction (negative or positive)
                   if (bodyA.vel.y <= 0 && bodyB.vel.y <= 0) {
-                     velY = Math.min(bodyA.vel.y, bodyB.vel.y);
-                  } else if (bodyA.vel.y >= 0 && bodyB.vel.y >= 0) {
                      velY = Math.max(bodyA.vel.y, bodyB.vel.y);
+                  } else if (bodyA.vel.y >= 0 && bodyB.vel.y >= 0) {
+                     velY = Math.min(bodyA.vel.y, bodyB.vel.y);
                   } else {
                      // bodies are traveling in opposite directions
                      velY = 0;

--- a/src/engine/Collision/CollisionContact.ts
+++ b/src/engine/Collision/CollisionContact.ts
@@ -91,9 +91,9 @@ module ex {
                   } else if (bodyA.vel.x >= 0 && bodyB.vel.x >= 0) {
                      velX = Math.max(bodyA.vel.x, bodyB.vel.x);
                      velX = bodyA.vel.x + bodyA.vel.x;
-                  }else {
+                  } else if (bodyB.collisionType === ex.CollisionType.Fixed) {
                      // bodies are traveling in opposite directions
-                     velX = 0;
+                     velX = bodyB.vel.x;
                   }
                   bodyA.vel.x = velX;
                }
@@ -101,15 +101,17 @@ module ex {
                
                if (this.mtv.y !== 0) {
                   var velY = 0;
-                  // both bodies are traveling in the same direction (negative or positive)
-                  if (bodyA.vel.y <= 0 && bodyB.vel.y <= 0) {
-                     velY = Math.max(bodyA.vel.y, bodyB.vel.y);
-                  } else if (bodyA.vel.y >= 0 && bodyB.vel.y >= 0) {
-                     velY = Math.min(bodyA.vel.y, bodyB.vel.y);
-                  } else {
+                  if (bodyB.collisionType === ex.CollisionType.Fixed) {
                      // bodies are traveling in opposite directions
-                     velY = 0;
-                  }
+                     velY = bodyB.vel.y;
+                  } else {
+                     // both bodies are traveling in the same direction (negative or positive)
+                     if (bodyA.vel.y <= 0 && bodyB.vel.y <= 0) {
+                        velY = Math.min(bodyA.vel.y, bodyB.vel.y);
+                     } else if (bodyA.vel.y >= 0 && bodyB.vel.y >= 0) {
+                        velY = Math.max(bodyA.vel.y, bodyB.vel.y);
+                     } 
+                  }                  
                   
                   bodyA.vel.y = velY;
                }

--- a/src/engine/Collision/CollisionContact.ts
+++ b/src/engine/Collision/CollisionContact.ts
@@ -87,10 +87,8 @@ module ex {
                   // both bodies are traveling in the same direction (negative or positve)
                   if (bodyA.vel.x < 0 && bodyB.vel.x < 0) {
                      velX = Math.min(bodyA.vel.x, bodyB.vel.x);
-                     velX = bodyA.vel.x + bodyA.vel.x;
                   } else if (bodyA.vel.x > 0 && bodyB.vel.x > 0) {
                      velX = Math.max(bodyA.vel.x, bodyB.vel.x);
-                     velX = bodyA.vel.x + bodyA.vel.x;
                   } else if (bodyB.collisionType === ex.CollisionType.Fixed) {
                      // bodies are traveling in opposite directions
                      if (bodyA.pos.sub(bodyB.pos).dot(bodyA.vel) > 0) {

--- a/src/engine/Collision/DynamicTree.ts
+++ b/src/engine/Collision/DynamicTree.ts
@@ -179,7 +179,7 @@ module ex {
 
       }
 
-      public registerBody(body: Body) {
+      public trackBody(body: Body) {
          var node = new TreeNode();
          node.body = body;
          node.bounds = body.getBounds();
@@ -226,7 +226,7 @@ module ex {
          return true;
       }
 
-      public removeBody(body: Body) {
+      public untrackBody(body: Body) {
          var node = this.nodes[body.actor.id];
          if (!node) { return; }
          this.remove(node);
@@ -360,7 +360,7 @@ module ex {
 
       public query(body: Body, callback: (other: Body) => boolean): void {
          var bounds = body.getBounds();
-         var helper = currentNode => {
+         var helper = (currentNode: TreeNode) => {
             if (currentNode && currentNode.bounds.collides(bounds)) {
                if (currentNode.isLeaf() && currentNode.body !== body) {
                   if (callback.call(body, currentNode.body)) {

--- a/src/engine/Collision/DynamicTreeCollisionBroadphase.ts
+++ b/src/engine/Collision/DynamicTreeCollisionBroadphase.ts
@@ -8,12 +8,26 @@ module ex {
       private _collisionHash: { [key: string]: boolean; } = {};
       private _collisionContactCache: CollisionContact[] = [];
 
-      public register(target: Actor): void {
-         this._dynamicCollisionTree.registerBody(target.body);
+      /**
+       * Tracks a physics body for collisions
+       */
+      public track(target: Body): void {
+         if (!target) {
+            ex.Logger.getInstance().warn('Cannot track null physics body');
+            return;
+         }
+         this._dynamicCollisionTree.trackBody(target);
       }
 
-      public remove(target: Actor): void {
-         this._dynamicCollisionTree.removeBody(target.body);
+      /**
+       * Untracks a physics body
+       */
+      public untrack(target: Body): void {
+         if (!target) {
+            ex.Logger.getInstance().warn('Cannot untrack a null physics body');
+            return;
+         }
+         this._dynamicCollisionTree.untrackBody(target);
       }
 
       private _canCollide(actorA: Actor, actorB: Actor) {
@@ -35,7 +49,7 @@ module ex {
          return true;
       }
 
-      public findCollisionContacts(targets: Actor[], delta: number): CollisionContact[] {
+      public detect(targets: Actor[], delta: number): CollisionContact[] {
          // TODO optimization use only the actors that are moving to start 
          // Retrieve the list of potential colliders, exclude killed, prevented, and self
          var potentialColliders = targets.filter((other) => {
@@ -108,6 +122,9 @@ module ex {
          return this._collisionContactCache;
       }
 
+      /**
+       * Update the dynamic tree positions
+       */
       public update(targets: Actor[], delta: number): number {
          var updated = 0, i = 0, len = targets.length;
 

--- a/src/engine/Collision/ICollisionResolver.ts
+++ b/src/engine/Collision/ICollisionResolver.ts
@@ -1,10 +1,11 @@
 ﻿module ex {
   
    export interface ICollisionBroadphase {
-      register(target: Actor);
-      remove(tartet: Actor);
-
-      findCollisionContacts(targets: Actor[], delta: number): CollisionContact[];
+      track(target: Body);
+      untrack(tartet: Body);
+      
+      //getPairs(): CollisionContact[];
+      detect(targets: Actor[], delta: number): CollisionContact[];
       update(targets: Actor[], delta: number): number;
 
       debugDraw(ctx, delta): void;

--- a/src/engine/Collision/NaiveCollisionBroadphase.ts
+++ b/src/engine/Collision/NaiveCollisionBroadphase.ts
@@ -5,15 +5,15 @@
 module ex {
    export class NaiveCollisionBroadphase implements ICollisionBroadphase {
       
-      public register(target: Actor) {
+      public track(target: Body) {
          // pass
       }
 
-      public remove(tartet: Actor) {
+      public untrack(tartet: Body) {
          // pass
       }
 
-      public findCollisionContacts(targets: Actor[], delta: number): CollisionContact[] {
+      public detect(targets: Actor[], delta: number): CollisionContact[] {
 
          // Retrieve the list of potential colliders, exclude killed, prevented, and self
          var potentialColliders = targets.filter((other) => {

--- a/src/engine/Physics.ts
+++ b/src/engine/Physics.ts
@@ -198,5 +198,10 @@ module ex {
       public static useRigidBodyPhysics(): void {
          ex.Physics.collisionResolutionStrategy = ex.CollisionResolutionStrategy.RigidBody;
       }
+
+      /**
+       * Small value to help collision passes settle themselves after the narrowphase. 
+       */
+      public static collisionShift = .001;
    };
 }

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -254,25 +254,32 @@ module ex {
          for (i = 0, len = this.tileMaps.length; i < len; i++) {
             this.tileMaps[i].update(engine, delta);
          }
-         
-         var iter: number = Physics.collisionPasses;
-         var collisionDelta = delta / iter;
-         while (iter > 0) {
-            // Cycle through actors updating actors
-            for (i = 0, len = this.children.length; i < len; i++) {
-                this.children[i].update(engine, collisionDelta);
-                this.children[i].collisionArea.recalc();
-            }
 
-            // TODO meh I don't like how this works... maybe find a way to make collisions
-            // a trait
+         for (i = 0, len = this.children.length; i < len; i++) {
+            //this.children[i].integrate(delta);
+         }
+
+         // Cycle through actors updating actors
+         for (i = 0, len = this.children.length; i < len; i++) {
+               this.children[i].update(engine, delta);
+         }
+         this._broadphase.update(this.children, delta);
+
+         var iter: number = 20; //Physics.collisionPasses;
+         var collisionDelta = delta / iter;
+
+         while (iter > 0) { 
             // Run collision resolution strategy
-            if (this._broadphase && Physics.enabled) {
-               this._broadphase.update(this.children, collisionDelta);
-               this._broadphase.findCollisionContacts(this.children, collisionDelta);
+            if (this._broadphase && Physics.enabled) {               
+               this._broadphase.detect(this.children, collisionDelta);
+               for (i = 0, len = this.children.length; i < len; i++) {
+                     this.children[i].integrate(collisionDelta * .01);
+               }
             }
             iter--;
          }
+
+         
 
          // Remove actors from scene graph after being killed
          var actorIndex: number;
@@ -464,7 +471,7 @@ module ex {
             return;
          }
          if (entity instanceof Actor) {
-            this._broadphase.remove(entity);
+            this._broadphase.untrack(entity.body);
             this._removeChild(entity);
          }
          if (entity instanceof Timer) {
@@ -501,7 +508,7 @@ module ex {
        * Adds an actor to the scene, once this is done the actor will be drawn and updated.       
        */
       protected _addChild(actor: Actor) {
-         this._broadphase.register(actor);
+         this._broadphase.track(actor.body);
          actor.scene = this;
          this.children.push(actor);
          this._sortedDrawingTree.add(actor);
@@ -529,7 +536,7 @@ module ex {
        * Removes an actor from the scene, it will no longer be drawn or updated.
        */
       protected _removeChild(actor: Actor) {
-         this._broadphase.remove(actor);
+         this._broadphase.untrack(actor.body);
          this._killQueue.push(actor);
          actor.parent = null;
       }

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -255,31 +255,29 @@ module ex {
             this.tileMaps[i].update(engine, delta);
          }
 
-         for (i = 0, len = this.children.length; i < len; i++) {
-            //this.children[i].integrate(delta);
-         }
-
          // Cycle through actors updating actors
          for (i = 0, len = this.children.length; i < len; i++) {
-               this.children[i].update(engine, delta);
+            this.children[i].update(engine, delta);
          }
-         this._broadphase.update(this.children, delta);
+         
+         // Run the broadphase
+         if (this._broadphase) {
+            this._broadphase.update(this.children, delta);
+         }
 
-         var iter: number = 20; //Physics.collisionPasses;
+         // Run the narrowphase
+         var iter: number = Physics.collisionPasses;
          var collisionDelta = delta / iter;
-
          while (iter > 0) { 
             // Run collision resolution strategy
             if (this._broadphase && Physics.enabled) {               
                this._broadphase.detect(this.children, collisionDelta);
                for (i = 0, len = this.children.length; i < len; i++) {
-                     this.children[i].integrate(collisionDelta * .01);
+                     this.children[i].integrate(collisionDelta * .001);
                }
             }
             iter--;
-         }
-
-         
+         }         
 
          // Remove actors from scene graph after being killed
          var actorIndex: number;

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -273,6 +273,8 @@ module ex {
             if (this._broadphase && Physics.enabled) {               
                this._broadphase.detect(this.children, collisionDelta);
                for (i = 0, len = this.children.length; i < len; i++) {
+                     // helps move settle collisions
+                     // todo there is a better way to do this
                      this.children[i].integrate(collisionDelta * .001);
                }
             }

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -273,9 +273,8 @@ module ex {
             if (this._broadphase && Physics.enabled) {               
                this._broadphase.detect(this.children, collisionDelta);
                for (i = 0, len = this.children.length; i < len; i++) {
-                     // helps move settle collisions
-                     // todo there is a better way to do this
-                     this.children[i].integrate(collisionDelta * .001);
+                     // helps move settle collisions, really there is a better way to do this
+                     this.children[i].integrate(collisionDelta * ex.Physics.collisionShift);
                }
             }
             iter--;

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -669,4 +669,53 @@ describe('A game actor', () => {
       scene.update(engine, 100);
       scene.draw(engine.ctx, 100);
    });
+
+   it('opt into pointer capture when pointerup', () => {
+      var actor = new ex.Actor(0, 0, 100, 100);
+      expect(actor.enableCapturePointer).toBe(false, 'Actors start without pointer caputer enabled');
+      actor.on('pointerup', () => {
+         // doesn't matter;
+      });
+      expect(actor.enableCapturePointer).toBe(true, 'Actors should have pointer caputer enabled after pointerup');
+   });
+
+   it('opt into pointer capture when pointerdown', () => {
+      var actor = new ex.Actor(0, 0, 100, 100);
+      expect(actor.enableCapturePointer).toBe(false, 'Actors start without pointer caputer enabled');
+      actor.on('pointerdown', () => {
+         // doesn't matter;
+      });
+      expect(actor.enableCapturePointer).toBe(true, 'Actors should have pointer caputer enabled after pointerdown');
+   });
+
+   it('opt into pointer capture when pointermove', () => {
+      var actor = new ex.Actor(0, 0, 100, 100);
+      expect(actor.enableCapturePointer).toBe(false, 'Actors start without pointer caputer enabled');
+      actor.on('pointermove', () => {
+         // doesn't matter;
+      });
+      expect(actor.enableCapturePointer).toBe(true, 'Actors should have pointer caputer enabled after pointermove');
+      expect(actor.capturePointer.captureMoveEvents).toBe(true, 'Actor should capture move events after pointermove');
+
+   });
+
+   it('only has pointer events happen once per frame', () => {
+      var actor = new ex.Actor(0, 0, 100, 100);
+      //actor.enableCapturePointer = true;
+      var numPointerUps = 0;
+
+      spyOn(engine.input.pointers, 'propogate').and.callThrough();
+      (<any>engine.input.pointers)._pointerUp.push({x: 0, y: 0});
+
+      actor.on('pointerup', () => {
+         numPointerUps++;
+      });
+
+      scene.add(actor);
+      
+      scene.update(engine, 100);
+
+      expect(numPointerUps).toBe(1, 'Pointer up should be triggered once');
+      expect(engine.input.pointers.propogate.calls.count()).toEqual(1, 'Propogate should be called once');
+   });
 });

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -542,7 +542,7 @@ describe('A game actor', () => {
       var active = new ex.Actor(0, -50, 100, 100);
       active.collisionType = ex.CollisionType.Active;
       active.vel.y = -100;
-      //active.acc.y = 1000;
+      ex.Physics.acc.setTo(0, 0);
 	  
       var fixed = new ex.Actor(-100, 50, 1000, 100);
       fixed.collisionType = ex.CollisionType.Fixed;
@@ -556,16 +556,15 @@ describe('A game actor', () => {
       expect(fixed.pos.x).toBe(-100);
       expect(fixed.pos.y).toBe(50);
 	  
-      var iterations = 50;
+      var iterations = 1;
       // update many times for safety
       for (var i = 0; i < iterations; i++) {
-         scene.update(engine, 100);
+         scene.update(engine, 1000);
       }
 	 	
-      var seconds = 100 / 1000;
-
+      expect(ex.Physics.acc.y).toBe(0);
       expect(active.pos.x).toBeCloseTo(0, .0001);
-      expect(active.pos.y).toBeCloseTo(-100 * seconds * iterations, .0001);
+      expect(active.pos.y).toBeCloseTo(-100 * iterations + (-50) /* original y is -50 */, .0001);
 	  
       expect(fixed.pos.x).toBe(-100);
       expect(fixed.pos.y).toBe(50);

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -22,6 +22,9 @@ describe('A game actor', () => {
       spyOn(actor, 'debugDraw');
 
       engine = mock.engine(100, 100, scene);
+
+      ex.Physics.useBoxPhysics();
+      ex.Physics.acc.setTo(0, 0);
    });
 
    it('should be loaded', () => {
@@ -502,8 +505,9 @@ describe('A game actor', () => {
    });
 
    it('with an active collision type can be placed on a fixed type', () => {
+      ex.Physics.useBoxPhysics();
       var scene = new ex.Scene(engine); 
-	  
+      	  
       var active = new ex.Actor(0, -50, 100, 100);
       active.collisionType = ex.CollisionType.Active;
       active.vel.y = 10;
@@ -526,8 +530,42 @@ describe('A game actor', () => {
          scene.update(engine, 100);
       }
 	 	  
+      expect(active.pos.x).toBeCloseTo(0, .0001);
+      expect(active.pos.y).toBeCloseTo(-50, .0001);
+	  
+      expect(fixed.pos.x).toBe(-100);
+      expect(fixed.pos.y).toBe(50);
+   });
+
+    it('with an active collision type can jump on a fixed type', () => {
+      var scene = new ex.Scene(engine);
+      var active = new ex.Actor(0, -50, 100, 100);
+      active.collisionType = ex.CollisionType.Active;
+      active.vel.y = -100;
+      //active.acc.y = 1000;
+	  
+      var fixed = new ex.Actor(-100, 50, 1000, 100);
+      fixed.collisionType = ex.CollisionType.Fixed;
+	  
+      scene.add(active);
+      scene.add(fixed);
+	  
       expect(active.pos.x).toBe(0);
       expect(active.pos.y).toBe(-50);
+
+      expect(fixed.pos.x).toBe(-100);
+      expect(fixed.pos.y).toBe(50);
+	  
+      var iterations = 50;
+      // update many times for safety
+      for (var i = 0; i < iterations; i++) {
+         scene.update(engine, 100);
+      }
+	 	
+      var seconds = 100 / 1000;
+
+      expect(active.pos.x).toBeCloseTo(0, .0001);
+      expect(active.pos.y).toBeCloseTo(-100 * seconds * iterations, .0001);
 	  
       expect(fixed.pos.x).toBe(-100);
       expect(fixed.pos.y).toBe(50);

--- a/src/spec/DynamicTreeBroadphaseSpec.ts
+++ b/src/spec/DynamicTreeBroadphaseSpec.ts
@@ -44,12 +44,12 @@ describe('A DynamicTree Broadphase', () => {
 
    it('can find collision pairs for actors that are potentially colliding', () => {
       var dt = new ex.DynamicTreeCollisionBroadphase();
-      dt.register(actorA);
-      dt.register(actorB);
-      dt.register(actorC);
+      dt.track(actorA.body);
+      dt.track(actorB.body);
+      dt.track(actorC.body);
 
       // only should be 1 pair since C is very far away
-      var pairs = dt.findCollisionContacts([actorA, actorB, actorC], 100);
+      var pairs = dt.detect([actorA, actorB, actorC], 100);
 
       expect(pairs.length).toBe(1);
 

--- a/src/spec/Mocks.ts
+++ b/src/spec/Mocks.ts
@@ -90,6 +90,11 @@ module Mocks {
             camera: {
                getZoom: function () { return 1; }
             },
+            input : {
+               keyboard: null,
+               pointers: new ex.Input.Pointers(<any>this),
+               gamepads: null
+            },
             worldToScreenCoordinates: ex.Engine.prototype.worldToScreenCoordinates,
             screenToWorldCoordinates: ex.Engine.prototype.screenToWorldCoordinates,
             addScene: ex.Engine.prototype.addScene,


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #643

Pointer events were being triggered multiple times per frame. This was a result of the physics doing multiple passes on each actor by calling the update function multiple times.

## Proposed Changes:

This fixes the issue by refactoring the integration step of actor update out of actor update, so that it can be called multiple times for collision passes and not affect other operations that expect update to be called once per frame.

Additionally, this uncovered a bug in Actor.on('pointerup') opt-in which was subsequently fixed.

