### PR TITLE
[#726] Update to TypeScript 2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Changed Util.clamp to use math libraries ([#536](https://github.com/excaliburjs/Excalibur/issues/536))
+- Upgraded to TypeScript 2.1.4 ([#726](https://github.com/excaliburjs/Excalibur/issues/726))
 
 ### Deprecated
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1723,9 +1723,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.0.10",
-      "from": "typescript@latest",
-      "resolved": "./node_shrinkwrap/typescript-2.0.10.tar",
+      "version": "2.1.4",
+      "from": "typescript@2.1.4",
+      "resolved": "./node_shrinkwrap/typescript-2.1.4.tar",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "source-map-support": "^0.4.3",
     "travis-ci": "^2.1.0",
     "tslint": "^3.13.0",
-    "typescript": "^2.0.10"
+    "typescript": "^2.1.4"
   }
 }

--- a/src/engine/Drawing/Sprite.ts
+++ b/src/engine/Drawing/Sprite.ts
@@ -267,7 +267,7 @@ module ex {
          var xpoint = (scaledSWidth) * this.anchor.x;
          var ypoint = (scaledSHeight) * this.anchor.y;
 
-         ctx.strokeStyle = Color.Black;
+         ctx.strokeStyle = Color.Black.toString();
          ctx.strokeRect(-xpoint, -ypoint, scaledSWidth, scaledSHeight);
          ctx.restore();
       }


### PR DESCRIPTION
Closes #726

## Changes:

- Update to TS 2.1.4
- Fix bug in `Sprite.debugDraw`

## TODO

- [x] Update TypeDoc and verify compatibility/output (see TypeStrong/typedoc#365)
