### PR TITLE
[#621] Automate npm pre-release versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 - grunt travis
 after_success:
 - node deploy-docs.js
-- if [ "$TRAVIS_BRANCH" = "master" ]; then grunt dists; fi
+- if [ "$TRAVIS_BRANCH" = "master" ]; then grunt bumpup dists; fi
 notifications:
   slack:
     secure: aQXFk2/MxX5eR2JM90xWAA9YX03QArY1ejUmnP/NkFHbB4zzKZblACjEeDTDTDCThZpXhrganX2nDWrWFrrXbOG28wKrRhEZSULPAgyiWGpfkMoT44fKmgh+eZ5C/isMF2eeQCrYo3EQCMxfCKxNaBhyLc+jr/Sm232zU2LaXo8=

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -225,7 +225,22 @@ module.exports = function (grunt) {
                force: true
             }
          }
-      }
+      },
+
+      bumpup: {
+        setters: {
+            // Overrides version setter 
+            version: function (old, releaseType, options) {
+               var version = grunt.file.readJSON('package.json').version;
+               var build = process.env.TRAVIS_BUILD_NUMBER || "localbuild";
+               var commit = process.env.TRAVIS_COMMIT || "localcommit";
+               var alphaVersion = version + '-alpha.' + build + "+" + commit.substring(0, 7);  
+               return alphaVersion;
+            },
+        },
+        files: ['build/package.json']
+    }
+
    });
 
    //
@@ -240,6 +255,8 @@ module.exports = function (grunt) {
    grunt.loadNpmTasks('grunt-contrib-watch');
    grunt.loadNpmTasks('grunt-coveralls');
    grunt.loadNpmTasks('grunt-build-control');
+   grunt.loadNpmTasks('grunt-bumpup');
+
    
    //
    // Register available Grunt tasks

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "excalibur",
+  "private": true,
   "description": "Excalibur.js is a simple JavaScript game engine with TypeScript bindings for making 2D games in HTML5 Canvas. Our mission is to make web game development as simple as possible.",
-  "main": "dist/excalibur-0.7.0.js",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "https://github.com/excaliburjs/Excalibur/graphs/contributors",
   "homepage": "https://github.com/excaliburjs/Excalibur",
   "repository": {
@@ -24,6 +24,7 @@
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-build-control": "^0.7.1",
+    "grunt-bumpup": "^0.6.3",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-concat": "0.1.2",
     "grunt-contrib-copy": "0.5.0",


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #621 

## Proposed Changes:

This includes a new grunt plugin for manipulating package.json files to help on 2 fronts
 1. Only needing to update the package.json version in 1 place (main excalibur repo package.json)
 2. Automate pre-release npm package deployments in the form exVersion-alpha.travisBuildNumber+commitHash (for example a plausible package version would be 0.7.1-alpha.12+6feca33)

This PR needs to be merged into master before the travis automation can be verified, bummer I know 😭  Once we know that the excalibur-dist repo is being updated appropriately with the correct package.json, the automagic publish to npm job can be activated.

Ultimately I would like to also automate the cutting of release NPM packages when a release is tagged (see https://docs.travis-ci.com/user/deployment/npm/) but I think that may be a bigger team discussion outside of this PR 
