### PR TITLE
[#663] Add alias `magnitude` to `Vector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `ex.Vector.magnitude` alias that calls `ex.Vector.distance()` to get magnitude of Vector ([#663](https://github.com/excaliburjs/Excalibur/issues/663))
+
 ## [0.7.1]
 
 ### Breaking Changes

--- a/src/engine/Algebra.ts
+++ b/src/engine/Algebra.ts
@@ -60,14 +60,21 @@ module ex {
       }
 
       /**
-       * The distance to another vector
-       * @param v  The other vector
+       * The distance to another vector. If no other Vector is specified, this will return the [[magnitude]].
+       * @param v  The other vector. Leave blank to use origin vector.
        */
       public distance(v?: Vector): number {
          if (!v) {
-            v = new Vector(0.0, 0.0);
+            v = Vector.Zero;
          }
          return Math.sqrt(Math.pow(this.x - v.x, 2) + Math.pow(this.y - v.y, 2));
+      }
+
+      /**
+       * The magnitude (size) of the Vector
+       */
+      public magnitude(): number {
+         return this.distance();
       }
 
       /**

--- a/src/spec/AlgebraSpec.ts
+++ b/src/spec/AlgebraSpec.ts
@@ -60,6 +60,14 @@ describe('Vectors', () => {
       expect(v.distance()).toBe(20);
       expect(v2.distance()).toBe(20);
    });
+
+   it('can have a magnitude', () =>  {
+      var v = new ex.Vector(20, 0);
+      var v2 = new ex.Vector(0, -20);
+      
+      expect(v.magnitude()).toBe(20);
+      expect(v2.magnitude()).toBe(20);
+   });
    
    it('can calculate the distance to another vector', () => {
      var v = new ex.Vector(-10, 0);


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #663

## Proposed Changes:

- Add `Vector.magnitude` alias that calls `Vector.distance()`
- Clarify docs on `Vector.distance()`

