### PR TITLE
Add Node.js sourcemap support and fix TSLint for VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,8 @@
 	"editor.detectIndentation": false,
    "restructuredtext.confPath": "docs/source/conf.py",
    "restructuredtext.builtDocumentationPath" : "docs/build/html",
+   "tslint.enable": true,
+   "tslint.configFile": "./tslint/tslint.json",
 	"files.exclude": {
 		"**/.git": true,
 		"**/.DS_Store": true,

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -94,8 +94,9 @@ module.exports = function (grunt) {
          specs: {
             command: function () {
             	var files = grunt.file.expand("./src/spec/*.ts");
+               files.push('src/spec/support/sourcemaps.js');
 
-            	return '<%= tscCmd %> --target ES5 --sourceMap ' + files.join(' ') + ' --out ./src/spec/TestsSpec.js'
+            	return '<%= tscCmd %> --target ES5 --allowJs --sourceMap ' + files.join(' ') + ' --out ./src/spec/TestsSpec.js'
             },
             options: {
                stdout: true,
@@ -204,9 +205,7 @@ module.exports = function (grunt) {
       //
       tslint: {
          options: {
-            formatter: 'prose',
-            rulesDirectory: './tslint/rules/',
-            configuration: grunt.file.readJSON('./tslint/tslint.json')            
+            configuration: './tslint/tslint.json'          
          },
          src: [
             "src/engine/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "grunt-contrib-watch": "0.6.1",
     "grunt-coveralls": "^1.0.0",
     "grunt-shell": "0.6.1",
-    "grunt-tslint": "^3.1.1",
+    "grunt-tslint": "^3.2.1",
     "istanbul": "^0.4.3",
     "jasmine": "^2.4.1",
+    "source-map-support": "^0.4.3",
     "travis-ci": "^2.1.0",
     "tslint": "^3.13.0",
     "typescript": "^1.8.10"

--- a/src/spec/support/sourcemaps.js
+++ b/src/spec/support/sourcemaps.js
@@ -1,0 +1,1 @@
+require('source-map-support').install();

--- a/tslint/tslint.json
+++ b/tslint/tslint.json
@@ -1,56 +1,77 @@
 {
-  "rules": {
-    "underscore-prefix": true,
-    "class-name": true,
-    "curly": true,
-    "indent": [true, "spaces"],
-    "label-position": true,
-    "label-undefined": true,
-    "interface-name": true,
-    "max-line-length": [true, 140],
-    "no-arg": true,
-    "no-console": [true,
-        "debug",
-        "info",
-        "time",
-        "timeEnd",
-        "trace"
-    ],
-    "no-construct": true,
-    "no-debugger": true,
-    "no-duplicate-key": true,
-    "no-duplicate-variable": true,
-    "no-empty": true,
-    "no-eval": true,
-    "no-string-literal": true,
-    "no-switch-case-fall-through": true,
-    "trailing-comma": [true, {
-       "multiline": "never",
-       "single": "never"
-    }],
-    "no-trailing-whitespace": false,
-    "no-unused-expression": true,
-    "no-unused-variable": false,
-    "no-unreachable": true,
-    "no-use-before-declare": true,
-    "one-line": [true,
-        "check-open-brace",
-        "check-catch",
-        "check-else",
-        "check-whitespace"
-    ],
-    "jsdoc-format": true,
-    "quotemark": [true, "single"],
-    "radix": true,
-    "semicolon": true,
-    "triple-equals": [true, "allow-null-check"],
-    "variable-name": false,
-    "whitespace": [true,
-        "check-branch",
-        "check-decl",
-        "check-operator",
-        "check-separator",
-        "check-type"
-    ]
-  }
+   "rulesDirectory": [
+      "./rules"
+   ],
+   "rules": {
+      "underscore-prefix": true,
+      "class-name": true,
+      "curly": true,
+      "indent": [
+         true,
+         "spaces"
+      ],
+      "label-position": true,
+      "label-undefined": true,
+      "interface-name": true,
+      "max-line-length": [
+         true,
+         140
+      ],
+      "no-arg": true,
+      "no-console": [
+         true,
+         "debug",
+         "info",
+         "time",
+         "timeEnd",
+         "trace"
+      ],
+      "no-construct": true,
+      "no-debugger": true,
+      "no-duplicate-key": true,
+      "no-duplicate-variable": true,
+      "no-empty": true,
+      "no-eval": true,
+      "no-string-literal": true,
+      "no-switch-case-fall-through": true,
+      "trailing-comma": [
+         true,
+         {
+            "multiline": "never",
+            "single": "never"
+         }
+      ],
+      "no-trailing-whitespace": false,
+      "no-unused-expression": true,
+      "no-unused-variable": false,
+      "no-unreachable": true,
+      "no-use-before-declare": true,
+      "one-line": [
+         true,
+         "check-open-brace",
+         "check-catch",
+         "check-else",
+         "check-whitespace"
+      ],
+      "jsdoc-format": true,
+      "quotemark": [
+         true,
+         "single"
+      ],
+      "radix": true,
+      "semicolon": true,
+      "triple-equals": [
+         true,
+         "allow-null-check"
+      ],
+      "variable-name": false,
+      "whitespace": [
+         true,
+         "check-branch",
+         "check-decl",
+         "check-operator",
+         "check-separator",
+         "check-type"
+      ]
+   }
 }


### PR DESCRIPTION
## Proposed Changes:

- Add TS source map support for test failures
- Fix TSLint integration with VS Code and upgrade grunt plugin

You can now use TSLint VS code extension! And when tests fail it will pinpoint the Typescript source line.

