### PR TITLE
Minimize Sprite#_applyEffects calls count

### DIFF
--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -604,7 +604,7 @@ module ex {
     private _collisionHandlers: {[key: string]: {(actor: Actor): void}[]; } = {};
     private _isInitialized: boolean = false;
     public frames: { [key: string]: IDrawable; } = {};
-    private _framesDirty: boolean = false;
+    private _effectsDirty: boolean = false;
 
     /**
      * Access to the current drawing for the actor, this can be 
@@ -826,7 +826,7 @@ module ex {
           if (!this.currentDrawing) {
              this.currentDrawing = arguments[1];
           }
-          this._framesDirty = true;
+          this._effectsDirty = true;
        } else {
           if (arguments[0] instanceof Sprite) {
              this.addDrawing('default', arguments[0]);   
@@ -1159,6 +1159,11 @@ module ex {
        return new ex.Vector(this.getWidth() * this.anchor.x, this.getHeight() * this.anchor.y);
     }
 
+    protected _reapplyEffects(drawing: IDrawable) {
+      drawing.removeEffect(this._opacityFx);
+      drawing.addEffect(this._opacityFx);
+    }
+    
     /**
      * Perform euler integration at the specified time step
      */
@@ -1213,19 +1218,7 @@ module ex {
        if (this.previousOpacity !== this.opacity) {
           this.previousOpacity = this.opacity;
           this._opacityFx.opacity = this.opacity;          
-          this._framesDirty = true;                    
-       }
-
-       // handle dirty frames and reapply any effects we are tracking
-       if (this._framesDirty) {
-          this._framesDirty = false;
-
-          // ensure we remove existing opacity effect we created
-          // and also ensure we do this everytime in case frames change
-          for (var drawing in this.frames) {
-             this.frames[drawing].removeEffect(this._opacityFx);
-             this.frames[drawing].addEffect(this._opacityFx);
-          }
+          this._effectsDirty = true;
        }
 
        // Capture old values before integration step updates them
@@ -1272,6 +1265,11 @@ module ex {
           var offsetX = (this._width - drawing.naturalWidth * drawing.scale.x) * this.anchor.x;
           var offsetY = (this._height - drawing.naturalHeight * drawing.scale.y) * this.anchor.y;
 
+          if (this._effectsDirty) {
+            this._reapplyEffects(this.currentDrawing);
+            this._effectsDirty = false;
+          }
+         
           this.currentDrawing.draw(ctx, offsetX, offsetY);
        } else {
           if (this.color) {

--- a/src/engine/Drawing/Sprite.ts
+++ b/src/engine/Drawing/Sprite.ts
@@ -1,5 +1,7 @@
 module ex {
 
+   var clamp = Util.clamp;
+   
    /**
     * Sprites
     *
@@ -140,7 +142,6 @@ module ex {
 
       private _loadPixels() {
          if (this._texture.isLoaded() && !this._pixelsLoaded) {
-            var clamp = ex.Util.clamp;
             var naturalWidth = this._texture.image.naturalWidth || 0;
             var naturalHeight = this._texture.image.naturalHeight || 0;
 
@@ -280,7 +281,6 @@ module ex {
       }
 
       private _applyEffects() {
-         var clamp = ex.Util.clamp;
          var naturalWidth = this._texture.image.naturalWidth || 0;
          var naturalHeight = this._texture.image.naturalHeight || 0;
 
@@ -305,6 +305,8 @@ module ex {
          this._spriteCtx.clearRect(0, 0, this.swidth, this.sheight);
          this._spriteCtx.putImageData(this._pixelData, 0, 0);
          this.internalImage.src = this._spriteCanvas.toDataURL('image/png');
+         
+         this._dirtyEffect = false;
       }
 
       /**
@@ -326,11 +328,13 @@ module ex {
          ctx.save();
          ctx.translate(x, y);
          ctx.rotate(this.rotation);
-         var xpoint = (this.width * this.scale.x) * this.anchor.x;
-         var ypoint = (this.height * this.scale.y) * this.anchor.y;
+         const scaledSWidth = this.width * this.scale.x;
+         const scaledSHeight = this.height * this.scale.y;
+         var xpoint = (scaledSWidth) * this.anchor.x;
+         var ypoint = (scaledSHeight) * this.anchor.y;
 
          ctx.strokeStyle = Color.Black;
-         ctx.strokeRect(-xpoint, -ypoint, this.width * this.scale.x, this.height * this.scale.y);
+         ctx.strokeRect(-xpoint, -ypoint, scaledSWidth, scaledSHeight);
          ctx.restore();
       }
 
@@ -343,7 +347,6 @@ module ex {
       public draw(ctx: CanvasRenderingContext2D, x: number, y: number) {
          if (this._dirtyEffect) {
             this._applyEffects();
-            this._dirtyEffect = false;
          }
          
          // calculating current dimensions
@@ -355,30 +358,29 @@ module ex {
          var ypoint = this.height * this.anchor.y;
          ctx.translate(x, y);
          ctx.rotate(this.rotation);
+
+         var scaledSWidth = this.swidth * this.scale.x;
+         var scaledSHeight = this.sheight * this.scale.y;
          
          // todo cache flipped sprites
          if (this.flipHorizontal) {
-            ctx.translate(this.swidth * this.scale.x, 0);
+            ctx.translate(scaledSWidth, 0);
             ctx.scale(-1, 1);
          }
 
          if (this.flipVertical) {
-            ctx.translate(0, this.sheight * this.scale.y);
+            ctx.translate(0, scaledSHeight);
             ctx.scale(1, -1);
          }
 
          if (this.internalImage) {
-            
             ctx.drawImage(this.internalImage, 0, 0, this.swidth, this.sheight, 
                -xpoint, 
                -ypoint, 
-               this.swidth * this.scale.x, 
-               this.sheight * this.scale.y);
+               scaledSWidth,
+               scaledSHeight);
          }
          ctx.restore();
-
-         
-
       }
 
       /**


### PR DESCRIPTION
## Proposed Changes:

- In `Actor`, don't reapply effects to drawing in `update` method, do it only in `draw` and if `frames` or `opacity` was changed
- In `Sprite`, always set `_effectsDirty` flag after effects were applied
- Few minor changes, like don't calculate same value twice in same method

It's my attempt to improve things on issue #481. It doesn't close issue completely because source of unnecessary calls to `Sprite#_loadPixels` remains mystery to me, but I was able to reduce amount of `_applyEffects` calls.
I can miss some effects' use cases (although sandbox tests seemed working), so please review this carefully.