### PR TITLE
[#584] Fix order of timer processing in Scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking Changes
 
 ### Added
+- Added `preupdate`, `postupdate`, `predraw`, `postdraw` events to TileMap
 - Added `ex.Random` with seed support via Mersenne Twister algorithm ([#538](https://github.com/excaliburjs/Excalibur/issues/538))
 - Added extended feature detection and reporting to `ex.Detector` ([#707](https://github.com/excaliburjs/Excalibur/issues/707))
   - `ex.Detector.getBrowserFeatures()` to retrieve the support matrix of the current browser
@@ -33,6 +34,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed Scene/Actor activation and initialization order, actors were not being initialized before scene activation causing bugs ([#661](https://github.com/excaliburjs/Excalibur/issues/661))
 - Fixed bug with Excalibur where it would not load if a loader was provided without any resources ([#565](https://github.com/excaliburjs/Excalibur/issues/565))
+- Fixed bug where an Actor/UIActor/TileMap added during a Timer callback would not initialize before running `draw` loop. ([#584](https://github.com/excaliburjs/Excalibur/issues/584))
 
 ## [0.8.0] 2016-12-04
 

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -271,10 +271,12 @@ newScene.on('activate', (evt?: ex.ActivateEvent) => {
    console.log('activate newScene');
 });
 
-newScene.on('deactivate', (evt?: ex.ActivateEvent) => {
+newScene.on('deactivate', (evt?: ex.DeactivateEvent) => {
    console.log('deactivate newScene');
 });
+newScene.on('foo', (ev: ex.GameEvent) => {
 
+});
 
 
 

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -92,7 +92,7 @@ export class Scene extends Class {
    public on(eventName: Events.predraw, handler: (event?: PreDrawEvent) => void);
    public on(eventName: Events.postdraw, handler: (event?: PostDrawEvent) => void);
    public on(eventName: Events.predebugdraw, handler: (event?: PreDebugDrawEvent) => void);
-   public on(eventName: Events.postdebugdraw, handler: (event?: PostDebugDrawEvent) => void);
+   public on(eventName: Events.postdebugdraw, handler: (event?: PostDebugDrawEvent) => void);   
    public on(eventName: string, handler: (event?: GameEvent) => void);
    public on(eventName: string, handler: (event?: GameEvent) => void) {
       super.on(eventName, handler);
@@ -173,6 +173,18 @@ export class Scene extends Class {
          this.camera.update(engine, delta);
       }
 
+      // Remove timers in the cancel queue before updating them
+      for (i = 0, len = this._cancelQueue.length; i < len; i++) {
+         this.removeTimer(this._cancelQueue[i]);
+      }
+      this._cancelQueue.length = 0;
+
+      // Cycle through timers updating timers
+      this._timers = this._timers.filter(timer => {
+         timer.update(delta);
+         return !timer.complete;
+      });
+
       // Cycle through actors updating UI actors
       for (i = 0, len = this.uiActors.length; i < len; i++) {
          this.uiActors[i].update(engine, delta);
@@ -223,19 +235,7 @@ export class Scene extends Class {
          }
       }
       engine.stats.currFrame.actors.killed = this._killQueue.length;
-      this._killQueue.length = 0;
-
-      // Remove timers in the cancel queue before updating them
-      for (i = 0, len = this._cancelQueue.length; i < len; i++) {
-         this.removeTimer(this._cancelQueue[i]);
-      }
-      this._cancelQueue.length = 0;
-
-      // Cycle through timers updating timers
-      this._timers = this._timers.filter(timer => {
-         timer.update(delta);
-         return !timer.complete;
-      });
+      this._killQueue.length = 0;      
 
       this.emit('postupdate', new PostUpdateEvent(engine, delta, this));
    }

--- a/src/spec/SceneSpec.ts
+++ b/src/spec/SceneSpec.ts
@@ -40,8 +40,8 @@ describe('A scene', () => {
       expect(scene.children.length).toBe(1);
    });
 
-   it('cannot have the same Timer added to it more than once', () => {
-      //TODO
+   xit('cannot have the same Timer added to it more than once', () => {
+      // TODO
    });
 
    it('cannot have the same TileMap added to it more than once', () => {
@@ -158,6 +158,91 @@ describe('A scene', () => {
       scene._initialize(engine);
 
       expect(initializeCount).toBe(1, 'Scenes can only be initialized once');
+   });
+
+   it('will update Actors that were added in a Timer callback', () => {
+      var updated = false;
+      var initialized = false;
+      var actor = new ex.Actor();
+      actor.on('initialize', () => {
+         initialized = true;
+      });
+      actor.on('postupdate', () => {
+         updated = true;
+
+         expect(initialized).toBe(true, 'Actor was not initialized before calling update');
+      });
+      actor.on('postdraw', () => {
+         expect(updated).toBe(true, 'Actor was not updated before calling draw');
+         expect(initialized).toBe(true, 'Actor was not initialized before calling draw');
+      });
+
+      // create Timer
+      var timer = new ex.Timer(() => {
+         scene.add(actor);
+      }, 10, false);
+
+      scene.add(timer);
+      scene.update(engine, 11);
+      scene.draw(engine.ctx, 11);
+
+      expect(scene.children.indexOf(actor)).toBeGreaterThan(-1, 'Actor was not added to scene');
+      expect(initialized).toBe(true, 'Actor was not initialized after timer callback');
+      expect(updated).toBe(true, 'Actor was not updated after timer callback');
+   });
+
+   it('will update UIActors that were added in a Timer callback', () => {
+      var updated = false;
+      var initialized = false;
+      var actor = new ex.UIActor();
+      actor.on('initialize', () => {
+         initialized = true;
+      });
+      actor.on('postupdate', () => {
+         updated = true;
+
+         expect(initialized).toBe(true, 'UIActor was not initialized before calling update');
+      });
+      actor.on('postdraw', () => {
+         expect(updated).toBe(true, 'UIActor was not updated before calling draw');
+         expect(initialized).toBe(true, 'UIActor was not initialized before calling draw');
+      });
+
+      // create Timer
+      var timer = new ex.Timer(() => {
+         scene.add(actor);
+      }, 10, false);
+
+      scene.add(timer);
+      scene.update(engine, 11);
+      scene.draw(engine.ctx, 11);
+
+      expect(scene.uiActors.indexOf(actor)).toBeGreaterThan(-1, 'UIActor was not added to scene');
+      expect(initialized).toBe(true, 'UIActor was not initialized after timer callback');
+      expect(updated).toBe(true, 'UIActor was not updated after timer callback');
+   });
+
+   it('will update TileMaps that were added in a Timer callback', () => {
+      var updated = false;
+      var tilemap = new ex.TileMap(0, 0, 1, 1, 1, 1);
+      tilemap.on('postupdate', () => {
+         updated = true;
+      });
+      tilemap.on('postdraw', () => {
+         expect(updated).toBe(true, 'TileMap was not updated before calling draw');
+      });
+
+      // create Timer
+      var timer = new ex.Timer(() => {
+         scene.add(tilemap);
+      }, 10, false);
+
+      scene.add(timer);
+      scene.update(engine, 11);
+      scene.draw(engine.ctx, 11);
+
+      expect(scene.tileMaps.indexOf(tilemap)).toBeGreaterThan(-1, 'TileMap was not added to scene');
+      expect(updated).toBe(true, 'TileMap was not updated after timer callback');
    });
 
 });


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #584

## Changes:

- Fixed order of processing of Timers in Scene to support processing Actors/UIActors/TileMaps added during callback
- Added `preupdate`, `postupdate`, `predraw`, and `postdraw` events to TileMap for testing
