### PR TITLE
[#707] Add report for browser feature support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking Changes
 
 ### Added
+- Added extended feature detection and reporting to `ex.Detector` ([#707](https://github.com/excaliburjs/Excalibur/issues/707))
+  - `ex.Detector.getBrowserFeatures()` to retrieve the support matrix of the current browser
+  - `ex.Detector.logBrowserFeatures()` to log the support matrix to the console (runs at startup when in Debug mode)
 
 ### Changed
 - Changed Util.clamp to use math libraries ([#536](https://github.com/excaliburjs/Excalibur/issues/536))

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -319,6 +319,12 @@ O|===|* >________________>\n\
          }
 
          this._logger = Logger.getInstance();
+
+         // If debug is enabled, let's log browser features to the console.
+         if (this._logger.defaultLevel === LogLevel.Debug) {
+            detector.logBrowserFeatures();
+         }
+         
          this._logger.debug('Building engine...');
 
          this.canvasElementId = options.canvasElementId;

--- a/src/engine/Util/Detector.ts
+++ b/src/engine/Util/Detector.ts
@@ -54,7 +54,7 @@ module ex {
                args.push('font-weight: bold; color: green');
                args.push('font-weight: normal; color: inherit');
             } else {
-               msg += '(%c\u2717%c)'
+               msg += '(%c\u2717%c)';
                args.push('font-weight: bold; color: red');
                args.push('font-weight: normal; color: inherit'); 
             };

--- a/src/engine/Util/Detector.ts
+++ b/src/engine/Util/Detector.ts
@@ -15,7 +15,7 @@ module ex {
    /**
     * Interface for detected browser features matrix
     */
-   export interface DetectedFeatures {
+   export interface IDetectedFeatures {
       canvas: boolean;
       arraybuffer: boolean;
       dataurl: boolean;
@@ -31,7 +31,7 @@ module ex {
     */
    export class Detector {
 
-      private _features: DetectedFeatures = null;
+      private _features: IDetectedFeatures = null;
 
       public failedTests: string[] = [];
 
@@ -85,7 +85,7 @@ module ex {
        * Executes several IIFE's to get a constant reference to supported
        * features within the current execution context.
        */
-      private _loadBrowserFeatures(): DetectedFeatures {
+      private _loadBrowserFeatures(): IDetectedFeatures {
          return {
             // IIFE to check canvas support
             canvas: (() => {

--- a/src/engine/Util/Detector.ts
+++ b/src/engine/Util/Detector.ts
@@ -1,12 +1,37 @@
 /// <reference path="Log.ts" />
+
+/**
+ * This is the list of features that will be used to log the supported
+ * features to the console when Detector.logBrowserFeatures() is called.
+ */
+const REPORTED_FEATURES: Object = {
+   webgl: 'WebGL',
+   webaudio: 'WebAudio',
+   gamepadapi: 'Gamepad API'
+};
+
 module ex {
+
+   /**
+    * Interface for detected browser features matrix
+    */
+   export interface DetectedFeatures {
+      canvas: boolean;
+      arraybuffer: boolean;
+      dataurl: boolean;
+      objecturl: boolean;
+      rgba: boolean;
+      webaudio: boolean;
+      webgl: boolean;
+      gamepadapi: boolean;
+   }
 
    /**
     * Excalibur internal feature detection helper class
     */
    export class Detector {
 
-      private _features: Object = null;
+      private _features: DetectedFeatures = null;
 
       public failedTests: string[] = [];
 
@@ -18,8 +43,6 @@ module ex {
        * Returns a map of currently supported browser features. This method
        * treats the features as a singleton and will only calculate feature
        * support if it has not previously been done.
-       * 
-       * @return {Object} the list of supported features
        */
       public getBrowserFeatures(): Object {
          if (this._features === null) {
@@ -31,16 +54,8 @@ module ex {
       /**
        * Report on non-critical browser support for debugging purposes.
        * Use native browser console colors for visibility.
-       * 
-       * @return {void}
        */
       public logBrowserFeatures(): void {
-         let features = {
-            webgl: 'WebGL',
-            webaudio: 'WebAudio',
-            gamepadapi: 'Gamepad API'
-         };
-
          let msg = '%cSUPPORTED BROWSER FEATURES\n==========================%c\n';
          let args = [
             'font-weight: bold; color: navy',
@@ -48,18 +63,18 @@ module ex {
          ];
 
          let supported = this.getBrowserFeatures();
-         for (let feature of Object.keys(features)) {
+         for (let feature of Object.keys(REPORTED_FEATURES)) {
             if (supported[feature]) {
-               msg += '(%c\u2713%c)';
+               msg += '(%c\u2713%c)'; // (✓)
                args.push('font-weight: bold; color: green');
                args.push('font-weight: normal; color: inherit');
             } else {
-               msg += '(%c\u2717%c)';
+               msg += '(%c\u2717%c)'; // (✗)
                args.push('font-weight: bold; color: red');
                args.push('font-weight: normal; color: inherit'); 
             };
 
-            msg += ' ' + features[feature] + '\n';
+            msg += ' ' + REPORTED_FEATURES[feature] + '\n';
          }         
 
          args.unshift(msg);
@@ -69,10 +84,8 @@ module ex {
       /**
        * Executes several IIFE's to get a constant reference to supported
        * features within the current execution context.
-       * 
-       * @return {Object} a map of features
        */
-      private _loadBrowserFeatures(): Object {
+      private _loadBrowserFeatures(): DetectedFeatures {
          return {
             // IIFE to check canvas support
             canvas: (() => {

--- a/src/engine/Util/Detector.ts
+++ b/src/engine/Util/Detector.ts
@@ -16,14 +16,14 @@ module ex {
     * Interface for detected browser features matrix
     */
    export interface IDetectedFeatures {
-      canvas: boolean;
-      arraybuffer: boolean;
-      dataurl: boolean;
-      objecturl: boolean;
-      rgba: boolean;
-      webaudio: boolean;
-      webgl: boolean;
-      gamepadapi: boolean;
+      readonly canvas: boolean;
+      readonly arraybuffer: boolean;
+      readonly dataurl: boolean;
+      readonly objecturl: boolean;
+      readonly rgba: boolean;
+      readonly webaudio: boolean;
+      readonly webgl: boolean;
+      readonly gamepadapi: boolean;
    }
 
    /**

--- a/src/engine/Util/Detector.ts
+++ b/src/engine/Util/Detector.ts
@@ -5,9 +5,117 @@ module ex {
     * Excalibur internal feature detection helper class
     */
    export class Detector {
-      
+
+      private _features: Object = null;
+
       public failedTests: string[] = [];
+
+      public constructor() {
+         this._features = this._loadBrowserFeatures();
+      }
+
+      /**
+       * Returns a map of currently supported browser features. This method
+       * treats the features as a singleton and will only calculate feature
+       * support if it has not previously been done.
+       * 
+       * @return {Object} the list of supported features
+       */
+      public getBrowserFeatures(): Object {
+         if (this._features === null) {
+            this._features = this._loadBrowserFeatures();
+         }
+         return this._features;
+      }
       
+      /**
+       * Report on non-critical browser support for debugging purposes.
+       * Use native browser console colors for visibility.
+       * 
+       * @return {void}
+       */
+      public logBrowserFeatures(): void {
+         let features = {
+            webgl: 'WebGL',
+            webaudio: 'WebAudio',
+            gamepadapi: 'Gamepad API'
+         };
+
+         let msg = '%cSUPPORTED BROWSER FEATURES\n==========================%c\n';
+         let args = [
+            'font-weight: bold; color: navy',
+            'font-weight: normal; color: inherit'
+         ];
+
+         let supported = this.getBrowserFeatures();
+         for (let feature of Object.keys(features)) {
+            if (supported[feature]) {
+               msg += '(%c\u2713%c)';
+               args.push('font-weight: bold; color: green');
+               args.push('font-weight: normal; color: inherit');
+            } else {
+               msg += '(%c\u2717%c)'
+               args.push('font-weight: bold; color: red');
+               args.push('font-weight: normal; color: inherit'); 
+            };
+
+            msg += ' ' + features[feature] + '\n';
+         }         
+
+         args.unshift(msg);
+         console.log.apply(console, args);
+      }
+
+      /**
+       * Executes several IIFE's to get a constant reference to supported
+       * features within the current execution context.
+       * 
+       * @return {Object} a map of features
+       */
+      private _loadBrowserFeatures(): Object {
+         return {
+            // IIFE to check canvas support
+            canvas: (() => {
+               return this._criticalTests.canvasSupport();
+            })(),
+
+            // IIFE to check arraybuffer support
+            arraybuffer: (() => {
+               return this._criticalTests.arrayBufferSupport();
+            })(),
+
+            // IIFE to check dataurl support
+            dataurl: (() => {
+               return this._criticalTests.dataUrlSupport();
+            })(),
+
+            // IIFE to check objecturl support
+            objecturl: (() => {
+               return this._criticalTests.objectUrlSupport();
+            })(),
+
+            // IIFE to check rgba support
+            rgba: (() => {
+               return this._criticalTests.rgbaSupport();
+            })(),
+
+            // IIFE to check webaudio support
+            webaudio: (() => {
+               return this._warningTest.webAudioSupport();
+            })(),
+
+            // IIFE to check webgl support
+            webgl: (() => {
+               return this._warningTest.webglSupport();
+            })(),
+
+            // IIFE to check gamepadapi support
+            gamepadapi: (() => {
+               return !!(<any>navigator).getGamepads;
+            })()
+         };
+      }
+
       // critical browser features required for ex to run
       private _criticalTests = {
          // Test canvas/2d context support
@@ -61,7 +169,7 @@ module ex {
             return !!(elem.getContext && elem.getContext('webgl'));
          }
       };
-      
+
       public test(): boolean {			
          // Critical test will for ex not to run
          var failedCritical = false;

--- a/src/engine/Util/Detector.ts
+++ b/src/engine/Util/Detector.ts
@@ -44,7 +44,7 @@ module ex {
        * treats the features as a singleton and will only calculate feature
        * support if it has not previously been done.
        */
-      public getBrowserFeatures(): Object {
+      public getBrowserFeatures(): IDetectedFeatures {
          if (this._features === null) {
             this._features = this._loadBrowserFeatures();
          }


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #707 

## Changes:

- Added singleton browser feature support matrix into Detector.ts
- Added debug step in Engine.ts to log feature support matrix
- Added a getter to access the current support matrix from consuming modules: `Detector.getBrowserFeatures()`

For future reference, any additional features that are desired to show up in this log statement need two things:
1.  Add the IIFE to assign support value in `Detector._loadBrowserFeatures()`
2.  Add the human readable label to the features map in `Detector.logBrowserFeatures()`

![image](https://cloud.githubusercontent.com/assets/155616/20976049/1a0d3774-bc56-11e6-96eb-c417a104adf0.png)

As it stands, if debugging is enabled, here is the output to the console:

![image](https://cloud.githubusercontent.com/assets/155616/20976089/497085fc-bc56-11e6-8846-f8d52d30c4ea.png)

Feedback encouraged!