### PR TITLE
Fix JSDoc and typos in comments

### DIFF
--- a/src/engine/Actions/Action.ts
+++ b/src/engine/Actions/Action.ts
@@ -20,7 +20,7 @@ module ex.Internal.Actions {
    
    export class EaseTo implements IAction {
       private _currentLerpTime: number = 0;
-      private _lerpDuration: number = 1 * 1000; // 5 seconds
+      private _lerpDuration: number = 1 * 1000; // 1 second
       private _lerpStart: Vector = new ex.Vector(0, 0);
       private _lerpEnd: Vector = new ex.Vector(0, 0);
       private _initialized: boolean = false;

--- a/src/engine/Actions/ActionContext.ts
+++ b/src/engine/Actions/ActionContext.ts
@@ -244,8 +244,10 @@ module ex {
        * specified (in magnitude increase per second) and return back the 
        * actor. This method is part of the actor 'Action' fluent API allowing 
        * action chaining.
-       * @param size   The scaling factor to apply
-       * @param speed  The speed of scaling specified in magnitude increase per second
+       * @param sizeX   The scaling factor to apply on X axis
+       * @param sizeY   The scaling factor to apply on Y axis
+       * @param speedX  The speed of scaling specified in magnitude increase per second on X axis
+       * @param speedY  The speed of scaling specified in magnitude increase per second on Y axis
        */
       public scaleTo(sizeX: number, sizeY: number, speedX: number, speedY: number): ActionContext {
          var i = 0, len = this._queues.length;
@@ -259,8 +261,9 @@ module ex {
        * This method will scale an actor to the specified size by a certain time
        * (in milliseconds) and return back the actor. This method is part of the
        * actor 'Action' fluent API allowing action chaining.
-       * @param size   The scaling factor to apply
-       * @param time   The time it should take to complete the scaling in milliseconds
+       * @param sizeX   The scaling factor to apply on X axis
+       * @param sizeY   The scaling factor to apply on Y axis
+       * @param time    The time it should take to complete the scaling in milliseconds
        */
       public scaleBy(sizeX: number, sizeY: number, time: number): ActionContext {
          var i = 0, len = this._queues.length;
@@ -332,7 +335,7 @@ module ex {
       /**
        * This method allows you to call an arbitrary method as the next action in the
        * action queue. This is useful if you want to execute code in after a specific
-       * action, i.e An actor arrives at a destinatino after traversing a path
+       * action, i.e An actor arrives at a destination after traversing a path
        */
       public callMethod(method: () => any): ActionContext {
          var i = 0, len = this._queues.length;

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -51,7 +51,7 @@ module ex {
    * 
    * ## Actor Lifecycle
    * 
-   * An [[Actor|actor]] has a basic lifecycle that dictacts how it is initialized, updated, and drawn. Once an actor is part of a 
+   * An [[Actor|actor]] has a basic lifecycle that dictates how it is initialized, updated, and drawn. Once an actor is part of a 
    * [[Scene|scene]], it will follow this lifecycle.
    * 
    * ![Actor Lifecycle](/assets/images/docs/ActorLifecycle.png)
@@ -473,14 +473,14 @@ module ex {
     }
     
     /**
-     * Gets the current momemnt of inertia, moi can be thought of as the resistance to rotation.
+     * Gets the current moment of inertia, moi can be thought of as the resistance to rotation.
      */
     public get moi() {
        return this.body.moi;
     }
     
     /**
-     * Sets the current momemnt of inertia, moi can be thought of as the resistance to rotation.
+     * Sets the current moment of inertia, moi can be thought of as the resistance to rotation.
      */
     public set moi(theMoi: number) {
        this.body.moi = theMoi;
@@ -627,7 +627,7 @@ module ex {
     public color: Color;
 
     /**
-     * Whether or not to enable the [[CapturePointer]] trait that propogates 
+     * Whether or not to enable the [[CapturePointer]] trait that propagates 
      * pointer events to this actor
      */
     public enableCapturePointer: boolean = false;
@@ -792,7 +792,7 @@ module ex {
     }
      
     /**
-     * Add minimum translation vectors accumulated during the current frame to resolve collisons.
+     * Add minimum translation vectors accumulated during the current frame to resolve collisions.
      */ 
     public addMtv(mtv: Vector) {
         this._totalMtv.addEqual(mtv);
@@ -858,7 +858,7 @@ module ex {
      * Sets the z-index of an actor and updates it in the drawing list for the scene. 
      * The z-index determines the relative order an actor is drawn in.
      * Actors with a higher z-index are drawn on top of actors with a lower z-index
-     * @param actor The child actor to remove
+     * @param newIndex new z-index to assign
      */
      public setZIndex(newIndex: number) {
        this.scene.cleanupDrawTree(this);

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -146,7 +146,7 @@ module ex {
        * This moves the camera focal point to the specified position using specified easing function. Cannot move when following an Actor.
        * 
        * @param pos The target position to move to
-       * @param duration The duration in millseconds the move should last
+       * @param duration The duration in milliseconds the move should last
        * @param [easingFn] An optional easing function ([[ex.EasingFunctions.EaseInOutCubic]] by default)
        * @returns A [[Promise]] that resolves when movement is finished, including if it's interrupted. 
        *          The [[Promise]] value is the [[Vector]] of the target position. It will be rejected if a move cannot be made.
@@ -290,6 +290,7 @@ module ex {
 
       /**
        * Applies the relevant transformations to the game canvas to "move" or apply effects to the Camera
+       * @param ctx    Canvas context to apply transformations
        * @param delta  The number of milliseconds since the last update
        */
       public draw(ctx: CanvasRenderingContext2D, delta: number) {

--- a/src/engine/Class.ts
+++ b/src/engine/Class.ts
@@ -53,7 +53,7 @@ module ex {
       /**
        * You may wish to extend native Excalibur functionality in vanilla Javascript. 
        * Any method on a class inheriting [[Class]] may be extended to support 
-       * additional functionaliy. In the example below we create a new type called `MyActor`.
+       * additional functionality. In the example below we create a new type called `MyActor`.
        * 
        *
        * ```js

--- a/src/engine/Collision/Body.ts
+++ b/src/engine/Collision/Body.ts
@@ -51,7 +51,7 @@ module ex {
       public mass: number = 1.0;
       
       /**
-       * The current momemnt of inertia, moi can be thought of as the resistance to rotation.
+       * The current moment of inertia, moi can be thought of as the resistance to rotation.
        */
       public moi: number = 1000;
       
@@ -78,7 +78,7 @@ module ex {
       /** 
        * The rotational velocity of the actor in radians/second
        */
-      public rx: number = 0; //radions/sec
+      public rx: number = 0; //radians/sec
 
       /**
        * Returns the body's [[BoundingBox]] calculated for this instant in world space.
@@ -125,7 +125,7 @@ module ex {
             pos: center // position relative to actor
          });
 
-         // in case of a nan moi, collesce to a safe default
+         // in case of a nan moi, coalesce to a safe default
          this.moi = this.collisionArea.getMomentOfInertia() || this.moi;
 
       }

--- a/src/engine/Collision/BoundingBox.ts
+++ b/src/engine/Collision/BoundingBox.ts
@@ -80,7 +80,7 @@ module ex {
         }
 
         /**
-         * Tests wether a point is contained within the bounding box
+         * Tests whether a point is contained within the bounding box
          * @param p  The point to test
          */
         public contains(p: Vector): boolean;
@@ -119,7 +119,7 @@ module ex {
 
         /** 
          * Test wether this bounding box collides with another returning,
-         * the intersection vector that can be used to resovle the collision. If there
+         * the intersection vector that can be used to resolve the collision. If there
          * is no collision null is returned.
          * @param collidable  Other collidable to test
          */

--- a/src/engine/Collision/CircleArea.ts
+++ b/src/engine/Collision/CircleArea.ts
@@ -121,9 +121,8 @@
         }
 
         /**
-         * Returns the moment of intertia of a circle given it's mass
+         * Returns the moment of inertia of a circle given it's mass
          * https://en.wikipedia.org/wiki/List_of_moments_of_inertia
-         * @param mass
          */
         public getMomentOfInertia(): number {
            var mass = this.body ? this.body.mass : Physics.defaultMass;

--- a/src/engine/Collision/CollisionContact.ts
+++ b/src/engine/Collision/CollisionContact.ts
@@ -84,7 +84,7 @@ module ex {
                // non-zero intersection on the y axis
                if (this.mtv.x !== 0) {
                   var velX = 0;
-                  // both bodies are traveling in the same direction (negative or positve)
+                  // both bodies are traveling in the same direction (negative or positive)
                   if (bodyA.vel.x < 0 && bodyB.vel.x < 0) {
                      velX = Math.min(bodyA.vel.x, bodyB.vel.x);
                   } else if (bodyA.vel.x > 0 && bodyB.vel.x > 0) {

--- a/src/engine/Collision/DynamicTreeCollisionBroadphase.ts
+++ b/src/engine/Collision/DynamicTreeCollisionBroadphase.ts
@@ -58,7 +58,7 @@ module ex {
 
          var actor: Actor;
          
-         // Check collison cache and re-add pairs that still are in collision
+         // Check collision cache and re-add pairs that still are in collision
          var newPairs = [];
          this._collisionContactCache.forEach(c => {
             var contact = c.bodyA.collide(c.bodyB);
@@ -76,7 +76,7 @@ module ex {
          for (var j = 0, l = potentialColliders.length; j < l; j++) {
             actor = potentialColliders[j];
 
-            // Query the colllision tree for potential colliders
+            // Query the collision tree for potential colliders
             this._dynamicCollisionTree.query(actor.body, (other: Body) => {
                if (this._canCollide(actor, other.actor)) {
                   // generate all the collision contacts between the 2 sets of collision areas between both actors

--- a/src/engine/Collision/EdgeArea.ts
+++ b/src/engine/Collision/EdgeArea.ts
@@ -153,7 +153,7 @@
         }
 
         /**
-         * Get the momemnt of inertia for an edge
+         * Get the moment of inertia for an edge
          * https://en.wikipedia.org/wiki/List_of_moments_of_inertia
          */
         public getMomentOfInertia(): number {

--- a/src/engine/Collision/IPhysics.ts
+++ b/src/engine/Collision/IPhysics.ts
@@ -2,7 +2,7 @@ module ex {
    
    export interface IEnginePhysics {
       /**
-       * Global engine acceleration, useful for defining consitent gravity on all actors
+       * Global engine acceleration, useful for defining consistent gravity on all actors
        */
       acc: Vector;
       /**
@@ -22,7 +22,7 @@ module ex {
        */
       integrator: string;
       /**
-       * Number of collision resultion passes 
+       * Number of collision resolution passes 
        */
       collisionPasses: number;
       

--- a/src/engine/Collision/PolygonArea.ts
+++ b/src/engine/Collision/PolygonArea.ts
@@ -289,7 +289,7 @@ module ex {
         public debugDraw(ctx: CanvasRenderingContext2D, color: Color = Color.Red.clone()) {
             ctx.beginPath();
             ctx.strokeStyle = color.toString();
-            // Iterate through the supplied points and contruct a 'polygon'
+            // Iterate through the supplied points and construct a 'polygon'
             var firstPoint = this.getTransformedPoints()[0];
             ctx.moveTo(firstPoint.x, firstPoint.y);
             this.getTransformedPoints().forEach(function (point, i) {

--- a/src/engine/Drawing/Animation.ts
+++ b/src/engine/Drawing/Animation.ts
@@ -153,7 +153,7 @@ module ex {
       }
 
       /**
-       * Applies the colorize effect to a sprite, changing the color channels of all pixesl to be the average of the original color and the
+       * Applies the colorize effect to a sprite, changing the color channels of all pixels to be the average of the original color and the
        * provided color.
        */
       public colorize(color: Color) {
@@ -175,14 +175,14 @@ module ex {
       }
 
       /**
-       * Applies the saturate effect to a sprite, saturates the color acccording to hsl
+       * Applies the saturate effect to a sprite, saturates the color according to hsl
        */
       public saturate(factor: number = 0.1) {
          this.addEffect(new Effects.Saturate(factor));
       }
 
       /**
-       * Applies the desaturate effect to a sprite, desaturates the color acccording to hsl
+       * Applies the desaturate effect to a sprite, desaturates the color according to hsl
        */
       public desaturate(factor: number = 0.1) {
          this.addEffect(new Effects.Desaturate(factor));

--- a/src/engine/Drawing/Polygon.ts
+++ b/src/engine/Drawing/Polygon.ts
@@ -108,7 +108,7 @@ module ex {
          ctx.beginPath();
          ctx.lineWidth = this.lineWidth;
 
-         // Iterate through the supplied points and contruct a 'polygon'
+         // Iterate through the supplied points and construct a 'polygon'
          var firstPoint = this._points[0];
          ctx.moveTo(firstPoint.x, firstPoint.y);
 

--- a/src/engine/Drawing/Sprite.ts
+++ b/src/engine/Drawing/Sprite.ts
@@ -194,7 +194,7 @@ module ex {
       }
 
       /**
-       * Applies the [[Effects.Colorize]] to a sprite, changing the color channels of all pixesl to be the average of the original color
+       * Applies the [[Effects.Colorize]] to a sprite, changing the color channels of all pixels to be the average of the original color
        * and the provided color.
        */
       public colorize(color: Color) {
@@ -216,14 +216,14 @@ module ex {
       }
 
       /**
-       * Applies the [[Effects.Saturate]] to a sprite, saturates the color acccording to HSL
+       * Applies the [[Effects.Saturate]] to a sprite, saturates the color according to HSL
        */
       public saturate(factor: number = 0.1) {
          this.addEffect(new Effects.Saturate(factor));
       }
 
       /**
-       * Applies the [[Effects.Desaturate]] to a sprite, desaturates the color acccording to HSL
+       * Applies the [[Effects.Desaturate]] to a sprite, desaturates the color according to HSL
        */
       public desaturate(factor: number = 0.1) {
          this.addEffect(new Effects.Desaturate(factor));

--- a/src/engine/Drawing/SpriteEffects.ts
+++ b/src/engine/Drawing/SpriteEffects.ts
@@ -138,7 +138,7 @@ module ex {
       }
 
       /**
-       * Applies the "Saturate" effect to a sprite, saturates the color acccording to HSL
+       * Applies the "Saturate" effect to a sprite, saturates the color according to HSL
        */
       export class Saturate implements ISpriteEffect {
         /**
@@ -160,7 +160,7 @@ module ex {
       }
 
       /**
-       * Applies the "Desaturate" effect to a sprite, desaturates the color acccording to HSL
+       * Applies the "Desaturate" effect to a sprite, desaturates the color according to HSL
        */
       export class Desaturate implements ISpriteEffect {
         /**

--- a/src/engine/Drawing/SpriteSheet.ts
+++ b/src/engine/Drawing/SpriteSheet.ts
@@ -285,10 +285,10 @@ module ex {
       /**
        * @param image           The backing image texture to build the SpriteFont
        * @param alphabet        A string representing all the characters in the image, in row major order.
-       * @param caseInsensitve  Indicate whether this font takes case into account 
+       * @param caseInsensitive  Indicate whether this font takes case into account 
        * @param columns         The number of columns of characters in the image
        * @param rows            The number of rows of characters in the image
-       * @param spWdith         The width of each character in pixels
+       * @param spWidth         The width of each character in pixels
        * @param spHeight        The height of each character in pixels
        */
       constructor(public image: Texture,
@@ -320,7 +320,7 @@ module ex {
       /**
        * Sets the text shadow for sprite fonts
        * @param offsetX      The x offset in pixels to place the shadow
-       * @param offsetY      The y offset in pixles to place the shadow
+       * @param offsetY      The y offset in pixels to place the shadow
        * @param shadowColor  The color of the text shadow
        */
       public setTextShadow(offsetX: number, offsetY: number, shadowColor: Color) {

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -218,8 +218,8 @@ module ex {
     *     |_ Actor 1
     *       |_ Child Actor 1
     *     |_ Actor 2
-    *   |_ Scene 2 (deactiveated)
-    *   |_ Scene 3 (deactiveated)
+    *   |_ Scene 2 (deactivated)
+    *   |_ Scene 3 (deactivated)
     * ```
     *
     * The engine splits the game into two primary responsibilities: updating and drawing. This is
@@ -916,7 +916,7 @@ O|===|* >________________>\n\
             screenY -= focus.y;
          }
 
-         // transfrom back on zoom
+         // transform back on zoom
          screenX = screenX + this.getWidth() / 2;
          screenY = screenY + this.getHeight() / 2;
 
@@ -1054,7 +1054,7 @@ O|===|* >________________>\n\
 
       /**
        * Draws the entire game
-       * @param draw  Number of milliseconds elapsed since the last draw.
+       * @param delta  Number of milliseconds elapsed since the last draw.
        */
       private _draw(delta: number) {
          var ctx = this.ctx;

--- a/src/engine/Events.ts
+++ b/src/engine/Events.ts
@@ -252,14 +252,15 @@ module ex {
    }
 
    /**
-    * Event thrown on an [[Actor|actor]] when a collision has occured
+    * Event thrown on an [[Actor|actor]] when a collision has occurred
     */
    export class CollisionEvent extends GameEvent {
 
       /**
-       * @param actor  The actor the event was thrown on
-       * @param other  The actor that was collided with
-       * @param side   The side that was collided with
+       * @param actor         The actor the event was thrown on
+       * @param other         The actor that was collided with
+       * @param side          The side that was collided with
+       * @param intersection  Intersection vector
        */
       constructor(public actor: Actor, public other: Actor, public side: Side, public intersection: Vector) {
          super();

--- a/src/engine/Group.ts
+++ b/src/engine/Group.ts
@@ -13,7 +13,7 @@ module ex {
     *
     * ## Using Groups
     *
-    * Groups can be used to detect collisions across a large nubmer of actors. For example 
+    * Groups can be used to detect collisions across a large number of actors. For example 
     * perhaps a large group of "enemy" actors.
     *
     * ```typescript

--- a/src/engine/Input/Gamepad.ts
+++ b/src/engine/Input/Gamepad.ts
@@ -179,12 +179,12 @@
        * configuration is set all pads are valid.
        */
       public setMinimumGamepadConfiguration(config: IGamepadConfiguration) : void {
-         this._enableAndUpdate(); // if config is used, implicitely enable
+         this._enableAndUpdate(); // if config is used, implicitly enable
          this._minimumConfiguration = config;
       }
       
       /** 
-       * When implicitely enabled, set the enabled flag and run an update so information is updated
+       * When implicitly enabled, set the enabled flag and run an update so information is updated
        */
       private _enableAndUpdate() {
          if (!this.enabled) {
@@ -319,7 +319,7 @@
       }
       
       /**
-       * Returns a list of all valid gamepads that meet the minimum configuration requirment.
+       * Returns a list of all valid gamepads that meet the minimum configuration requirement.
        */
       public getValidGamepads(): Gamepad[] {
          this._enableAndUpdate();
@@ -564,4 +564,4 @@
       axis: number;
       buttons: number;
    }
-}  
+}

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -192,7 +192,7 @@
 
       /**
        * Tests if a certain key was just pressed this frame. This is cleared at the end of the update frame.
-       * @param key Test wether a key was just pressed
+       * @param key Test whether a key was just pressed
        */
       public wasPressed(key: Keys): boolean {
          return this._keysDown.indexOf(key) > -1;
@@ -200,7 +200,7 @@
 
       /**
        * Tests if a certain key is held down. This is persisted between frames.
-       * @param key  Test wether a key is held down
+       * @param key  Test whether a key is held down
        */
       public isHeld(key: Keys): boolean {
          return this._keys.indexOf(key) > -1;
@@ -208,7 +208,7 @@
 
       /**
        * Tests if a certain key was just released this frame. This is cleared at the end of the update frame.
-       * @param key  Test wether a key was just released
+       * @param key  Test whether a key was just released
        */
       public wasReleased(key: Keys): boolean {
          return this._keysUp.indexOf(key) > -1;

--- a/src/engine/Input/Pointer.ts
+++ b/src/engine/Input/Pointer.ts
@@ -185,7 +185,7 @@ module ex.Input {
     * ```js
     * var player = new ex.Actor();
     *
-    * // enable propogating pointer events
+    * // enable propagating pointer events
     * player.enableCapturePointer = true;
     *
     * // enable move events, warning: performance intensive!

--- a/src/engine/Interfaces/IDrawable.ts
+++ b/src/engine/Interfaces/IDrawable.ts
@@ -64,7 +64,7 @@ module ex {
 
 
       /**
-       * Gets or sets the scale trasformation
+       * Gets or sets the scale transformation
        */
       scale: ex.Vector;
 

--- a/src/engine/Label.ts
+++ b/src/engine/Label.ts
@@ -96,7 +96,7 @@ module ex {
     * Labels
     *
     * Labels are the way to draw small amounts of text to the screen. They are
-    * actors and inherit all of the benifits and capabilities.
+    * actors and inherit all of the benefits and capabilities.
     *
     * ## Creating a Label
     *
@@ -118,7 +118,7 @@ module ex {
     * label.y = 50;
     * label.fontFamily = "Arial";
     * label.fontSize = 10;
-    * lable.fontUnit = ex.FontUnit.Px // pixels are the default
+    * label.fontUnit = ex.FontUnit.Px // pixels are the default
     * label.text = "Foo";
     * label.color = ex.Color.White;
     * label.textAlign = ex.TextAlign.Center;
@@ -255,8 +255,8 @@ module ex {
        * @param text        The text of the label
        * @param x           The x position of the label
        * @param y           The y position of the label
-       * @param font        Use any valid CSS font string for the label's font. Web fonts are supported. Default is `10px sans-serif`.
-       * @param spriteFont  Use an Excalibur sprite font for the label's font, if a SpriteFont is provided it will take precendence 
+       * @param fontFamily  Use any valid CSS font string for the label's font. Web fonts are supported. Default is `10px sans-serif`.
+       * @param spriteFont  Use an Excalibur sprite font for the label's font, if a SpriteFont is provided it will take precedence 
        * over a css font.
        */
       constructor(text?: string, x?: number, y?: number, fontFamily?: string, spriteFont?: SpriteFont) {
@@ -265,7 +265,7 @@ module ex {
          this.color = Color.Black.clone();
          this.spriteFont = spriteFont;
          this.collisionType = CollisionType.PreventCollision;                  
-         this.fontFamily = fontFamily || 'sans-serif'; // coallesce to default canvas font
+         this.fontFamily = fontFamily || 'sans-serif'; // coalesce to default canvas font
          if (spriteFont) {
             //this._textSprites = spriteFont.getTextSprites();
          }
@@ -341,7 +341,7 @@ module ex {
       /**
        * Sets the text shadow for sprite fonts
        * @param offsetX      The x offset in pixels to place the shadow
-       * @param offsetY      The y offset in pixles to place the shadow
+       * @param offsetY      The y offset in pixels to place the shadow
        * @param shadowColor  The color of the text shadow
        */
       public setTextShadow(offsetX: number, offsetY: number, shadowColor: Color) {

--- a/src/engine/Particles.ts
+++ b/src/engine/Particles.ts
@@ -210,11 +210,11 @@ module ex {
       public deadParticles: Util.Collection<Particle> = null;
 
       /**
-       * Gets or sets the minimum partical velocity
+       * Gets or sets the minimum particle velocity
        */
       public minVel: number = 0;
       /**
-       * Gets or sets the maximum partical velocity
+       * Gets or sets the maximum particle velocity
        */
       public maxVel: number = 0;
 
@@ -349,9 +349,9 @@ module ex {
          this.particles.clear();
       }
 
-      // Creates a new particle given the contraints of the emitter
+      // Creates a new particle given the constraints of the emitter
       private _createParticle(): Particle {
-         // todo implement emitter contraints;
+         // todo implement emitter constraints;
          var ranX = 0;
          var ranY = 0;
 

--- a/src/engine/Physics.ts
+++ b/src/engine/Physics.ts
@@ -3,7 +3,7 @@ module ex {
    /**
     * Possible collision resolution strategies
     *
-    * The default is [[CollisionResolutionStrategy.Box]] which performs simple axis aligned arcade style physcs.
+    * The default is [[CollisionResolutionStrategy.Box]] which performs simple axis aligned arcade style physics.
     * 
     * More advanced rigid body physics are enabled by setting [[CollisionResolutionStrategy.RigidBody]] which allows for complicated
     * simulated physical interactions.
@@ -85,7 +85,7 @@ module ex {
     * ## Limitations
     *
     * Currently Excalibur only supports single contact point collisions and non-sleeping physics bodies. This has some negative stability 
-    * and performance implications. Single contact point collisions can have odd oscilating behavior. Non-sleeping bodies will recalculate
+    * and performance implications. Single contact point collisions can have odd oscillating behavior. Non-sleeping bodies will recalculate
     * collisions whether they need to or not. We fully intend to add these features into Excalibur in future releases.
     *
     */
@@ -93,7 +93,7 @@ module ex {
    export class Physics {
       /**
        * Global acceleration that is applied to all vanilla actors (it wont effect [[Label|labels]], [[UIActor|ui actors]], or 
-       * [[Trigger|triggers]] in Excalibur that have an [[CollisionType.Active|active]] collison type).
+       * [[Trigger|triggers]] in Excalibur that have an [[CollisionType.Active|active]] collision type).
        * 
        * 
        * This is a great way to globally simulate effects like gravity.
@@ -111,7 +111,7 @@ module ex {
        * Reducing collision passes may cause things not to collide as expected in your game, but may increase performance.
        * 
        * More passes can improve the visual quality of collisions when many objects are on the screen. This can reduce jitter, improve the
-       * collison resolution of fast move objects, or the stability of large numbers of objects stacked together.
+       * collision resolution of fast move objects, or the stability of large numbers of objects stacked together.
        * 
        * Fewer passes will improve the performance of the game at the cost of collision quality, more passes will improve quality at the 
        * cost of performance. 

--- a/src/engine/PostProcessing/IPostProcessor.ts
+++ b/src/engine/PostProcessing/IPostProcessor.ts
@@ -6,7 +6,7 @@
      * Sometimes it is necessary to apply an effect to the canvas after the engine has completed its drawing pass. A few reasons to do 
      * this might be creating a blur effect, adding a lighting effect, or changing how colors and pixels look.
      *
-     * ## Basic post procesors
+     * ## Basic post processors
      *
      * To create and use a post processor you just need to implement a class that implements [[IPostProcessor]], which has one method
      * [[IPostProcessor.process]]. Set the `out` canvas parameter to the final result, using the `image` pixel data.
@@ -41,7 +41,7 @@
      * Choosing colors that are friendly to players with color blindness is an important consideration when making a game. 
      * There is a significant portion of the population that has some form of color blindness, 
      * and choosing bad colors can make your game unplayable. We have built
-     * a post procesors that can shift your colors into as more visible range for the 3 most common types of 
+     * a post processors that can shift your colors into as more visible range for the 3 most common types of 
      * [[https://en.wikipedia.org/wiki/Color_blindness|color blindness]]. 
      * 
      *  - [[ColorBlindness.Protanope|Protanope]]

--- a/src/engine/Promises.ts
+++ b/src/engine/Promises.ts
@@ -151,7 +151,7 @@ module ex {
       }
 
       /**
-       * Chain success and reject callbacks after the promise is resovled
+       * Chain success and reject callbacks after the promise is resolved
        * @param successCallback  Call on resolution of promise
        * @param rejectCallback   Call on rejection of promise
        */
@@ -237,7 +237,7 @@ module ex {
       }
 
       /**
-       * Inpect the current state of a promise
+       * Inspect the current state of a promise
        */
       public state(): PromiseState {
          return this._state;

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -64,7 +64,7 @@ module ex {
     * 
     * ## Scene Lifecycle
     *
-    * A [[Scene|scene]] has a basic lifecycle that dictacts how it is initialized, updated, and drawn. Once a [[Scene|scene]] is added to 
+    * A [[Scene|scene]] has a basic lifecycle that dictates how it is initialized, updated, and drawn. Once a [[Scene|scene]] is added to 
     * the [[Engine|engine]] it will follow this lifecycle.
     * 
     * ![Scene Lifecycle](/assets/images/docs/SceneLifecycle.png)

--- a/src/engine/TileMap.ts
+++ b/src/engine/TileMap.ts
@@ -22,7 +22,7 @@ module ex {
    *
    * ## Creating a tile map
    *
-   * A [[TileMap]] is meant to be used in conjuction with a map editor. Creating
+   * A [[TileMap]] is meant to be used in conjunction with a map editor. Creating
    * a tile map is fairly straightforward.
    *
    * You need a tile sheet (see [[SpriteSheet]]) that holds all the available tiles to
@@ -158,7 +158,6 @@ module ex {
      * @param cellHeight    The individual height of each cell (in pixels) (should not be changed once set)
      * @param rows          The number of rows in the TileMap (should not be changed once set)
      * @param cols          The number of cols in the TileMap (should not be changed once set)
-     * @param spriteSheet   The spriteSheet to use for drawing
      */
     constructor(
        public x: number, 

--- a/src/engine/Timer.ts
+++ b/src/engine/Timer.ts
@@ -16,7 +16,8 @@ module ex {
     public scene: Scene = null;
 
     /**
-     * @param callback   The callback to be fired after the interval is complete.
+     * @param fcn        The callback to be fired after the interval is complete.
+     * @param interval   Interval length
      * @param repeats    Indicates whether this call back should be fired only once, or repeat after every interval as completed.    
      */      
     constructor(fcn: () => void, interval: number, repeats?: boolean) {

--- a/src/engine/Util/DrawUtil.ts
+++ b/src/engine/Util/DrawUtil.ts
@@ -85,7 +85,7 @@ module ex.Util.DrawUtil {
    }
 
    /**
-    * Draw a round rectange on a canvas context
+    * Draw a round rectangle on a canvas context
     * 
     * @param ctx The canvas context
     * @param x The top-left x coordinate

--- a/src/engine/Util/EasingFunctions.ts
+++ b/src/engine/Util/EasingFunctions.ts
@@ -9,7 +9,7 @@
 
    /**
     * Standard easing functions for motion in Excalibur, defined on a domain of [0, duration] and a range from [+startValue,+endValue]
-    * Given a time, the function will return a value from postive startValue to postive endValue.
+    * Given a time, the function will return a value from positive startValue to positive endValue.
     *
     * ```js
     * function Linear (t) {

--- a/src/engine/Util/Util.ts
+++ b/src/engine/Util/Util.ts
@@ -221,7 +221,7 @@ module ex.Util {
    }
 
    /**
-    * Excaliburs dynamically resizing collection
+    * Excalibur's dynamically resizing collection
     */
    export class Collection<T> {
       /**
@@ -291,7 +291,7 @@ module ex.Util {
 
       /**
        * Returns an element at a specific index
-       * @param index  Index of element to retreive
+       * @param index  Index of element to retrieve
        */
       public elementAt(index: number): T {
          if (index >= this.count()) {
@@ -303,6 +303,7 @@ module ex.Util {
       /**
        * Inserts an element at a specific index
        * @param index  Index to insert the element
+       * @param value  Element to insert
        */
       public insert(index: number, value: T): T {
          if (index >= this.count()) {
@@ -329,7 +330,7 @@ module ex.Util {
 
       /**
        * Removes an element by reference
-       * @param element  Element to retreive
+       * @param element  Element to retrieve
        */
       public removeElement(element: T) {
          var index = this._internalArray.indexOf(element);


### PR DESCRIPTION
## Proposed Changes:

- Fixing mismatched/missing/hanging JSDoc `@param` tags, according to code
- Typos in JSDoc and usual comments

Rationale: friendlier user documentation and code base.