### PR TITLE
[#538] Implement a better seeded Random 

### DIFF
--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1,5 +1,6 @@
 /// <reference path="MonkeyPatch.ts" />
 /// <reference path="Debug.ts" />
+/// <reference path="Math/Random.ts" />
 /// <reference path="Util/Decorators.ts" />
 /// <reference path="Events.ts" />
 /// <reference path="EventDispatcher.ts" />

--- a/src/engine/Math/Random.ts
+++ b/src/engine/Math/Random.ts
@@ -135,10 +135,25 @@ module ex {
       }
 
       /**
+       * Returns a new array random picking elements from the original
+       * @param array Original array to pick from
+       * @param numPicks can be any positive number
+       * @param allowDuplicates indicates whether the returned set is allowed duplicates (it does not mean there will always be duplicates 
+       * just that it is possible)
+       */
+      public pickSet<T>(array: Array<T>, numPicks: number, allowDuplicates: boolean = false): Array<T> {
+         if (allowDuplicates) {
+            return this._pickSetWithDuplicates(array, numPicks);
+         } else {
+            return this._pickSetWithoutDuplicates(array, numPicks);
+         }
+      }
+
+      /**
        * Returns a new array randomly picking elements in the original (not reused)
        * @param numPicks must be less than or equal to the number of elements in the array.
        */
-      public pickSet<T>(array: Array<T>, numPicks: number): Array<T> {
+      private _pickSetWithoutDuplicates<T>(array: Array<T>, numPicks: number): Array<T> {
          if (numPicks > array.length || numPicks < 0) {
             throw new Error('Invalid number of elements to pick, must pick a value 0 < n <= length');
          }
@@ -162,7 +177,7 @@ module ex {
        * Returns a new array random picking elements from the original allowing duplicates
        * @param numPicks can be any positive number
        */
-      public pickSetWithDuplicates<T>(array: Array<T>, numPicks): Array<T> {
+      private _pickSetWithDuplicates<T>(array: Array<T>, numPicks): Array<T> {
          if (numPicks < 0) {
             throw new Error('Invalid number of elements to pick, must pick a value 0 <= n < MAX_INT');
          }

--- a/src/engine/Math/Random.ts
+++ b/src/engine/Math/Random.ts
@@ -159,6 +159,52 @@ module ex {
       }
 
       /**
+       * Returns a new array random picking elements from the original allowing duplicates
+       * @param numPicks can be any positive number
+       */
+      public pickSetWithDuplicates<T>(array: Array<T>, numPicks): Array<T> {
+         if (numPicks < 0) {
+            throw new Error('Invalid number of elements to pick, must pick a value 0 <= n < MAX_INT');
+         }
+         var result = new Array<T>(numPicks);
+         for (var i = 0; i < numPicks; i++) {
+            result.push(this.pickOne(array));
+         }
+         return result;
+      }
+
+      /**
+       * Returns a new array that has it's elements shuffled. Using the Fisher/Yates method
+       * https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+       */
+      public shuffle<T>(array: Array<T>): Array<T> {
+         var tempArray = array.slice(0);
+         var swap: T = null;
+         for (var i = 0; i < tempArray.length - 2; i++) {
+            var randomIndex = this.integer(i, tempArray.length - 1);
+            swap = tempArray[i];
+            tempArray[i] = tempArray[randomIndex];
+            tempArray[randomIndex] = swap;
+         }
+
+         return tempArray;
+      }
+
+      /**
+       * Generate a list of random integer numbers
+       * @param length the length of the final array
+       * @param min the minimum integer number to generate inclusive
+       * @param max the maximum integer number to generate inclusive
+       */
+      public range(length: number, min: number, max: number): Array<number> {
+         var result: Array<number> = new Array(length);
+         for (var i = 0; i < length; i++) {
+            result[i] = this.integer(min, max);
+         }
+         return result;
+      }
+
+      /**
        * Returns the result of a d4 dice roll
        */
       public d4() {

--- a/src/engine/Math/Random.ts
+++ b/src/engine/Math/Random.ts
@@ -1,0 +1,164 @@
+
+module ex {
+
+   const BITMASK32: number = 0xFFFFFFFF;
+   /**
+    * Pseudo-random number generator following the Mersenne_Twister algorithm. Given a seed this generator will produce the same sequence 
+    * of numbers each time it is called.
+    * See https://en.wikipedia.org/wiki/Mersenne_Twister for more details.
+    * Uses the MT19937-32 implementation
+    * 
+    * Api inspired by http://chancejs.com/# https://github.com/chancejs/chancejs
+    */
+   export class Random {
+      
+      private _lowerMask: number = 0x7FFFFFFF; // 31 bits same as _r
+      private _upperMask: number = 0x80000000; // 34 high bits
+
+      // Word size, 64 bits
+      private _w: number = 32;
+
+      // Degree of recurrance
+      private _n: number = 624;
+      
+      // Middle word, an offset used in the recurrance defining the series x, 1<=m<n
+      private _m: number = 397;
+      // Separation point of one one word, the number of bits in the lower bitmask 0 <= r <= w-1
+      private _r: number = 31;
+      // coefficients of teh rational normal form twist matrix
+      private _a: number = 0x9908B0DF;
+
+      // tempering bit shifts and masks
+      private _u: number = 11;
+      private _s: number = 7;
+      private _b: number = 0x9d2c5680;
+      private _t: number = 15;
+      private _c: number = 0xefc60000;
+      private _l: number = 18;
+      private _f: number = 1812433253;
+      
+      private _mt: number[];
+
+      private _index: number;
+
+      /**
+       * If no seed is specified, the Date.now() is used
+       */
+      constructor(public seed?: number) {
+         this._mt = new Array<number>(this._n);
+         this._mt[0] = (seed || Date.now()) & BITMASK32;
+
+         for (var i = 1; i < this._n; i++) {
+            this._mt[i] = (this._f * (this._mt[i - 1] ^ (this._mt[i - 1] >> (this._w - 2))) + i) & BITMASK32;
+         }
+         this._index = this._n;
+      }
+
+      /**
+       * Return next 32 bit integer number in sequence
+       */
+      public nextInt(): number {
+         if (this._index >= this._n) {
+            this._twist();            
+         }
+
+         var y = this._mt[this._index++];
+
+         y ^= y >>> this._u;
+         y ^= ((y << this._s) & this._b);
+         y ^= ((y << this._t) & this._c);
+         y ^= (y >>> this._l);
+ 
+         return y >>> 0;
+      }
+
+      /**
+       * Return a random floating point number between [0, 1)
+       */
+      public next(): number {
+         return this.nextInt() * (1.0 / 4294967296.0); // divided by 2^32
+      }
+
+      /**
+       * Return a random floating point in range [min, max) min is included, max is not included
+       */
+      public floating(min: number, max: number): number {
+         return (max - min) * this.next() + min;
+      }
+
+      /**
+       * Return a random integer in range [min, max] min is included, max is included
+       */
+      public integer(min: number, max: number): number {
+         return Math.floor((max - min + 1) * this.next() + min);
+      }
+
+      /**
+       * Returns true or false randomly with 50/50 odds by default. 
+       * By default the likelihood of returning a true is .5 (50%).
+       * @param likelihood takes values between [0, 1]
+       */
+      public bool(likelihood: number = .5): boolean {
+         return this.next() <= likelihood;
+      }
+
+      /**
+       * Returns the result of a d4 dice roll
+       */
+      public d4() {
+         return this.integer(1, 4);
+      }
+
+      /**
+       * Returns the result of a d6 dice roll
+       */
+      public d6() {
+         return this.integer(1, 6);
+      }
+
+      /**
+       * Returns the result of a d8 dice roll
+       */
+      public d8() {
+         return this.integer(1, 8);
+      }
+
+      /**
+       * Returns the result of a d10 dice roll
+       */
+      public d10() {
+         return this.integer(1, 10);
+      }
+
+      /**
+       * Returns the result of a d12 dice roll
+       */
+      public d12() {
+         return this.integer(1, 12);
+      }
+
+      /**
+       * Returns the result of a d20 dice roll
+       */
+      public d20() {
+         return this.integer(1, 20);
+      }
+
+
+      /**
+       * Apply the twist
+       */
+      private _twist(): void {
+         for (var i = 0; i < this._n; i++) {
+            let x = (this._mt[i] & this._upperMask) + (this._mt[(i + 1) % this._n] & this._lowerMask);
+            let xA = x >> 1;
+            if ( x & 0x1 ) {
+               xA ^= this._a;
+            }
+            this._mt[i] = this._mt[(i + this._m) % this._m] ^ xA;
+        }
+        this._index = 0;
+      }
+      
+   }
+}

--- a/src/spec/RandomSpec.ts
+++ b/src/spec/RandomSpec.ts
@@ -154,6 +154,78 @@ describe('A random number', () => {
       expect(random1.pickSet(array, 2).length).toBe(2);
    });
 
+   it('can pick a set of an array with dups', () => {
+      var array = ['one', 'two', 'three', 'four'];
+
+      var random1 = new ex.Random(10);
+      
+      var one = 0;
+      var two = 0;
+      var three = 0;
+      var four = 0;
+
+      var newSet = random1.pickSetWithDuplicates(array, 1000);
+
+      newSet.forEach((thing) => {
+         for (var i = 0; i < 1000; i++) {
+            switch (thing) {
+               case 'one':
+                  one++;
+                  break;
+               case 'two':
+                  two++;
+                  break;
+               case 'three':
+                  three++;
+                  break;
+               case 'four':
+                  four++;
+                  break;
+               default:
+                  throw Error('Invalid element!!!');
+            }
+         };
+      });
+      expect(one).toBeGreaterThan(0);
+      expect(two).toBeGreaterThan(0);
+      expect(three).toBeGreaterThan(0);
+      expect(four).toBeGreaterThan(0);
+
+      var ratio = (one / two) / (three / four);
+      expect(ratio).toBeCloseTo(1.0, .1, 'Should pick elements equally');
+
+   });
+
+   it('can shuffle arrays', () => {
+      var array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+
+      var random1 = new ex.Random(10);
+
+      var shuffled = random1.shuffle(array);
+
+      expect(array.length).toBe(shuffled.length);
+      // to be fair this won't necessarily be true all the time
+      // but for the seed it should be consistent
+      expect(array[0]).not.toBe(shuffled[0]);
+
+   });
+
+   it('can generate a random range', () => {
+      var random1 = new ex.Random(10);
+
+      var randomArray = random1.range(1000, 0, 4);
+
+      expect(randomArray.length).toBe(1000);
+
+      var expectedValue = (0 + 4) / 2;
+
+      var average = randomArray.reduce((acc, curr, i, arr) => {
+         return acc + curr;
+      }, 0) / 1000;
+
+      expect(average).toBeCloseTo(expectedValue, .01, 'Should pick elements equally');
+   });
+
    it('can do d4 dice rolls', () => {
       var d4min = 900;
       var d4max = -1;

--- a/src/spec/RandomSpec.ts
+++ b/src/spec/RandomSpec.ts
@@ -1,0 +1,91 @@
+// Random Tests 
+/// <reference path="jasmine.d.ts" />
+/// <reference path="require.d.ts" />
+/// <reference path="Mocks.ts" />
+
+
+describe('A random number', () => {
+   it('exists', () => {
+      expect(ex.Random).toBeDefined();
+   });
+
+   it('can be constructed', () => {
+      var random = new ex.Random();
+      expect(random).not.toBeNull();
+   });
+
+   it('can be seeded to produce the same sequence', () => {
+      var random1 = new ex.Random(10);
+      var random2 = new ex.Random(10);
+
+      expect(random1.seed).toBe(random2.seed);
+      for (var i = 0; i < 9000; i++) {
+         expect(random1.next()).toBe(random2.next());
+      }
+   });
+
+   xit('produces the correct first number for a specific seed', () => {
+      var random = new ex.Random(10);
+      expect(random.seed).toBe(10);
+      expect(random.nextInt()).toBe(3312796937);
+   });
+
+   it('can be seeded to produce the different sequences', () => {
+      var random1 = new ex.Random(10);
+      var random2 = new ex.Random(50);
+
+      expect(random1.seed).not.toBe(random2.seed);
+      for (var i = 0; i < 9000; i++) {
+         expect(random1.next()).not.toBe(random2.next());
+      }
+   });
+
+   it('can be seeded to produce numbers between [0, 1)', () => {
+      var random1 = new ex.Random(10);
+      for (var i = 0; i < 9000; i++) {
+         var r = random1.next(); 
+         var inrange = 0 <= r && r < 1.0;
+         expect(inrange).toBe(true, `Random ${r} not in range [0, 1). Seed [${random1.seed}] Iteration [${i}]`);
+      }
+   });
+
+   it('can be seeded to produce numbers in an arbitrary floating point range', () => {
+      var random1 = new ex.Random(10);
+      for (var i = 0; i < 9000; i++) {
+         var r = random1.floating(-88, 1900); 
+         var inrange = -88 <= r && r < 1900;
+         expect(inrange).toBe(true, `Random ${r} not in range [-88, 1900). Seed [${random1.seed}] Iteration [${i}]`);
+      }
+   });
+
+   it('can be seeded to produce numbers in an arbitrary integer range', () => {
+      var random1 = new ex.Random(10);
+      for (var i = 0; i < 9000; i++) {
+         var r = random1.integer(-10, 10); 
+         var inrange = -10 <= r && r <= 10;
+         expect(inrange).toBe(true, `Random ${r} not in range [-10, 10]. Seed [${random1.seed}] Iteration [${i}]`);
+      }
+   });
+
+   it('can do coin flips', () => {
+      var random1 = new ex.Random(10);
+      var truthCount = 0;
+      var falseCount = 0;
+
+      for (var i = 0; i < 9000; i++) {
+         var b = random1.bool(); 
+         if (b) {
+            truthCount++;
+         } else {
+            falseCount++;
+         }
+      }
+      var ratio = truthCount / falseCount;
+      expect(ratio).toBeCloseTo(1.0, .1, `Bool did not appear to be 50/50 Ratio true/false [${ratio}]`);
+   });
+
+   it('can do dice rolls', () => {
+      // pass      
+   });
+
+});

--- a/src/spec/RandomSpec.ts
+++ b/src/spec/RandomSpec.ts
@@ -24,11 +24,31 @@ describe('A random number', () => {
       }
    });
 
-   xit('produces the correct first number for a specific seed', () => {
-      var random = new ex.Random(10);
-      expect(random.seed).toBe(10);
-      expect(random.nextInt()).toBe(3312796937);
+   it('produces the correct first number for a specific seed according to original paper', () => {
+      // C implemenation output http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/MT2002/emt19937ar.html
+      var random = new ex.Random(19650218);
+      expect(random.seed).toBe(19650218);
+      expect(random.nextInt()).toBe(2325592414);
    });
+
+   it('produces the correct 1000th number for a specific seed according to original paper', () => {
+      var random = new ex.Random(19650218);
+
+      for (var i = 0; i < 999; i++) {
+         random.nextInt();
+      }
+      expect(random.nextInt()).toBe(1746987133);      
+   });
+
+   it('produces the correct 22000th number for a specific seed according to original paper', () => {
+      var random = new ex.Random(19650218);
+
+      for (var i = 0; i < 21999; i++) {
+         random.nextInt();
+      }
+      expect(random.nextInt()).toBe(3203887892);      
+   });
+   
 
    it('can be seeded to produce the different sequences', () => {
       var random1 = new ex.Random(10);
@@ -84,8 +104,144 @@ describe('A random number', () => {
       expect(ratio).toBeCloseTo(1.0, .1, `Bool did not appear to be 50/50 Ratio true/false [${ratio}]`);
    });
 
-   it('can do dice rolls', () => {
-      // pass      
+   it('can pick an element out of an array', () => {
+      var array = ['one', 'two', 'three', 'four'];
+
+      var random1 = new ex.Random(10);
+      
+      var one = 0;
+      var two = 0;
+      var three = 0;
+      var four = 0;
+
+      for (var i = 0; i < 1000; i++) {
+         let thing = random1.pickOne(array);
+         switch (thing) {
+            case 'one':
+               one++;
+               break;
+            case 'two':
+               two++;
+               break;
+            case 'three':
+               three++;
+               break;
+            case 'four':
+               four++;
+               break;
+            default:
+               throw Error('Invalid element!!!');
+         }
+      };
+
+      expect(one).toBeGreaterThan(0);
+      expect(two).toBeGreaterThan(0);
+      expect(three).toBeGreaterThan(0);
+      expect(four).toBeGreaterThan(0);
+
+      var ratio = (one / two) / (three / four);
+      expect(ratio).toBeCloseTo(1.0, .1, 'Should pick elements equally');
+
+   });
+
+   it('can pick a subset of an array', () => {
+      var random1 = new ex.Random(10);
+      var array = ['one', 'two', 'three', 'four'];
+
+      expect(() => random1.pickSet(array, 5)).toThrowError('Invalid number of elements to pick, must pick a value 0 < n <= length');
+      expect(() => random1.pickSet(array, -1)).toThrowError('Invalid number of elements to pick, must pick a value 0 < n <= length');
+      expect(random1.pickSet(array, 0).length).toBe(0);
+      expect(random1.pickSet(array, 2).length).toBe(2);
+   });
+
+   it('can do d4 dice rolls', () => {
+      var d4min = 900;
+      var d4max = -1;
+
+      var random1 = new ex.Random(10);
+      for (var i = 0; i < 2000; i++) {
+         let roll = random1.d4();
+         d4min = Math.min(roll, d4min);
+         d4max = Math.max(roll, d4max);
+      }
+
+      expect(d4min).toBeGreaterThan(0);
+      expect(d4max).toBeLessThan(5);
+   });
+
+   it('can do d6 dice rolls', () => {
+      var d6min = 900;
+      var d6max = -1;
+
+      var random1 = new ex.Random(10);
+      for (var i = 0; i < 2000; i++) {
+         let roll = random1.d6();
+         d6min = Math.min(roll, d6min);
+         d6max = Math.max(roll, d6max);
+      }
+
+      expect(d6min).toBeGreaterThan(0);
+      expect(d6max).toBeLessThan(7);
+   });
+
+   it('can do d8 dice rolls', () => {
+      var min = 900;
+      var max = -1;
+
+      var random1 = new ex.Random(10);
+      for (var i = 0; i < 2000; i++) {
+         let roll = random1.d8();
+         min = Math.min(roll, min);
+         max = Math.max(roll, max);
+      }
+
+      expect(min).toBeGreaterThan(0);
+      expect(max).toBeLessThan(9);
+   });
+
+   it('can do d10 dice rolls', () => {
+      var min = 900;
+      var max = -1;
+
+      var random1 = new ex.Random(10);
+      for (var i = 0; i < 2000; i++) {
+         let roll = random1.d10();
+         min = Math.min(roll, min);
+         max = Math.max(roll, max);
+      }
+
+      expect(min).toBeGreaterThan(0);
+      expect(max).toBeLessThan(11);
+   });
+
+   it('can do d12 dice rolls', () => {
+      var min = 900;
+      var max = -1;
+
+      var random1 = new ex.Random(10);
+      for (var i = 0; i < 2000; i++) {
+         let roll = random1.d12();
+         min = Math.min(roll, min);
+         max = Math.max(roll, max);
+      }
+
+      expect(min).toBeGreaterThan(0);
+      expect(max).toBeLessThan(13);
+   });
+
+    it('can do d20 dice rolls', () => {
+      var min = 900;
+      var max = -1;
+
+      var random1 = new ex.Random(10);
+      for (var i = 0; i < 2000; i++) {
+         let roll = random1.d20();
+         min = Math.min(roll, min);
+         max = Math.max(roll, max);
+      }
+
+      expect(min).toBeGreaterThan(0);
+      expect(max).toBeLessThan(21);
    });
 
 });

--- a/src/spec/RandomSpec.ts
+++ b/src/spec/RandomSpec.ts
@@ -164,7 +164,7 @@ describe('A random number', () => {
       var three = 0;
       var four = 0;
 
-      var newSet = random1.pickSetWithDuplicates(array, 1000);
+      var newSet = random1.pickSet(array, 1000, true);
 
       newSet.forEach((thing) => {
          for (var i = 0; i < 1000; i++) {


### PR DESCRIPTION
Closes #538 

## Changes:

- Implements a seeded random utility in Excalibur called `ex.Random` using the popular Mersenne-Twister algorithm documented [here](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/MT2002/emt19937ar.html) and [here](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html)
- Added new utilities for random
  * Random in range (`ex.Random.floating()`/`ex.Random.integer()`), 
  * Coin-tosses with variable outcomes `ex.Random.bool()`
  * Pick-one `ex.Random.pickOne(array)`
  * Pick-set `ex.Random.pickSet(array, numPicks)`
  * Dice roll helpers for d4, d6, d8, d10, d12, and d20
- Tests for the random features included

Additionally I have compared this implementation to the native C implementation done by the people who originally proposed the paper and it returns the same values for a seeded sequence as our implementation does. (downloaded and compiled locally using windows subsystem for linux).  

