### PR TITLE
[#750] Add Engine's Running Status Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.9.0] 2017-02-09
 
 ### Added
+- Added `Engine.isPaused` to retrieve the running status of Engine ([#750](https://github.com/excaliburjs/Excalibur/issues/750))
 - Added `preupdate`, `postupdate`, `predraw`, `postdraw` events to TileMap
 - Added `ex.Random` with seed support via Mersenne Twister algorithm ([#538](https://github.com/excaliburjs/Excalibur/issues/538))
 - Added extended feature detection and reporting to `ex.Detector` ([#707](https://github.com/excaliburjs/Excalibur/issues/707))

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -994,6 +994,13 @@ O|===|* >________________>\n\
    }
 
    /**
+    * Returns the Engine's Running status, Useful for checking whether engine is running or paused.
+    */
+   public isPaused(): boolean {
+      return !(this._hasStarted);
+   }
+
+   /**
     * Takes a screen shot of the current viewport and returns it as an
     * HTML Image Element.
     */

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -56,5 +56,22 @@ describe('The engine', () => {
 
       expect(fired).toBe(true);
    });
-
+   
+   it('should tell engine is running', () => {
+      var status = engine.isPaused();
+      expect(status).toBe(false);
+   });
+   
+   it('should tell engine is paused', () => {
+      engine.stop();
+      var status = engine.isPaused();
+      expect(status).toBe(true);
+   });
+   
+   it('should again tell engine is running', () => {
+      engine.start();
+      var status = engine.isPaused();
+      expect(status).toBe(false);
+   });
+   
 });


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #750 

## Changes:

- Added a function isPaused to check the running status of Engine into Engine.ts
