### PR TITLE
[#729] Added getWorldBounds method to Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### Fixed
 
+### Added
+- Added `Engine.getWorldBounds`
+- Added test for `Engine.getWorldBounds`
+
 ## [0.9.0] 2017-02-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 ### Added
-- Added `Engine.getWorldBounds`
-- Added test for `Engine.getWorldBounds`
+- Added `Engine.getWorldBounds`, this method provide the user with a quick way to get the top left corner and bottom right corner of the screen in a BoundingBox so the user does not have to caluclate it themselves. This resovles issue ([#729](https://github.com/excaliburjs/Excalibur/issues/729))
 
 ## [0.9.0] 2017-02-09
 

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -22,6 +22,7 @@ import * as Input from './Input/Index';
 import { obsolete } from './Util/Decorators';
 import * as Util from './Util/Util';
 import * as Events from './Events';
+import { BoundingBox } from './Collision/BoundingBox';
 
 /**
  * Enum representing the different display modes available to Excalibur
@@ -346,6 +347,20 @@ O|===|* >________________>\n\
       this.addScene('root', this.rootScene);
       this.goToScene('root');
    }
+
+   /**
+    * Returns a BoundingBox of the top left corner of the screen
+    * and the bottom right corner of the screen.
+    */
+   public getWorldBounds() {
+      var left = this.screenToWorldCoordinates(Vector.Zero).x;
+      var top = this.screenToWorldCoordinates(Vector.Zero).y;
+      var right = left + this.getDrawWidth();
+      var bottom = top + this.getDrawHeight();
+
+      return new BoundingBox(left, top, right, bottom);
+   }
+
 
    /**
     * Gets the current engine timescale factor (default is 1.0 which is 1:1 time)

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -73,5 +73,15 @@ describe('The engine', () => {
       var status = engine.isPaused();
       expect(status).toBe(false);
    });
+
+   it('should return screen dimensions', () => {
+      engine.start();
+      var left = engine.screenToWorldCoordinates(ex.Vector.Zero).x;
+      var top = engine.screenToWorldCoordinates(ex.Vector.Zero).y;
+      var right = left + engine.getDrawWidth();
+      var bottom = top + engine.getDrawHeight();
+      var localBoundingBox = new ex.BoundingBox(left, top, right, bottom);
+      expect(engine.getWorldBounds()).toEqual(localBoundingBox);
+   });
    
 });


### PR DESCRIPTION
Helper method getWorldBounds was added to the engine class.
It calculates the top left corner of the screen and the
bottom right corner of the screen and wraps them in a
BoundingBox. One test added to test this new method.

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #729

## Changes:

- Added getWorldBounds helper method to Engine class
- Added test for getWorldBounds
