### PR TITLE
[#662] Add Line math methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - `ex.Vector.magnitude` alias that calls `ex.Vector.distance()` to get magnitude of Vector ([#663](https://github.com/excaliburjs/Excalibur/issues/663))
+- Added new `ex.Line` utilities ([#662](https://github.com/excaliburjs/Excalibur/issues/662)):
+  - `ex.Line.slope` for the raw slope (m) value
+  - `ex.Line.intercept` for the Y intercept (b) value
+  - `ex.Line.findPoint(x?, y?)` to find a point given an X or a Y value
+  - `ex.Line.hasPoint(x, y, threshold)` to determine if given point lies on the line
 
 ## [0.7.1]
 

--- a/src/engine/Algebra.ts
+++ b/src/engine/Algebra.ts
@@ -1,5 +1,5 @@
 module ex {
-   
+
    /**
     * A 2D vector on a plane. 
     */
@@ -9,12 +9,12 @@ module ex {
        * A (0, 0) vector
        */
       public static Zero = new Vector(0, 0);
-      
+
       /**
        * A unit vector pointing up (0, -1)
        */
       public static Up = new Vector(0, -1);
-      
+
       /**
        * A unit vector pointing down (0, 1)
        */
@@ -42,7 +42,7 @@ module ex {
        * @param y  Y component of the Vector
        */
       constructor(public x: number, public y: number) { }
-      
+
       /**
        * Sets the x and y components at once
        */
@@ -50,7 +50,7 @@ module ex {
          this.x = x;
          this.y = y;
       }
-      
+
       /**
        * Compares this point against another and tests for equality
        * @param point  The other point to compare to
@@ -93,7 +93,7 @@ module ex {
        * Returns the average (midpoint) between the current point and the specified
        */
       public average(vec: Vector): Vector {
-          return this.add(vec).scale(.5);
+         return this.add(vec).scale(.5);
       }
 
       /**
@@ -119,7 +119,7 @@ module ex {
       public sub(v: Vector): Vector {
          return new Vector(this.x - v.x, this.y - v.y);
       }
-      
+
       /**
        * Adds one vector to this one modifying the original
        * @param v The vector to add
@@ -129,7 +129,7 @@ module ex {
          this.y += v.y;
          return this;
       }
-      
+
       /**
        * Subtracts a vector from this one modifying the original
        * @parallel v The vector to subtract
@@ -139,7 +139,7 @@ module ex {
          this.y -= v.y;
          return this;
       }
-      
+
       /**
        * Scales this vector by a factor of size and modifies the original
        */
@@ -174,8 +174,8 @@ module ex {
             return new Vector(v * this.y, -v * this.x);
          }
       }
-      
-      
+
+
 
       /**
        * Returns the perpendicular vector to this one
@@ -190,7 +190,7 @@ module ex {
       public normal(): Vector {
          return this.perpendicular().normalize();
       }
-      
+
       /**
        * Negate the current vector
        */
@@ -210,7 +210,7 @@ module ex {
        * degrees in radians
        */
       public rotate(angle: number, anchor?: Vector): Vector {
-          if (!anchor) {
+         if (!anchor) {
             anchor = new ex.Vector(0, 0);
          }
          var sinAngle = Math.sin(angle);
@@ -257,18 +257,18 @@ module ex {
        * This number indicates the mathematical intersection time.
        * @param line  The line to test
        */
-       public intersect(line: Line): number {
+      public intersect(line: Line): number {
          var numerator = line.begin.sub(this.pos);
 
          // Test is line and ray are parallel and non intersecting
-         if (this.dir.cross(line.getSlope()) === 0 && numerator.cross(this.dir) !== 0) { 
+         if (this.dir.cross(line.getSlope()) === 0 && numerator.cross(this.dir) !== 0) {
             return -1;
          }
-          
+
          // Lines are parallel
          var divisor = (this.dir.cross(line.getSlope()));
-         if (divisor === 0 ) {
-             return -1;
+         if (divisor === 0) {
+            return -1;
          }
 
          var t = numerator.cross(line.getSlope()) / divisor;
@@ -278,7 +278,7 @@ module ex {
             if (u >= 0 && u <= 1) {
                return t;
             }
-         }         
+         }
          return -1;
       }
 
@@ -302,6 +302,20 @@ module ex {
       constructor(public begin: Vector, public end: Vector) {
       }
 
+      /**
+       * Gets the raw slope (m) of the line. Will return (+/-)Infinity for vertical lines.
+       */
+      public get slope() {
+         return (this.end.y - this.begin.y) / (this.end.x - this.begin.x);
+      }
+
+      /**
+       * Gets the Y-intercept (b) of the line. Will return (+/-)Infinity if there is no intercept.
+       */
+      public get intercept() {
+         return this.begin.y - (this.slope * this.begin.x);
+      }
+
       /** 
        * Returns the slope of the line in the form of a vector
        */
@@ -322,15 +336,90 @@ module ex {
          return distance;
       }
 
+      /**
+       * Finds a point on the line given only an X or a Y value. Given an X value, the function returns
+       * a new point with the calculated Y value and vice-versa.
+       * 
+       * @param x The known X value of the target point 
+       * @param y The known Y value of the target point
+       * @returns A new point with the other calculated axis value       
+       */
+      public findPoint(x: number = null, y: number = null): Vector {
+         var m = this.slope;
+         var b = this.intercept;
+
+         if (x !== null) {
+            return new ex.Vector(x, (m * x) + b);
+         } else if (y !== null) {
+            return new ex.Vector((y - b) / m, y);
+         }
+      }
+
+      /**
+       * Whether or not the given point lies on this line. This method is precise by default
+       * meaning the point must lie exactly on the line. Adjust threshold to 
+       * loosen the strictness of the check for floating-point calculations.
+       */
+      public hasPoint(x: number, y: number, threshold?: number): boolean;
+
+      /**
+       * Whether or not the given point lies on this line. This method is precise by default
+       * meaning the point must lie exactly on the line. Adjust threshold to 
+       * loosen the strictness of the check for floating-point calculations.
+       */
+      public hasPoint(v: Vector, threshold?: number): boolean;
+
+      /**
+       * @see http://stackoverflow.com/a/11908158/109458
+       */
+      public hasPoint(): boolean {
+         var currPoint: Vector;
+         var threshold = 0;
+
+         if (typeof arguments[0] === 'number' && 
+             typeof arguments[1] === 'number') {
+            currPoint = new Vector(arguments[0], arguments[1]);
+            threshold = arguments[2] || 0;
+         } else if (arguments[0] instanceof Vector) {
+            currPoint = arguments[0];
+            threshold = arguments[1] || 0;
+         } else {
+            throw 'Could not determine the arguments for Vector.hasPoint';
+         }
+
+         var dxc = currPoint.x - this.begin.x;
+         var dyc = currPoint.y - this.begin.y;
+
+         var dx1 = this.end.x - this.begin.x;
+         var dy1 = this.end.y - this.begin.y;
+
+         var cross = dxc * dy1 - dyc * dx1;
+
+         // check whether point lines on the line
+         if (Math.abs(cross) > threshold) {
+            return false;
+         }
+
+         // check whether point lies in-between start and end
+         if (Math.abs(dx1) >= Math.abs(dy1)) {
+            return dx1 > 0
+               ? this.begin.x <= currPoint.x && currPoint.x <= this.end.x
+               : this.end.x <= currPoint.x && currPoint.x <= this.begin.x;
+         } else {
+            return dy1 > 0
+               ? this.begin.y <= currPoint.y && currPoint.y <= this.end.y
+               : this.end.y <= currPoint.y && currPoint.y <= this.begin.y;
+         }
+      }
    }
 
    /**
     * A 1 dimensional projection on an axis, used to test overlaps
     */
    export class Projection {
-      constructor(public min: number, public max: number) {}
+      constructor(public min: number, public max: number) { }
       public overlaps(projection: Projection): boolean {
-         return this.max > projection.min && projection.max > this.min;      
+         return this.max > projection.min && projection.max > this.min;
       }
 
       public getOverlap(projection: Projection): number {

--- a/src/spec/AlgebraSpec.ts
+++ b/src/spec/AlgebraSpec.ts
@@ -215,16 +215,118 @@ describe('Lines', () => {
       expect(line).toBeTruthy();
    });
    
-   it('can have a slope', () => {
+   it('can have a slope Vector', () => {
       var line = new ex.Line(new ex.Vector(1, -1), new ex.Vector(1, 1));
       var slope = line.getSlope();
       
       expect(slope.equals(new ex.Vector(0, 1))).toBeTruthy();
    });
+
+   it('can have a slope value of infinity', () => {
+      var line = new ex.Line(new ex.Vector(1, 0), new ex.Vector(1, 1));
+      var slope = line.slope;
+      
+      expect(line.slope).toBe(Infinity);
+   });
+
+   it('can have a slope value of 0', () => {
+      var line = new ex.Line(new ex.Vector(1, 1), new ex.Vector(2, 1));
+      var slope = line.slope;
+      
+      expect(line.slope).toBe(0);
+   });
+
+   it('can have a positive slope value', () => {
+      var line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(1, 1));
+            
+      expect(line.slope).toBe(1);
+   });
+
+   it('can have a negative slope value', () => {
+      var line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(-1, 1));
+            
+      expect(line.slope).toBe(-1);
+   });
+
+   it('can have a y intercept of infinity', () => {
+      var line = new ex.Line(new ex.Vector(1, 0), new ex.Vector(1, 1));
+      
+      expect(line.intercept).toBe(-Infinity);
+   });
+
+   it('can have a positive y intercept', () => {
+      var line = new ex.Line(new ex.Vector(1, 2), new ex.Vector(2, 2));
+      
+      expect(line.intercept).toBe(2);
+   });
+
+   it('can have a negative y intercept', () => {
+      var line = new ex.Line(new ex.Vector(1, 1), new ex.Vector(2, 2));
+      
+      expect(line.intercept).toBe(0);
+   });
    
    it('can have a length', () => {
       var line = new ex.Line(new ex.Vector(1, -1), new ex.Vector(1, 1));
       expect(line.getLength()).toBe(2);
+   });
+
+   it('can find a point by X value', () => {
+
+      var line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(2, 2));
+      var t = line.findPoint(1);
+
+      expect(t.y).toBe(1);
+   });
+
+   it('can find a point by Y value', () => {
+
+      var line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(2, 2));
+      var t = line.findPoint(null, 1);
+
+      expect(t.x).toBe(1);
+   });
+
+   it('can determine if point lies on the line by x and y', () => {
+      var line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(2, 2));
+      var t = line.hasPoint(1, 1);
+
+      expect(t).toBe(true);
+   });
+
+   it('can determine if point lies on the line by Vector', () => {
+      var line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(2, 2));
+      var t = line.hasPoint(new ex.Vector(1, 1));
+
+      expect(t).toBe(true);
+   });
+
+   it('can determine if point lies on the line by x and y with absolute precision', () => {
+      var line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(2, 2));
+      var t = line.hasPoint(1.005, 1);
+
+      expect(t).toBe(false);
+   });
+
+   it('can determine if point lies on the line by Vector with absolute precision', () => {
+      var line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(2, 2));
+      var t = line.hasPoint(new ex.Vector(1.005, 1));
+
+      expect(t).toBe(false);
+   });
+
+   it('can determine if point lies on the line by x and y at a certain threshold', () => {
+      var line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(2, 2));
+      var t = line.hasPoint(1.005, 1, 0.1);
+
+      expect(t).toBe(true);
+   });
+
+   it('can determine if point lies on the line by Vector at a certain threshold', () => {
+      var line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(2, 2));
+      var t = line.hasPoint(new ex.Vector(1.005, 1), 0.1);
+
+      expect(t).toBe(true);
    });
 });
 


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #662

## Proposed Changes:

  - `ex.Line.slope` for the raw slope (m) value
  - `ex.Line.intercept` for the Y intercept (b) value
  - `ex.Line.findPoint(x?, y?)` to find a point given an X or a Y value
  - `ex.Line.hasPoint(x, y, threshold)` to determine if given point lies on the line
