### PR TITLE
Fix Effects.Opacity invalid opacity handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix `Actor.oldPos` and `Actor.oldVel` values on update ([#666](https://github.com/excaliburjs/Excalibur/issues/666))
 - Fix `Label.getTextWidth` returns incorrect result ([#679](https://github.com/excaliburjs/Excalibur/issues/679))
+- Fix semi-transparent PNGs appear garbled ([#687](https://github.com/excaliburjs/Excalibur/issues/687))
 
 ## [0.7.1]
 

--- a/src/engine/Drawing/SpriteEffects.ts
+++ b/src/engine/Drawing/SpriteEffects.ts
@@ -67,7 +67,7 @@ module ex {
            var firstPixel = (x + y * imageData.width) * 4;
            var pixel = imageData.data;
            if (pixel[firstPixel + 3] !== 0) {
-              pixel[firstPixel + 3] = Math.round(this.opacity * 255);
+              pixel[firstPixel + 3] = Math.round(this.opacity * pixel[firstPixel + 3]);
            }
         }
       }


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #687 

## Proposed Changes:

- Change Effects.Opacity so it calculates pixel's opacity relative to current opacity value, not fixed number.