### PR TITLE
Fix typo in Physics docs (egde -> ground)

### DIFF
--- a/src/engine/Physics.ts
+++ b/src/engine/Physics.ts
@@ -75,7 +75,7 @@ module ex {
     * 
     * var ground = new ex.Actor(300, 380, 600, 10, ex.Color.Black.clone());
     * ground.collisionType = ex.CollisionType.Fixed;
-    * edge.body.useBoxCollision(); // optional 
+    * ground.body.useBoxCollision(); // optional 
     * game.add(ground);
     *
     * // start the game


### PR DESCRIPTION
## Proposed Changes:

- Fix typo in Physics docs, there's no `edge` variable around, definitely meant `ground`

