### PR TITLE
Add pre and post draw events [#744]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### Fixed
 
+### Added
+- Added predraw and postdraw events to `Engine` class. These events happen when prior to and after a draw ([#744](https://github.com/excaliburjs/Excalibur/issues/744))
+
 ## [0.9.0] 2017-02-09
 
 ### Added

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -223,6 +223,8 @@ export class Engine extends Class {
    public on(eventName: Events.postupdate, handler: (event?: PostUpdateEvent) => void);
    public on(eventName: Events.preframe, handler: (event?: PreFrameEvent) => void);
    public on(eventName: Events.postframe, handler: (event?: PostFrameEvent) => void);
+   public on(eventName: Events.predraw, handler: (event?: PreDrawEvent) => void);
+   public on(eventName: Events.postdraw, handler: (event?: PostDrawEvent) => void);
    public on(eventName: string, handler: (event?: GameEvent) => void);
    public on(eventName: string, handler: (event?: GameEvent) => void) {
       super.on(eventName, handler);

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -56,6 +56,24 @@ describe('The engine', () => {
 
       expect(fired).toBe(true);
    });
+
+   it('should emit a predraw event', () => {
+      var fired = false;
+      engine.on('predraw', () => fired = true);
+
+      loop.advance(100);
+
+      expect(fired).toBe(true);
+   });
+
+   it ('should emit a postdraw event', () => {
+      var fired = false;
+      engine.on('postdraw', () => fired = true);
+
+      loop.advance(100);
+
+      expect(fired).toBe(true);
+   });
    
    it('should tell engine is running', () => {
       var status = engine.isPaused();


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #744

## Changes:

- Added predraw and postdraw events to Engine class