### PR TITLE
[#692] Actor Bounding Boxes Include Rotation and Scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix `Label.getTextWidth` returns incorrect result ([#679](https://github.com/excaliburjs/Excalibur/issues/679))
 - Fix semi-transparent PNGs appear garbled ([#687](https://github.com/excaliburjs/Excalibur/issues/687))
 - Fix incorrect code coverage metrics, previously our test process was reporting higher than actual code coverage ([#521](https://github.com/excaliburjs/Excalibur/issues/521))
+- Fix `Actor.getBounds()` and `Actor.getRelativeBounds()` to return accurate bounding boxes based on the scale and rotation of actors. ([#692](https://github.com/excaliburjs/Excalibur/issues/692))
 
 ## [0.7.1]
 

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -1036,7 +1036,7 @@ module ex {
        return new BoundingBox(pos.x - anchor.x,
           pos.y - anchor.y,
           pos.x + this.getWidth() - anchor.x,
-          pos.y + this.getHeight() - anchor.y);
+          pos.y + this.getHeight() - anchor.y).rotate(this.rotation, pos);
     }
 
     /**
@@ -1048,7 +1048,7 @@ module ex {
        return new BoundingBox(-anchor.x,
                               -anchor.y,
                               this.getWidth() - anchor.x,
-                              this.getHeight() - anchor.y);
+                              this.getHeight() - anchor.y).rotate(this.rotation);
     }
 
 

--- a/src/engine/Collision/BoundingBox.ts
+++ b/src/engine/Collision/BoundingBox.ts
@@ -36,6 +36,29 @@ module ex {
          * @param bottom  y coordinate of the bottom edge
          */
         constructor(public left: number = 0, public top: number = 0, public right: number = 0, public bottom: number = 0) { }
+
+        public static fromPoints(points: Vector[]): BoundingBox {
+           var minX = Infinity;
+           var minY = Infinity;
+           var maxX = -Infinity;
+           var maxY = -Infinity;
+           for (var i = 0; i < points.length; i++) {
+              if (points[i].x < minX) {
+                 minX = points[i].x;
+              }
+              if (points[i].x > maxX) {
+                 maxX = points[i].x;
+              }
+              if (points[i].y < minY) {
+                 minY = points[i].y;
+              }
+              if (points[i].y > maxY) {
+                 maxY = points[i].y;
+              }
+           }
+           return new BoundingBox(minX, minY, maxX, maxY);
+        }
+
         /**
          * Returns the calculated width of the bounding box
          */
@@ -48,6 +71,14 @@ module ex {
          */
         public getHeight() {
             return this.bottom - this.top;
+        }
+
+        /**
+         * Rotates a bounding box by and angle and around a point, if no point is specified (0, 0) is used by default
+         */
+        public rotate(angle: number, point: Vector = ex.Vector.Zero.clone()): BoundingBox {
+           var points = this.getPoints().map((p) => p.rotate(angle, point));
+           return BoundingBox.fromPoints(points);
         }
 
         /**

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -218,6 +218,40 @@ describe('A game actor', () => {
       expect(child.getTop()).toBe(-50);
       expect(child.getBottom()).toBe(50);
    });
+
+   it('should have the correct bounds when scaled and rotated', () => {
+      
+      var actor = new ex.Actor(50, 50, 10, 10);
+      // actor is now 20 high
+      actor.scale.setTo(1, 2);
+      // rotating the actor 90 degrees should make the actor 20 wide
+      actor.rotation = Math.PI / 2;
+      var bounds = actor.getBounds();
+      expect(bounds.getWidth()).toBeCloseTo(20, .001);
+      expect(bounds.getHeight()).toBeCloseTo(10, .001);
+
+      expect(bounds.left).toBeCloseTo(40, .001);
+      expect(bounds.right).toBeCloseTo(60, .001);
+      expect(bounds.top).toBeCloseTo(45, .001);
+      expect(bounds.bottom).toBeCloseTo(55, .001);
+   });
+
+   it('should have the correct relative bounds when scaled and rotated', () => {
+      
+      var actor = new ex.Actor(50, 50, 10, 10);
+      // actor is now 20 high
+      actor.scale.setTo(1, 2);
+      // rotating the actor 90 degrees should make the actor 20 wide
+      actor.rotation = Math.PI / 2;
+      var bounds = actor.getRelativeBounds();
+      expect(bounds.getWidth()).toBeCloseTo(20, .001);
+      expect(bounds.getHeight()).toBeCloseTo(10, .001);
+
+      expect(bounds.left).toBeCloseTo(-10, .001);
+      expect(bounds.right).toBeCloseTo(10, .001);
+      expect(bounds.top).toBeCloseTo(-5, .001);
+      expect(bounds.bottom).toBeCloseTo(5, .001);
+   });
    
    it('has a left, right, top, and bottom when the anchor is (0, 0)', () => {
       actor.pos.x = 100;


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->
This pull request fixes an issue that was brought up on the google groups where rotated and scaled width and height could not be easily calculated, and the `actor.getWidth()` and `actor.getHeight()` were misleading.

@excaliburjs/core-contributers Before we merge this PR, I think we should have a discussion about `actor.getWidth()` and `actor.getHeight()` should they continue to operate without knowledge of rotation? is there a compelling reason to not just report the actual width and height of the bouding box? Please comment.

Closes #692 

## Proposed Changes:

- Add a static method for creating bounding boxes `ex.BoundingBox.fromPoints`
- Add a method for rotating bounding boxes `ex.BoundingBox.rotate`
- `actor.getBounds()` and `actor.getRelativeBounds()` now always return the correct bounds regardless of scale or rotation.

