### PR TITLE
[#684] Implement Obsolete Decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added extended feature detection and reporting to `ex.Detector` ([#707](https://github.com/excaliburjs/Excalibur/issues/707))
   - `ex.Detector.getBrowserFeatures()` to retrieve the support matrix of the current browser
   - `ex.Detector.logBrowserFeatures()` to log the support matrix to the console (runs at startup when in Debug mode)
+- Added @obsolete decorator to help give creater visibility to deprecated methods ([#684](https://github.com/excaliburjs/Excalibur/issues/684))
 
 ### Changed
 - Changed Util.clamp to use math libraries ([#536](https://github.com/excaliburjs/Excalibur/issues/536))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added extended feature detection and reporting to `ex.Detector` ([#707](https://github.com/excaliburjs/Excalibur/issues/707))
   - `ex.Detector.getBrowserFeatures()` to retrieve the support matrix of the current browser
   - `ex.Detector.logBrowserFeatures()` to log the support matrix to the console (runs at startup when in Debug mode)
-- Added @obsolete decorator to help give creater visibility to deprecated methods ([#684](https://github.com/excaliburjs/Excalibur/issues/684))
+- Added @obsolete decorator to help give greater visibility to deprecated methods ([#684](https://github.com/excaliburjs/Excalibur/issues/684))
 
 ### Changed
 - Changed Util.clamp to use math libraries ([#536](https://github.com/excaliburjs/Excalibur/issues/536))

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -75,7 +75,7 @@ module.exports = function (grunt) {
          // Execute TypeScript compiler against Excalibur core
          //
          tsc: {
-            command: '<%= tscCmd %> --declaration --sourceMap --target ES5 "./src/engine/Engine.ts" --out "./build/dist/<%= pkg.name %>.js"',               
+            command: '<%= tscCmd %> --declaration --sourceMap --target ES5 --experimentalDecorators "./src/engine/Engine.ts" --out "./build/dist/<%= pkg.name %>.js"',               
             options: {
                stdout: true,
                failOnError: true

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -100,7 +100,7 @@ module.exports = function (grunt) {
             command: function () {
             	var files = grunt.file.expand("./src/spec/*.ts");
 
-            	return '<%= tscCmd %> --target ES5 --allowJs --sourceMap ' + files.join(' ') + ' --out ./src/spec/TestsSpec.js'
+            	return '<%= tscCmd %> --target ES5 --experimentalDecorators --allowJs --sourceMap ' + files.join(' ') + ' --out ./src/spec/TestsSpec.js'
             },
             options: {
                stdout: true,

--- a/src/engine/Docs/Actions.md
+++ b/src/engine/Docs/Actions.md
@@ -31,7 +31,7 @@ class Enemy extends ex.Actor {
 
 ## Example: Follow a Path
 
-You can use [[Actor.actions.moveTo]] to move to a specific point,
+You can use [[ex.ActionContext.moveTo|Actor.actions.moveTo]] to move to a specific point,
 allowing you to chain together actions to form a path.
 
 This example has a `Ship` follow a path that it guards by

--- a/src/engine/Docs/Animations.md
+++ b/src/engine/Docs/Animations.md
@@ -28,6 +28,6 @@ game.start(loader).then(function () {
 
 ## Sprite effects
 
-You can add [[SpriteEffect|sprite effects]] to an animation through methods
+You can add [[ex.Effects|sprite effects]] to an animation through methods
 like [[Animation.invert]] or [[Animation.lighten]]. Keep in mind, since this
 manipulates the raw pixel values of a [[Sprite]], it can have a performance impact.

--- a/src/engine/Docs/Labels.md
+++ b/src/engine/Docs/Labels.md
@@ -38,7 +38,7 @@ helping in calculations.
 The HTML5 Canvas API draws text using CSS syntax. Because of this, web fonts
 are fully supported. To draw a web font, follow the same procedure you use
 for CSS. Then simply pass in the font string to the [[Label]] constructor
-or set [[Label.font]].
+or set [[Label.fontFamily]].
 
 **index.html**
 

--- a/src/engine/Docs/TileMaps.md
+++ b/src/engine/Docs/TileMaps.md
@@ -98,7 +98,7 @@ game.start();
 ```
 
 In a real game, you will want to ensure all the textures for the sprite sheets
-have been loaded. You could do this in the [[Resource.processDownload]] function
+have been loaded. You could do this in the [[Resource.processData]] function
 of the generic resource when loading your JSON, before creating your `Map` object.
 
 ## Off-screen culling

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -146,7 +146,7 @@ module ex {
 
       /**
        * Current FPS
-       * @obsolete Use [[stats.currFrame.fps]]. Will be deprecated in future versions.
+       * @obsolete Use [[ex.FrameStats.fps|ex.Engine.stats.fps]]. Will be deprecated in future versions.
        */
       @obsolete({alternateMethod: 'ex.Engine.stats.currFrame.fps'})
       public get fps(): number {
@@ -159,7 +159,7 @@ module ex {
       public debug = new Debug(this);
 
       /**
-       * Access [[debug.stats]] that holds frame statistics.
+       * Access [[stats]] that holds frame statistics.
        */
       public get stats() {
          return this.debug.stats;

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -22,6 +22,7 @@
 /// <reference path="Promises.ts" />
 /// <reference path="Util/Util.ts" />
 /// <reference path="Util/Detector.ts" />
+/// <reference path="Util/Decorators.ts" />
 /// <reference path="TileMap.ts" />
 /// <reference path="Label.ts" />
 /// <reference path="PostProcessing/IPostProcessor.ts"/>
@@ -147,6 +148,7 @@ module ex {
        * Current FPS
        * @obsolete Use [[stats.currFrame.fps]]. Will be deprecated in future versions.
        */
+      @obsolete({alternateMethod: 'ex.Engine.stats.currFrame.fps'})
       public get fps(): number {
          return this.stats.currFrame.fps;
       }

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1,5 +1,6 @@
 /// <reference path="MonkeyPatch.ts" />
 /// <reference path="Debug.ts" />
+/// <reference path="Util/Decorators.ts" />
 /// <reference path="Events.ts" />
 /// <reference path="EventDispatcher.ts" />
 /// <reference path="Class.ts" />
@@ -22,7 +23,6 @@
 /// <reference path="Promises.ts" />
 /// <reference path="Util/Util.ts" />
 /// <reference path="Util/Detector.ts" />
-/// <reference path="Util/Decorators.ts" />
 /// <reference path="TileMap.ts" />
 /// <reference path="Label.ts" />
 /// <reference path="PostProcessing/IPostProcessor.ts"/>

--- a/src/engine/Label.ts
+++ b/src/engine/Label.ts
@@ -107,7 +107,7 @@ module ex {
       public text: string;
 
       /**
-       * The [[SpriteFont]] to use, if any. Overrides [[font]] if present.
+       * The [[SpriteFont]] to use, if any. Overrides [[fontFamily]] if present.
        */
       public spriteFont: SpriteFont;
 

--- a/src/engine/Promises.ts
+++ b/src/engine/Promises.ts
@@ -44,8 +44,8 @@ module ex {
        * @param value  An optional value to wrap in a resolved promise
        * @obsolete Use [[resolve]] instead. This will be deprecated in future versions.
        */
+      @obsolete({alternateMethod: 'ex.Promise.resolve/reject'})
       public static wrap<T>(value?: T): Promise<T> {
-         ex.Logger.getInstance().warn('[obsolete] Promise.wrap is obsolete. Use Promise.resolve/reject instead.');
          return Promise.resolve(value);
       }
 

--- a/src/engine/Util/Decorators.ts
+++ b/src/engine/Util/Decorators.ts
@@ -1,6 +1,3 @@
-/// <reference path="Log.ts" />
-/// <reference path="Util.ts" />
-
 module ex {
    export interface IObsoleteOptions {
       message?: string;

--- a/src/engine/Util/Decorators.ts
+++ b/src/engine/Util/Decorators.ts
@@ -1,0 +1,27 @@
+/// <reference path="Log.ts" />
+/// <reference path="Util.ts" />
+
+module ex {
+   export interface IObsoleteOptions {
+      message?: string;
+      alternateMethod?: string;
+   } 
+
+   /**
+    * Obsolete decorator for marking Excalibur methods obsolete. Inspired by https://github.com/jayphelps/core-decorators.js
+    */
+   export function obsolete(options?: IObsoleteOptions) {
+
+      options = Util.extend({}, {message: 'This method will be removed in future versions of Excalibur.', alternateMethod: null}, options);
+
+      return function (target: any, property: string, descriptor: PropertyDescriptor) {
+
+         const methodSignature = `${target.constructor.name}.${property}`;
+
+         var message = `${methodSignature} is marked obsolete: ${options.message} \n\n` + 
+                        options.alternateMethod ? `Use ${options.alternateMethod} instead` : '';
+         ex.Logger.getInstance().warn(message);
+      };
+   }
+
+}

--- a/src/engine/Util/Decorators.ts
+++ b/src/engine/Util/Decorators.ts
@@ -18,6 +18,11 @@ module ex {
       options = Util.extend({}, {message: 'This method will be removed in future versions of Excalibur.', alternateMethod: null}, options);
 
       return function (target: any, property: string, descriptor: PropertyDescriptor): any {
+         if (!(typeof descriptor.value === 'function' || 
+               typeof descriptor.get   === 'function' ||
+               typeof descriptor.get   === 'function')) {
+            throw new SyntaxError('Only functions/getters/setters can be marked as obsolete');
+         }
          const methodSignature = `${target.name || ''}${target.name ? '.' : ''}${property}`;
 
          var message = `${methodSignature} is marked obsolete: ${options.message} ` + 

--- a/src/engine/Util/Decorators.ts
+++ b/src/engine/Util/Decorators.ts
@@ -20,13 +20,13 @@ module ex {
       return function (target: any, property: string, descriptor: PropertyDescriptor): any {
          if (!(typeof descriptor.value === 'function' || 
                typeof descriptor.get   === 'function' ||
-               typeof descriptor.get   === 'function')) {
+               typeof descriptor.set   === 'function')) {
             throw new SyntaxError('Only functions/getters/setters can be marked as obsolete');
          }
          const methodSignature = `${target.name || ''}${target.name ? '.' : ''}${property}`;
 
-         var message = `${methodSignature} is marked obsolete: ${options.message} ` + 
-                        (options.alternateMethod ? `Use ${options.alternateMethod} instead` : '');
+         var message = `${methodSignature} is marked obsolete: ${options.message}` + 
+                        (options.alternateMethod ? ` Use ${options.alternateMethod} instead` : '');
          
          let method = Util.extend({}, descriptor);
 

--- a/src/engine/tsconfig.json
+++ b/src/engine/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "out": "../dist/Excalibur.js", 
         "sourceMap": true, 
+        "experimentalDecorators": true,
         "target": "es5"
     }, 
     "files": [

--- a/src/spec/DecoratorSpec.ts
+++ b/src/spec/DecoratorSpec.ts
@@ -1,0 +1,77 @@
+/// <reference path="jasmine.d.ts" />
+/// <reference path="require.d.ts" />
+/// <reference path="Mocks.ts" />
+
+class TestObsolete {
+  private _stuff = 'things';
+   
+  @ex.obsolete()
+  method() {
+    return 'hello world';
+  }
+
+  @ex.obsolete()
+  get getter(): string {
+     return this._stuff;
+  } 
+
+  @ex.obsolete()
+  set setter(value: string) {
+     this._stuff = value;
+  }
+
+  @ex.obsolete({alternateMethod: 'altMethod'})
+  altmethod() {
+     return 'stuff';
+  }
+
+  @ex.obsolete({message: 'mymessage'})
+  customMessage() {
+     return 'stuff';
+  }
+
+}
+
+describe('An @obsolete decorator', () => {
+   var testObsolete: TestObsolete = null;
+   var logger = null;
+   beforeEach(() => {
+      testObsolete = new TestObsolete();
+      logger = ex.Logger.getInstance();
+      spyOn(logger, 'warn');
+   });
+   it('exists', () => {
+      expect(ex.obsolete).toBeDefined();
+   });
+
+   it('can be used on a function', () => {
+      var value = testObsolete.method();
+      expect(logger.warn).toHaveBeenCalled();
+      expect(value).toBe('hello world');
+   });
+
+   it('can be used on a getter', () => {
+      var value = testObsolete.getter;
+      expect(logger.warn).toHaveBeenCalled();
+      expect(value).toBe('things');
+   });
+
+   it('can be used on a setter', () => {
+      testObsolete.setter = 'stuff2';
+      expect(logger.warn).toHaveBeenCalled();
+      expect(testObsolete.getter).toBe('stuff2'); 
+   });
+
+   it('can have a custom message', () => {
+      var value = testObsolete.customMessage();
+      expect(logger.warn).toHaveBeenCalledWith('customMessage is marked obsolete: mymessage');
+      expect(value).toBe('stuff');
+   });
+
+   it('can specify an alternate method', () => {
+      var value = testObsolete.altmethod();
+      expect(logger.warn).toHaveBeenCalledWith('altmethod is marked obsolete: This method will be ' +
+      'removed in future versions of Excalibur. Use altMethod instead');
+      expect(value).toBe('stuff');
+   });
+});

--- a/src/spec/tsconfig.json
+++ b/src/spec/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "out": "../dist/Excalibur.js", 
+        "sourceMap": true, 
+        "experimentalDecorators": true,
+        "target": "es5"
+    }
+}

--- a/src/spec/tsconfig.json
+++ b/src/spec/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "out": "../dist/Excalibur.js", 
         "sourceMap": true, 
         "experimentalDecorators": true,
         "target": "es5"


### PR DESCRIPTION
Closes #684 

## Changes:

- Implement `@obsolete` decorator with the ability to pass a custom message and/or suggest a suitable alternative method
- Mark `exPromise.wrap` and `exEngine.fps` as `@obsolete`
- Update grunt build and tsconfig.json to include the `experimentalDecorators` flag

One thing to note, is that the decorator api **only works on functions/getters/setters** so if you want to make a particular property obsolete, you'll need to refactor it into getter/setter and decorate accordingly.

![image](https://cloud.githubusercontent.com/assets/612071/21076294/57fb2f98-beed-11e6-8757-23cbe7b8f592.png)

This is what shows up in the console when attempting to use a decorated method.

![image](https://cloud.githubusercontent.com/assets/612071/21076317/db29c3e8-beed-11e6-8e4a-a420d2d058fc.png)

