### PR TITLE
[#501] Add Promise.resolve/reject methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `ex.Line.findPoint(x?, y?)` to find a point given an X or a Y value
   - `ex.Line.hasPoint(x, y, threshold)` to determine if given point lies on the line
 - new `Vector.One` and `Vector.Half` constants ([#649](https://github.com/excaliburjs/Excalibur/issues/649))
+- Added `ex.Promise.resolve` and `ex.Promise.reject` static methods, deprecated `ex.Promise.wrap` ([#501](https://github.com/excaliburjs/Excalibur/issues/501))
 
 ### Fixed
 

--- a/src/engine/Promises.ts
+++ b/src/engine/Promises.ts
@@ -101,7 +101,7 @@ module ex {
 
       /**
        * Create and reject a Promise with an optional value
-       * @param value  An optional value to wrap in a resolved promise
+       * @param value  An optional value to wrap in a rejected promise
        */
       public static reject<T>(value?: T): Promise<T> {
          var promise = (new Promise<T>()).reject(value);

--- a/src/engine/Promises.ts
+++ b/src/engine/Promises.ts
@@ -82,12 +82,32 @@ module ex {
       /**
        * Wrap a value in a resolved promise
        * @param value  An optional value to wrap in a resolved promise
+       * @obsolete Use [[resolve]] instead. This will be deprecated in future versions.
        */
       public static wrap<T>(value?: T): Promise<T> {
+         ex.Logger.getInstance().warn('[obsolete] Promise.wrap is obsolete. Use Promise.resolve/reject instead.');
+         return Promise.resolve(value);
+      }
+
+      /**
+       * Create and resolve a Promise with an optional value
+       * @param value  An optional value to wrap in a resolved promise
+       */
+      public static resolve<T>(value?: T): Promise<T> {
          var promise = (new Promise<T>()).resolve(value);
 
          return promise;
-      }
+      }     
+
+      /**
+       * Create and reject a Promise with an optional value
+       * @param value  An optional value to wrap in a resolved promise
+       */
+      public static reject<T>(value?: T): Promise<T> {
+         var promise = (new Promise<T>()).reject(value);
+
+         return promise;
+      }  
 
       /**
        * Returns a new promise that resolves when all the promises passed to it resolve, or rejects

--- a/src/spec/PromiseSpec.ts
+++ b/src/spec/PromiseSpec.ts
@@ -175,7 +175,7 @@ describe('A promise', () => {
          expect(composite.state()).toBe(ex.PromiseState.Resolved);
       });
 
-      it('can join promises and resovle when all resolve', () => {
+      it('can join promises and resolve when all resolve', () => {
          
          var composite = ex.Promise.join(p1, p2, p3);
 
@@ -194,7 +194,7 @@ describe('A promise', () => {
          expect(composite.state()).toBe(ex.PromiseState.Resolved);
       });
 
-      it('can join promises and resvlve when some reject', () => {
+      it('can join promises and resolve when some reject', () => {
          var composite = ex.Promise.join(p1, p2, p3);
 
          expect(composite.state()).toBe(ex.PromiseState.Pending);

--- a/src/spec/PromiseSpec.ts
+++ b/src/spec/PromiseSpec.ts
@@ -114,11 +114,11 @@ describe('A promise', () => {
       expect(() => { promise.resolve(); }).toThrow();
    });
 
-   it('should be able to wrap a value in a promise', (done) => {
+   it('should be able to resolve a value in a promise', (done) => {
       var p;
       var value : number;
       
-      p = ex.Promise.wrap<number>(12);
+      p = ex.Promise.resolve<number>(12);
       
       expect(p.state()).toBe(ex.PromiseState.Resolved);
 
@@ -127,6 +127,23 @@ describe('A promise', () => {
          expect(value).toBe(12);
          done();         
       });         
+   });
+
+   it('should be able to reject a value in a promise', (done) => {
+      var p;
+      var value : number;
+      
+      p = ex.Promise.reject<number>(12);
+      
+      expect(p.state()).toBe(ex.PromiseState.Rejected);
+
+      done();
+      // TODO Test onRejected callback
+      // p.then((v) => {
+      //    value = v;
+      //    expect(value).toBe(12);
+      //    done();         
+      // });         
    });
 
    describe('with multiple promises', () => {
@@ -177,7 +194,7 @@ describe('A promise', () => {
          expect(composite.state()).toBe(ex.PromiseState.Resolved);
       });
 
-      it('can join promises and resovle when some reject', () => {
+      it('can join promises and resvlve when some reject', () => {
          var composite = ex.Promise.join(p1, p2, p3);
 
          expect(composite.state()).toBe(ex.PromiseState.Pending);


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #501

## Proposed Changes:

- Add `ex.Promise.resolve`
- Add `ex.Promise.reject`
- Deprecated `ex.Promise.wrap`

## Notes

We need to add an `onRejected` callback to `then` to match Promise A+ spec.

