### PR TITLE
Fix Label#getTextWidth returns incorrect result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix `Actor.oldPos` and `Actor.oldVel` values on update ([#666](https://github.com/excaliburjs/Excalibur/issues/666))
+- Fix `Label.getTextWidth` returns incorrect result ([#679](https://github.com/excaliburjs/Excalibur/issues/679))
 
 ## [0.7.1]
 

--- a/src/engine/Label.ts
+++ b/src/engine/Label.ts
@@ -278,7 +278,7 @@ module ex {
        */
       public getTextWidth(ctx: CanvasRenderingContext2D): number {
          var oldFont = ctx.font;
-         ctx.font = this.fontFamily;
+         ctx.font = this._fontString;
          var width = ctx.measureText(this.text).width;
          ctx.font = oldFont;
          return width;
@@ -429,7 +429,7 @@ module ex {
                this.color.a = this.opacity;
             }
             ctx.fillStyle = this.color.toString();
-            ctx.font = `${this.fontSize}${this._lookupFontUnit(this.fontUnit)} ${this.fontFamily}`;
+            ctx.font = this._fontString;
             if (this.maxWidth) {
                ctx.fillText(this.text, 0, 0, this.maxWidth);
             } else {
@@ -439,6 +439,10 @@ module ex {
             ctx.textAlign = oldAlign;
             ctx.textBaseline = oldTextBaseline;
          }
+      }
+
+      protected get _fontString() {
+          return `${this.fontSize}${this._lookupFontUnit(this.fontUnit)} ${this.fontFamily}`;
       }
 
       public debugDraw(ctx: CanvasRenderingContext2D) {


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #679 

## Proposed Changes:

- fix `Label#getTextWidth` so it returns proper number
- introduce protected readonly `_fontString` property, which properly combines fontFamily with fontSize and is used in `_fontDraw` and `getTextWidth`.

Basically, this PR changes method so it takes into account not only fontFamily, but fontSize too.