### PR TITLE
Add window positioning as an Engine option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 ### Added
+- Added another DisplayMode option: `DisplayMode.Position`. When this is selected as the displayMode type, the user must specify a new `position` option
+- Added a new Interface `AbsolutePosition` which can described the `position` option. A `string` can also describe `position`
 ### Changed
 - Edge builds have more descriptive versions now containing build number and Git commit hash (e.g. `0.10.0-alpha.105#commit`) ([#777](https://github.com/excaliburjs/Excalibur/issues/777))
 ### Deprecated

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -18,6 +18,7 @@
       <li><a href="tests/input/pointer.html">Pointer Input</a></li>
       <li><a href="tests/input/gamepad.html">GamePad Input</a></li>
       <li><a href="tests/scene/lifecycle.html">Scene Lifecycle</a></li>
+      <li><a href="tests/scene/display-mode-position.html">DisplayMode Position</a></li>
       <li><a href="tests/zoom/zoom.html">Camera Zoom</a></li>
       <li><a href="tests/camera/lerp.html">Camera Lerp</a></li>
       <li><a href="tests/group/index.html">Groups</a></li>

--- a/sandbox/tests/scene/display-mode-position.css
+++ b/sandbox/tests/scene/display-mode-position.css
@@ -11,15 +11,11 @@ section{
   float: left;
   margin: 5px;
   border: 1px solid black;
-  z-index: 500;
 }
 
 .absolute-input{
-  z-index: 500;
   text-align: right;
 }
-
-
 
 button{
   position: relative;

--- a/sandbox/tests/scene/display-mode-position.css
+++ b/sandbox/tests/scene/display-mode-position.css
@@ -1,0 +1,27 @@
+section{
+  height: 100px;
+  position: absolute;
+  bottom: 0%;
+  right: 0%;
+  z-index: 500;
+}
+
+.btn{
+  height: 80%;
+  float: left;
+  margin: 5px;
+  border: 1px solid black;
+  z-index: 500;
+}
+
+.absolute-input{
+  z-index: 500;
+  text-align: right;
+}
+
+
+
+button{
+  position: relative;
+  top: 10px;
+}

--- a/sandbox/tests/scene/display-mode-position.html
+++ b/sandbox/tests/scene/display-mode-position.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Bloc Breaker</title>
+    <link rel="stylesheet" type="text/css" href="display-mode-position.css">
+  </head>
+  <body>
+    
+    <section class="buttons">
+      <div class ="btn top-left">Put game at top left</div>
+      <div class ="btn mid-right">Put game at middle right</div>
+      <div class ="btn mid-center">Put game at middle center</div>
+      <div class ="btn bottom-left">Put game at bottom left</div>
+      <div class ="btn top-right">Put game at top right</div>
+      <div class ="btn top-center">Put game at top center</div>
+    </section>
+    
+    <div class="absolute-input">
+      <p>You can set exactly where the game will be presented by giving absolute positioning in the boxes below</p>
+      <p> Use <strong>Strings</strong> like 4px and 50%</p>
+      <div>
+          Top: <input type="text" id="top" name="top">
+      </div>
+      <div>
+          Right: <input type="text" id="right" name="right">
+      </div>
+      <div>
+          Bottom: <input type="text" id="bottom" name="bottom">
+      </div>
+      <div>
+          Left: <input type="text" id="left" name="left">
+      </div>
+      <div class="button">
+        <button type="submit">Draw the game at these coordinates</button>
+      </div>
+    </div>
+    
+    
+    <script src="../../../build/dist/excalibur.min.js"></script>
+    <script src="display-mode-position.js"></script>
+  </body>
+</html>

--- a/sandbox/tests/scene/display-mode-position.html
+++ b/sandbox/tests/scene/display-mode-position.html
@@ -36,7 +36,7 @@
     </div>
     
     
-    <script src="../../../build/dist/excalibur.min.js"></script>
+    <script src="../../excalibur.js"></script>
     <script src="display-mode-position.js"></script>
   </body>
 </html>

--- a/sandbox/tests/scene/display-mode-position.ts
+++ b/sandbox/tests/scene/display-mode-position.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../build/dist/excalibur.d.ts' />
+/// <reference path='../../excalibur.d.ts' />
 
 document.querySelector(".top-left").addEventListener("click", function(){
   buildWorld("top left");

--- a/sandbox/tests/scene/display-mode-position.ts
+++ b/sandbox/tests/scene/display-mode-position.ts
@@ -1,0 +1,65 @@
+/// <reference path='../../../build/dist/excalibur.d.ts' />
+
+document.querySelector(".top-left").addEventListener("click", function(){
+  buildWorld("top left");
+})
+
+document.querySelector(".mid-right").addEventListener("click", function(){
+  buildWorld("middle right");
+})
+
+document.querySelector(".mid-center").addEventListener("click", function(){
+  buildWorld("middle center");
+})
+
+document.querySelector(".bottom-left").addEventListener("click", function(){
+  buildWorld("bottom left");
+})
+
+document.querySelector(".top-right").addEventListener("click", function(){
+  buildWorld("top right");
+})
+
+document.querySelector(".top-center").addEventListener("click", function(){
+  buildWorld("top center");
+})
+
+document.querySelector("button").addEventListener("click", function(){
+  
+  
+  buildWorld({top: (<HTMLInputElement>document.getElementById("top")).value, 
+   right: (<HTMLInputElement>document.getElementById("right")).value,
+   bottom: (<HTMLInputElement>document.getElementById("bottom")).value, 
+   left: (<HTMLInputElement>document.getElementById("left")).value});
+  
+})
+
+var buildWorld = function(position){
+  
+  var oldGame = document.querySelector("canvas");
+  if (oldGame){
+    oldGame.parentNode.removeChild(oldGame);
+  }
+  
+  var game = new ex.Engine({
+      height: 600,
+      width: 800,
+      displayMode: ex.DisplayMode.Position,
+      position: position
+  });
+  
+  var paddle = new ex.Actor(150, game.getDrawHeight() - 40, 200, 20);
+  paddle.color = ex.Color.Chartreuse;
+  
+  paddle.collisionType = ex.CollisionType.Fixed;
+  
+  game.add(paddle);
+  
+  game.input.pointers.primary.on('move', function (evt: PointerEvent) {
+      paddle.pos.x = evt.x;
+  });
+  
+  
+  
+  game.start();
+}

--- a/src/engine/Docs/Engine.md
+++ b/src/engine/Docs/Engine.md
@@ -102,6 +102,15 @@ If you use [[DisplayMode.Container]], the canvas will automatically resize to fi
 it's parent DOM element. This allows you maximum control over the game viewport, e.g. in case
 you want to provide HTML UI on top or as part of your game.
 
+You can use [[DisplayMode.Position]] to specify where the game window will be displayed on screen. if
+this DisplayMode is selected, then a [[position]] option _must_ be provided to the Engine constructor. 
+The [[position]] option can be a String or an [[IAbsolutePosition]]. The first word in a String _must_
+be the desired vertical alignment of the window. The second (optional) word is the desired horizontal
+alignment.
+
+Valid String examples: "top left", "top", "bottom", "middle", "middle center", "bottom right"
+Valid IAbsolutePosition examples: {top: 5, right: 10%}, {bottom: 49em, left: 10px}, {left: 10, bottom: 40}
+
 ## Extending the Engine
 
 For complex games, any entity that inherits [[Class]] can be extended to override built-in

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -50,6 +50,7 @@ export enum DisplayMode {
 /*
 * Interface describing the absolute CSS position of the game window. For use when DisplayMode.Position
 * is specified and when the user wants to define exact pixel spacing of the window.
+* When a number is given, the value is interpreted as pixels
 */
 export interface IAbsolutePosition {
   
@@ -105,7 +106,9 @@ export interface IEngineOptions {
    /*
    *Specify how the game window is to be positioned when the DisplayMode.Position is chosen. This option MUST be specified
    *if the DisplayMode is set as DisplayMode.Position. The position can be either a string or an AbsolutePosition. String must be in the
-   *format of css style background-position. 
+   *format of css style background-position. The vertical position must precede the horizontal position in Strings
+   *Valid String examples: "top left", "top", "bottom", "middle", "middle center", "bottom right"
+   *Valid IAbsolutePosition examples: {top: 5, right: 10%}, {bottom: 49em, left: 10px}, {left: 10, bottom: 40} 
    */
    
    position?: string | IAbsolutePosition;
@@ -802,10 +805,10 @@ O|===|* >________________>\n\
                 
                 switch (specifiedPosition[0]) {
                   case 'top':
-                    this.canvas.style.top = '1%';
+                    this.canvas.style.top = '0px';
                     break;
                   case 'bottom':
-                    this.canvas.style.bottom = '1%';
+                    this.canvas.style.bottom = '0px';
                     break;
                   case 'middle':
                     this.canvas.style.top = '50%';
@@ -820,10 +823,10 @@ O|===|* >________________>\n\
                   
                   switch (specifiedPosition[1]) {
                     case 'left':
-                      this.canvas.style.left = '1%';
+                      this.canvas.style.left = '0px';
                       break;
                     case 'right':
-                      this.canvas.style.right = '1%';
+                      this.canvas.style.right = '0px';
                       break;
                     case 'center':
                       this.canvas.style.left = '50%';

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -104,11 +104,11 @@ export interface IEngineOptions {
    suppressMinimumBrowserFeatureDetection?: boolean;
    
    /*
-   *Specify how the game window is to be positioned when the DisplayMode.Position is chosen. This option MUST be specified
-   *if the DisplayMode is set as DisplayMode.Position. The position can be either a string or an AbsolutePosition. String must be in the
-   *format of css style background-position. The vertical position must precede the horizontal position in Strings
-   *Valid String examples: "top left", "top", "bottom", "middle", "middle center", "bottom right"
-   *Valid IAbsolutePosition examples: {top: 5, right: 10%}, {bottom: 49em, left: 10px}, {left: 10, bottom: 40} 
+   * Specify how the game window is to be positioned when the DisplayMode.Position is chosen. This option MUST be specified
+   * if the DisplayMode is set as DisplayMode.Position. The position can be either a string or an AbsolutePosition. String must be in the
+   * format of css style background-position. The vertical position must precede the horizontal position in Strings
+   * Valid String examples: "top left", "top", "bottom", "middle", "middle center", "bottom right"
+   * Valid IAbsolutePosition examples: {top: 5, right: 10%}, {bottom: 49em, left: 10px}, {left: 10, bottom: 40} 
    */
    
    position?: string | IAbsolutePosition;

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -39,7 +39,25 @@ export enum DisplayMode {
    /** 
     * Show the game as a fixed size 
     */
-   Fixed
+   Fixed,
+   
+   /*
+   * Allow the game to be positioned with the position option
+   */
+   Position
+}
+
+/*
+* Interface describing the absolute CSS position of the game window. For use when DisplayMode.Position
+* is specified and when the user wants to define exact pixel spacing of the window.
+*/
+export interface AbsolutePosition{
+  
+  top?: number | string;
+  left?: number | string;
+  right?: number | string;
+  bottom?: number | string;
+  
 }
 
 /**
@@ -83,6 +101,14 @@ export interface IEngineOptions {
     * browsers or if there is a bug in excalibur preventing execution.
     */
    suppressMinimumBrowserFeatureDetection?: boolean;
+   
+   /*
+   *Specify how the game window is to be positioned when the DisplayMode.Position is chosen. This option MUST be specified
+   *if the DisplayMode is set as DisplayMode.Position. The position can be either a string or an AbsolutePosition. String must be in the
+   *format of css style background-position. 
+   */
+   
+   position?: string | AbsolutePosition;
 }
 
 /**
@@ -180,7 +206,11 @@ export class Engine extends Class {
     * Indicates the current [[DisplayMode]] of the engine.
     */
    public displayMode: DisplayMode = DisplayMode.FullScreen;
-
+   
+   /**
+    * Indicates the current position of the engine. Valid only when DisplayMode is DisplayMode.Position
+    */
+   public position: string | AbsolutePosition;
    /**
     * Indicates whether audio should be paused when the game is no longer visible.
     */
@@ -740,6 +770,10 @@ O|===|* >________________>\n\
     * Initializes the internal canvas, rendering context, displaymode, and native event listeners
     */
    private _initialize(options?: IEngineOptions) {
+      if (options.displayMode){
+        this.displayMode = options.displayMode;
+      }
+      
       if (this.displayMode === DisplayMode.FullScreen || this.displayMode === DisplayMode.Container) {
 
 
@@ -754,8 +788,72 @@ O|===|* >________________>\n\
             this._logger.info('parent.clientHeight ' + parent.clientHeight);
             this.setAntialiasing(this._isSmoothingEnabled);
          });
+      } else if(this.displayMode === DisplayMode.Position){
+          
+          if( !options.position ){
+            throw new Error("DisplayMode of Position was selected but no position option was given");
+          } else{
+              
+              this.canvas.style.display = 'block';
+              this.canvas.style.position = 'absolute';
+              
+              if (typeof options.position === 'string'){
+                var specifiedPosition = options.position.split(" ");
+                
+                switch (specifiedPosition[0]) {
+                  case "top":
+                    this.canvas.style.top = "1%";
+                    break;
+                  case "bottom":
+                    this.canvas.style.bottom = "1%";
+                    break;
+                  case "middle":
+                    this.canvas.style.top = '50%';
+                    var offsetY = this.getDrawHeight() / -2;
+                    this.canvas.style.marginTop = offsetY.toString();
+                    break;
+                  default:
+                    throw new Error("Invalid Position Given");                  
+                }
+                
+                if (specifiedPosition[1]){
+                  
+                  switch (specifiedPosition[1]){
+                    case "left":
+                      this.canvas.style.left = "1%";
+                      break;
+                    case "right":
+                      this.canvas.style.right = "1%";
+                      break;
+                    case "center":
+                      this.canvas.style.left = '50%';
+                      var offsetX = this.getDrawWidth() / -2;
+                      this.canvas.style.marginLeft = offsetX.toString();
+                      break;
+                    default:
+                      throw new Error("Invalid Position Given");
+                  }
+                }
+              } else {
+                  
+                  if (options.position.top){
+                    typeof options.position.top === 'number' ? this.canvas.style.top = options.position.top.toString() + "px" : this.canvas.style.top = options.position.top;
+                  }
+                  if (options.position.right){
+                    typeof options.position.right === 'number' ? this.canvas.style.right = options.position.right.toString() + "px" : this.canvas.style.right = options.position.right;
+                  }
+                  if (options.position.bottom){
+                    typeof options.position.bottom === 'number' ? this.canvas.style.bottom = options.position.bottom.toString() + "px" : this.canvas.style.bottom = options.position.bottom;
+                  }
+                  if (options.position.left){
+                    typeof options.position.left === 'number' ? this.canvas.style.left = options.position.left.toString() + "px" : this.canvas.style.left = options.position.left;
+                  }
+                  
+                  
+              }
+          }
       }
-
+       
       // initialize inputs
       this.input = {
          keyboard: new Input.Keyboard(this),

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -51,7 +51,7 @@ export enum DisplayMode {
 * Interface describing the absolute CSS position of the game window. For use when DisplayMode.Position
 * is specified and when the user wants to define exact pixel spacing of the window.
 */
-export interface AbsolutePosition{
+export interface IAbsolutePosition {
   
   top?: number | string;
   left?: number | string;
@@ -108,7 +108,7 @@ export interface IEngineOptions {
    *format of css style background-position. 
    */
    
-   position?: string | AbsolutePosition;
+   position?: string | IAbsolutePosition;
 }
 
 /**
@@ -210,7 +210,7 @@ export class Engine extends Class {
    /**
     * Indicates the current position of the engine. Valid only when DisplayMode is DisplayMode.Position
     */
-   public position: string | AbsolutePosition;
+   public position: string | IAbsolutePosition;
    /**
     * Indicates whether audio should be paused when the game is no longer visible.
     */
@@ -770,7 +770,7 @@ O|===|* >________________>\n\
     * Initializes the internal canvas, rendering context, displaymode, and native event listeners
     */
    private _initialize(options?: IEngineOptions) {
-      if (options.displayMode){
+      if (options.displayMode) {
         this.displayMode = options.displayMode;
       }
       
@@ -788,65 +788,73 @@ O|===|* >________________>\n\
             this._logger.info('parent.clientHeight ' + parent.clientHeight);
             this.setAntialiasing(this._isSmoothingEnabled);
          });
-      } else if(this.displayMode === DisplayMode.Position){
+      } else if (this.displayMode === DisplayMode.Position) {
           
-          if( !options.position ){
-            throw new Error("DisplayMode of Position was selected but no position option was given");
-          } else{
+          if ( !options.position ) {
+            throw new Error('DisplayMode of Position was selected but no position option was given');
+          } else {
               
               this.canvas.style.display = 'block';
               this.canvas.style.position = 'absolute';
               
-              if (typeof options.position === 'string'){
-                var specifiedPosition = options.position.split(" ");
+              if (typeof options.position === 'string') {
+                var specifiedPosition = options.position.split(' ');
                 
                 switch (specifiedPosition[0]) {
-                  case "top":
-                    this.canvas.style.top = "1%";
+                  case 'top':
+                    this.canvas.style.top = '1%';
                     break;
-                  case "bottom":
-                    this.canvas.style.bottom = "1%";
+                  case 'bottom':
+                    this.canvas.style.bottom = '1%';
                     break;
-                  case "middle":
+                  case 'middle':
                     this.canvas.style.top = '50%';
                     var offsetY = this.getDrawHeight() / -2;
                     this.canvas.style.marginTop = offsetY.toString();
                     break;
                   default:
-                    throw new Error("Invalid Position Given");                  
+                    throw new Error('Invalid Position Given');                  
                 }
                 
-                if (specifiedPosition[1]){
+                if (specifiedPosition[1]) {
                   
-                  switch (specifiedPosition[1]){
-                    case "left":
-                      this.canvas.style.left = "1%";
+                  switch (specifiedPosition[1]) {
+                    case 'left':
+                      this.canvas.style.left = '1%';
                       break;
-                    case "right":
-                      this.canvas.style.right = "1%";
+                    case 'right':
+                      this.canvas.style.right = '1%';
                       break;
-                    case "center":
+                    case 'center':
                       this.canvas.style.left = '50%';
                       var offsetX = this.getDrawWidth() / -2;
                       this.canvas.style.marginLeft = offsetX.toString();
                       break;
                     default:
-                      throw new Error("Invalid Position Given");
+                      throw new Error('Invalid Position Given');
                   }
                 }
               } else {
                   
-                  if (options.position.top){
-                    typeof options.position.top === 'number' ? this.canvas.style.top = options.position.top.toString() + "px" : this.canvas.style.top = options.position.top;
+                  if (options.position.top) {
+                    typeof options.position.top === 'number' ? 
+                    this.canvas.style.top = options.position.top.toString() + 'px' : 
+                    this.canvas.style.top = options.position.top;
                   }
-                  if (options.position.right){
-                    typeof options.position.right === 'number' ? this.canvas.style.right = options.position.right.toString() + "px" : this.canvas.style.right = options.position.right;
+                  if (options.position.right) {
+                    typeof options.position.right === 'number' ? 
+                    this.canvas.style.right = options.position.right.toString() + 'px' : 
+                    this.canvas.style.right = options.position.right;
                   }
-                  if (options.position.bottom){
-                    typeof options.position.bottom === 'number' ? this.canvas.style.bottom = options.position.bottom.toString() + "px" : this.canvas.style.bottom = options.position.bottom;
+                  if (options.position.bottom) {
+                    typeof options.position.bottom === 'number' ? 
+                    this.canvas.style.bottom = options.position.bottom.toString() + 'px' : 
+                    this.canvas.style.bottom = options.position.bottom;
                   }
-                  if (options.position.left){
-                    typeof options.position.left === 'number' ? this.canvas.style.left = options.position.left.toString() + "px" : this.canvas.style.left = options.position.left;
+                  if (options.position.left) {
+                    typeof options.position.left === 'number' ? 
+                    this.canvas.style.left = options.position.left.toString() + 'px' : 
+                    this.canvas.style.left = options.position.left;
                   }
                   
                   

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -107,7 +107,7 @@ describe('The engine', () => {
    });
    
    it('should accept strings to position the window', () => {
-     expect(engine.canvas.style.top).toEqual('1%');
+     expect(engine.canvas.style.top).toEqual('0px');
    });
    
    it('should accept AbsolutePosition Interfaces to position the window', () => {

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -102,23 +102,23 @@ describe('The engine', () => {
       expect(engine.getWorldBounds()).toEqual(localBoundingBox);
    });
    
-   it('should accept a displayMode of Position', () =>{
+   it('should accept a displayMode of Position', () => {
      expect(engine.displayMode).toEqual(ex.DisplayMode.Position);
    });
    
-   it('should accept strings to position the window', () =>{
-     expect(engine.canvas.style.top).toEqual("1%");
+   it('should accept strings to position the window', () => {
+     expect(engine.canvas.style.top).toEqual('1%');
    });
    
-   it('should accept AbsolutePosition Interfaces to position the window', () =>{
+   it('should accept AbsolutePosition Interfaces to position the window', () => {
      var game = new ex.Engine({
        height: 600,
        width: 800,
        displayMode: ex.DisplayMode.Position,
-       position: {top: 1, left: "5em"}
+       position: {top: 1, left: '5em'}
      });
      
-     expect(game.canvas.style.top).toEqual("1px");
+     expect(game.canvas.style.top).toEqual('1px');
    });
    
 });

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -102,4 +102,23 @@ describe('The engine', () => {
       expect(engine.getWorldBounds()).toEqual(localBoundingBox);
    });
    
+   it('should accept a displayMode of Position', () =>{
+     expect(engine.displayMode).toEqual(ex.DisplayMode.Position);
+   });
+   
+   it('should accept strings to position the window', () =>{
+     expect(engine.canvas.style.top).toEqual("1%");
+   });
+   
+   it('should accept AbsolutePosition Interfaces to position the window', () =>{
+     var game = new ex.Engine({
+       height: 600,
+       width: 800,
+       displayMode: ex.DisplayMode.Position,
+       position: {top: 1, left: "5em"}
+     });
+     
+     expect(game.canvas.style.top).toEqual("1px");
+   });
+   
 });

--- a/src/spec/TestUtils.ts
+++ b/src/spec/TestUtils.ts
@@ -10,7 +10,7 @@ module TestUtils {
          suppressConsoleBootMessage: true,
          suppressMinimumBrowserFeatureDetection: true,
          displayMode: ex.DisplayMode.Position,
-         position: "top"
+         position: 'top'
       }, options);
       var game = new ex.Engine(options);
 

--- a/src/spec/TestUtils.ts
+++ b/src/spec/TestUtils.ts
@@ -8,7 +8,9 @@ module TestUtils {
          width: 500,
          height: 500,
          suppressConsoleBootMessage: true,
-         suppressMinimumBrowserFeatureDetection: true
+         suppressMinimumBrowserFeatureDetection: true,
+         displayMode: ex.DisplayMode.Position,
+         position: "top"
       }, options);
       var game = new ex.Engine(options);
 


### PR DESCRIPTION
<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in CONTRIBUTING.md-->

Closes #781 

## Changes:

- Added another DisplayMode option: `DisplayMode.Position`. When this is selected as the displayMode type, the user must specify a new `position` option
- Added a new Interface `AbsolutePosition` which can describe the `position` option. A `string` can also describe `position`

##  Note
I've written some Jasmine tests for this issue, as well as made sure that this didn't break any tests. (there were 8 tests that were failing before I implemented my changes, looks like HTML property changing tests).

I've updated the docs in the repo, but it may be good to document on [the external docs site](https://excaliburjs.com/docs/api/v0.10.0/index.html). I'm happy to do that if need be!

Note also that I don't believe the Engine display mode was reliably being set before. There were references to `options.displayMode`, but `this.displayMode` was only set as a default. So, I've added lines 773-775 as you can see below.
