### PR TITLE
[#711] Removing reference to setting deprecated value

### DIFF
--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -788,10 +788,14 @@ O|===|* >________________>\n\
        */
       public setAntialiasing(isSmooth: boolean) {
          this._isSmoothingEnabled = isSmooth;
-         (<any>this.ctx).imageSmoothingEnabled = isSmooth;
-         (<any>this.ctx).webkitImageSmoothingEnabled = isSmooth;
-         (<any>this.ctx).mozImageSmoothingEnabled = isSmooth;
-         (<any>this.ctx).msImageSmoothingEnabled = isSmooth;
+
+         var ctx: any = this.ctx;
+         ctx.imageSmoothingEnabled = isSmooth;
+         ['webkitImageSmoothingEnabled', 'mozImageSmoothingEnabled', 'msImageSmoothingEnabled'].forEach((smoothing) => {
+            if (smoothing in ctx) {
+               ctx[smoothing] = isSmooth;
+            }
+         });
       }
 
       /**

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -791,11 +791,11 @@ O|===|* >________________>\n\
 
          var ctx: any = this.ctx;
          ctx.imageSmoothingEnabled = isSmooth;
-         ['webkitImageSmoothingEnabled', 'mozImageSmoothingEnabled', 'msImageSmoothingEnabled'].forEach((smoothing) => {
+         for (var smoothing of ['webkitImageSmoothingEnabled', 'mozImageSmoothingEnabled', 'msImageSmoothingEnabled']) {
             if (smoothing in ctx) {
                ctx[smoothing] = isSmooth;
             }
-         });
+         };
       }
 
       /**

--- a/src/spec/AlgebraSpec.ts
+++ b/src/spec/AlgebraSpec.ts
@@ -49,8 +49,9 @@ describe('Vectors', () => {
    });
    
    it('can be transformed to an angle', () => {
-      var v = ex.Vector.fromAngle(Math.PI / 4);
-      expect(v.toAngle()).toBe(Math.PI / 4);
+      var target = Math.PI / 4;
+      var v = ex.Vector.fromAngle(target);
+      expect(v.toAngle()).toBeCloseTo(target, 4);
    });
    
    it('can calculate distance to origin', () =>  {


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #711

## Changes:

- Remove direct references to deprecated context smoothing attributes
- Added dynamic setting of context smoothing attributes by existence
