### PR TITLE
[#666] Fix `oldVel` and `oldPos` values being updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `ex.Line.hasPoint(x, y, threshold)` to determine if given point lies on the line
 - new `Vector.One` and `Vector.Half` constants ([#649](https://github.com/excaliburjs/Excalibur/issues/649))
 
+### Fixed
+
+- Fix `Actor.oldPos` and `Actor.oldVel` values on update ([#666](https://github.com/excaliburjs/Excalibur/issues/666))
+
 ## [0.7.1]
 
 ### Breaking Changes

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -1173,10 +1173,8 @@ module ex {
           !(this instanceof Label)) {
           totalAcc.addEqual(ex.Physics.acc);
        }
-
-       this.oldVel = this.vel;
-       this.vel.addEqual(totalAcc.scale(seconds));
-
+       
+       this.vel.addEqual(totalAcc.scale(seconds));       
        this.pos.addEqual(this.vel.scale(seconds)).addEqual(totalAcc.scale(0.5 * seconds * seconds));
 
        this.rx += this.torque * (1.0 / this.moi) * seconds;
@@ -1229,6 +1227,11 @@ module ex {
           }
        }
 
+       // Capture old values before integration step updates them
+       this.oldVel.setTo(this.vel.x, this.vel.y);
+       this.oldPos.setTo(this.pos.x, this.pos.y);
+
+       // Run Euler integration
        this.integrate(delta);
 
        // Update actor pipeline (movement, collision detection, event propagation, offscreen culling)

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -30,6 +30,27 @@ describe('A game actor', () => {
    it('should be loaded', () => {
       expect(ex.Actor).toBeTruthy();
    });
+
+   it('should have a position', () => {
+
+      actor.pos.setTo(10, 10);
+
+      expect(actor.pos.x).toBe(10);
+      expect(actor.pos.y).toBe(10);
+   });
+
+   it('should have an old position after an update', () => {
+
+      actor.pos.setTo(10, 10);
+      actor.vel.setTo(10, 10);
+
+      actor.update(engine, 1000);
+
+      expect(actor.oldPos.x).toBe(10);
+      expect(actor.oldPos.y).toBe(10);
+      expect(actor.pos.x).toBe(20);
+      expect(actor.pos.y).toBe(20);
+   });
    
    it('actors should generate pair hashes in the correct order', () => {
       var actor = new ex.Actor();
@@ -67,6 +88,20 @@ describe('A game actor', () => {
       actor.update(engine, 1000);
       expect(actor.pos.x).toBe(-20);
       expect(actor.pos.y).toBe(20);
+   });
+
+   it('should have an old velocity after an update', () => {
+
+      actor.pos.setTo(0, 0);
+      actor.vel.setTo(10, 10);
+      actor.acc.setTo(10, 10);
+
+      actor.update(engine, 1000);
+
+      expect(actor.oldVel.x).toBe(10);
+      expect(actor.oldVel.y).toBe(10);
+      expect(actor.vel.x).toBe(20);
+      expect(actor.vel.y).toBe(20);
    });
 
    it('can have its height and width scaled', () => {


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #666 
## Proposed Changes:
- Fix `oldVel` value being set to the current frame's value due to `addEqual` mutator method
- Fix `oldPos` not being set at all
## Notes

Two issues I discovered:
1. `oldVel` was wrong, it was being set to the current frame's value
2. `oldVel` (and now `oldPos`) are being set in the `integrate()` method of Actor but that method can be called multiple times per update, hence oldVel and oldPos are probably not accurate for use within an update loop especially if they are supposed to represent the previous frame values.
