### PR TITLE
Correct method name in documentation

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -76,7 +76,7 @@ play. Actors are the primary way to draw things to the screen.
     // Create an actor with x position of 150px,
     // y position of 40px from the bottom of the screen,
     // width of 200px, height and a height of 20px
-    var paddle = new ex.Actor(150, game.getHeight() - 40, 200, 20);
+    var paddle = new ex.Actor(150, game.getDrawHeight() - 40, 200, 20);
 
     // Let's give it some color with one of the predefined
     // color constants
@@ -142,7 +142,7 @@ event.
 
         // If the ball collides with the right side
         // of the screen reverse the x velocity
-        if (this.pos.x + (this.getWidth() / 2) > game.getWidth()) {
+        if (this.pos.x + (this.getWidth() / 2) > game.getDrawWidth()) {
             this.vel.x *= -1;
         }
 
@@ -192,7 +192,7 @@ layout and add them to the current scene.
     var brickColor = [ex.Color.Violet, ex.Color.Orange, ex.Color.Yellow];
 
     // Individual brick width with padding factored in
-    var brickWidth = game.getWidth() / columns - padding - padding/columns; // px
+    var brickWidth = game.getDrawWidth() / columns - padding - padding/columns; // px
     var brickHeight = 30; // px
     var bricks = [];
     for (var j = 0; j < rows; j++) {


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #790 

## Changes:

- Corrected 3 instances of `game.getHeight()` or 'game.getWidth()` to `game.getDrawHeight()` or `game.getDrawWidth()` in the [Getting Started guide](http://docs.excaliburjs.com/en/latest/quickstart.html) per latest naming in v 0.10.0

##Note:
This change corrects files in github, but the old verbiage is still used on the [JS Fiddle site](http://jsfiddle.net/excaliburjs/6Ay9S/39/?utm_source=website&utm_medium=embed&utm_campaign=6Ay9S). I am unsure if it is desired to update the [code being fed to JS Fiddle](https://rawgit.com/excaliburjs/excalibur-dist/v0.7.1/dist/excalibur.js) to the latest version.
