### PR TITLE
Fix Appveyor versioning and update unstable docs

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -2,10 +2,10 @@
 /* Excalibur.js Grunt Build File
 /*********************************/
 var path = require('path');
-var appveyorBuild = process.env.APPVEYOR_BUILD_VERSION || '';
+var appveyorBuild = process.env.APPVEYOR_BUILD_NUMBER || '';
 
 if (appveyorBuild) {
-   appveyorBuild = '-unstable+' + appveyorBuild;
+   appveyorBuild = '-alpha.' + appveyorBuild + '+' + process.env.APPVEYOR_REPO_COMMIT.substring(0, 7);
 }
 
 /*global module:false*/

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -5,7 +5,7 @@ var path = require('path');
 var appveyorBuild = process.env.APPVEYOR_BUILD_NUMBER || '';
 
 if (appveyorBuild) {
-   appveyorBuild = '-alpha.' + appveyorBuild;
+   appveyorBuild = '.' + appveyorBuild + '-alpha';
 }
 
 /*global module:false*/

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -2,6 +2,11 @@
 /* Excalibur.js Grunt Build File
 /*********************************/
 var path = require('path');
+var appveyorBuild = process.env.APPVEYOR_BUILD_VERSION || '';
+
+if (appveyorBuild) {
+   appveyorBuild = '.' + appveyorBuild + '-unstable';
+}
 
 /*global module:false*/
 module.exports = function (grunt) {
@@ -11,7 +16,7 @@ module.exports = function (grunt) {
    //
    grunt.initConfig({
       pkg: grunt.file.readJSON('package.json'),
-      version: process.env.APPVEYOR_BUILD_VERSION || '<%= pkg.version %>',
+      version: '<%= pkg.version %>' + appveyorBuild,
       tscCmd: path.join('node_modules', '.bin', 'tsc'),
       jasmineCmd: path.join('node_modules', '.bin', 'jasmine'),
       jasmineConfig: path.join('src', 'spec', 'support', 'jasmine.json'),

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -5,7 +5,7 @@ var path = require('path');
 var appveyorBuild = process.env.APPVEYOR_BUILD_VERSION || '';
 
 if (appveyorBuild) {
-   appveyorBuild = '.' + appveyorBuild + '-unstable';
+   appveyorBuild = '-unstable+' + appveyorBuild;
 }
 
 /*global module:false*/

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -5,7 +5,7 @@ var path = require('path');
 var appveyorBuild = process.env.APPVEYOR_BUILD_NUMBER || '';
 
 if (appveyorBuild) {
-   appveyorBuild = '-alpha.' + appveyorBuild + '+' + process.env.APPVEYOR_REPO_COMMIT.substring(0, 7);
+   appveyorBuild = '-alpha.' + appveyorBuild;
 }
 
 /*global module:false*/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '0.8.0-{build}-unstable'
+version: '{build}'
 # Fix line endings on Windows
 init:
   - git config --global core.autocrlf true
@@ -17,11 +17,10 @@ install:
 build_script:
   - grunt appveyor
 artifacts:
-  - path: build\dist\Excalibur.%APPVEYOR_BUILD_VERSION%.nupkg
+  - path: build\dist\**\*.nupkg
     name: Nuget Package
 after_build:
-  - appveyor PushArtifact build\dist\Excalibur.%APPVEYOR_BUILD_VERSION%.nupkg
-#build: off
+  - ps: Get-ChildItem build\dist\*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 matrix:
   fast_finish: true
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+version: '0.8.0-{build}-unstable'
 # Fix line endings on Windows
 init:
   - git config --global core.autocrlf true

--- a/docs/source/unstable.rst
+++ b/docs/source/unstable.rst
@@ -1,10 +1,40 @@
 Unstable Builds
 ===============
 
+There are 4 easy ways to reference the latest unstable version of Excalibur depending on your tech stack of choice:
+
+npm
+---
+
+Each Excalibur build is published to the public NPM registry. 
+
+You can install the latest alpha version using the tag ``next``: 
+
+.. code-block:: bash
+
+   npm install excalibur@next
+
+Or reference the `excalibur-dist repository <https://github.com/excaliburjs/excalibur-dist>`_: 
+
+.. code-block:: bash
+
+   npm install excaliburjs/excalibur-dist
+
+Either way will work.
+
+bower
+-----
+
+For bower projects, just reference the `excalibur-dist repository <https://github.com/excaliburjs/excalibur-dist>`_:
+
+.. code-block:: bash
+
+   npm install excaliburjs/excalibur-dist
+
 Nuget Feed
 ----------
 
-To get unstable builds of Excalibur for your project and live on the edge, you can set add the Appveyor Nuget feed for Excalibur to your project.
+For a Windows project or Visual Studio Solution, you can add the Appveyor Nuget feed for Excalibur to your project:
 
    https://ci.appveyor.com/nuget/excalibur/
 

--- a/docs/source/unstable.rst
+++ b/docs/source/unstable.rst
@@ -29,7 +29,7 @@ For bower projects, just reference the `excalibur-dist repository <https://githu
 
 .. code-block:: bash
 
-   npm install excaliburjs/excalibur-dist
+   bower install excaliburjs/excalibur-dist
 
 Nuget Feed
 ----------


### PR DESCRIPTION
Previously, we had to update a setting in the Appveyor UI to hold the current Excalibur version, making releases difficult.

I've updated the appveyor build to now just use the package.json version, and append the build number. This eliminates any dependency on anything inside of Appveyor.

## Changes:

- Remove dependency on Appveyor version environment variable
- Update Unstable Builds documentation to add npm/bower information
