### PR TITLE
[#801] Add per-play sound volume option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 ### Added
+- Added optional volume argument to `Sound.play(volume?: number)`, which will play the Audio file
+at anywhere from mute (`volume` is 0.0) to full volume (`volume` is 1.0).
 ### Changed
 - Edge builds have more descriptive versions now containing build number and Git commit hash (e.g. `0.10.0-alpha.105#commit`) ([#777](https://github.com/excaliburjs/Excalibur/issues/777))
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking Changes
 ### Added
 - Added optional volume argument to `Sound.play(volume?: number)`, which will play the Audio file
-at anywhere from mute (`volume` is 0.0) to full volume (`volume` is 1.0).
+at anywhere from mute (`volume` is 0.0) to full volume (`volume` is 1.0). ([#801](https://github.com/excaliburjs/Excalibur/issues/801))
 - Added another DisplayMode option: `DisplayMode.Position`. When this is selected as the displayMode type, the user must specify a new `position` option
 - Added a new Interface `AbsolutePosition` which can described the `position` option. A `string` can also describe `position`
 

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -23,6 +23,7 @@
       <li><a href="tests/group/index.html">Groups</a></li>
       <li><a href="tests/audio/index.html">Audio</a></li>
       <li><a href="tests/audio/longsound.html">Audio: Long-running sound muting</a></li>
+      <li><a href="tests/audio/setvolume.html">Set volume with argument to play></a></li>
       <li><a href="tests/label/label.html">Label</a></li>
       <li><a href="tests/label/fonts.html">Label - Fonts</a></li>
       <li><a href="tests/collision/index.html">Collision</a></li>

--- a/sandbox/tests/audio/setvolume.html
+++ b/sandbox/tests/audio/setvolume.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Audio test</title>
+</head>
+    <body>
+        
+        <script src="../../excalibur.js"></script>
+        <script src="setvolume.js"></script>
+    </body>
+</html>

--- a/sandbox/tests/audio/setvolume.ts
+++ b/sandbox/tests/audio/setvolume.ts
@@ -19,7 +19,7 @@ button.on('pointerup', function () {
             button.color = ex.Color.Red;
         });
         
-        //change colume of the sound after 800 ms to show that
+        //change volume of the sound after 2000 ms to show that
         //initial setting worked
         setTimeout(function(){
           testSound.setVolume(1);

--- a/sandbox/tests/audio/setvolume.ts
+++ b/sandbox/tests/audio/setvolume.ts
@@ -1,0 +1,31 @@
+﻿/// <reference path='../../excalibur.d.ts' />
+
+ex.Logger.getInstance().defaultLevel = ex.LogLevel.Debug;
+//create game and load the sound file with custom loader
+var game = new ex.Engine();
+var loader = new ex.Loader();
+var testSound = new ex.Sound("loop.mp3");
+loader.addResource(testSound);
+
+//click a button to play the sound
+var button = new ex.Actor(100, 100, 100, 100, ex.Color.Red);
+button.enableCapturePointer = true;
+button.on('pointerup', function () {
+    button.color = ex.Color.Green;
+    
+    //button will turn red again when song is done
+    if (!testSound.isPlaying()) {
+        testSound.play(0.2).then(function () {
+            button.color = ex.Color.Red;
+        });
+        
+        //change colume of the sound after 800 ms to show that
+        //initial setting worked
+        setTimeout(function(){
+          testSound.setVolume(1);
+        }, 2000);
+    }
+});
+game.add(button);
+game.start(loader);
+//# sourceMappingURL=index.js.map

--- a/src/engine/Docs/Sounds.md
+++ b/src/engine/Docs/Sounds.md
@@ -1,7 +1,8 @@
 ## Pre-loading sounds
 
 Pass the [[Sound]] to a [[Loader]] to pre-load the asset. Once a [[Sound]]
-is loaded, you can [[Sound.play|play]] it.
+is loaded, you can [[Sound.play|play]] it. You can pass an argument from 0.0 - 1.0
+into [[Sound.play|play]] in order to play the sound at that volume.
 
 ```js
 // define multiple sources (such as mp3/wav/ogg) as a browser fallback

--- a/src/engine/Resources/Sound.ts
+++ b/src/engine/Resources/Sound.ts
@@ -295,7 +295,7 @@ export class Sound implements ILoadable, IAudio {
          var newTrack = this.sound.createInstance(this._data);
          newTrack.setLoop(this._loop);
          if (volume) {
-           newTrack.setVolume(Util.clamp(volume, 0, 1.0));
+           newTrack.setVolume(Util.clamp(volume, 0.0, 1.0));
          } else {
            newTrack.setVolume(this._volume);
          }

--- a/src/engine/Resources/Sound.ts
+++ b/src/engine/Resources/Sound.ts
@@ -270,8 +270,9 @@ export class Sound implements ILoadable, IAudio {
 
    /**
     * Play the sound, returns a promise that resolves when the sound is done playing
+    * An optional volume argument can be passed in to play the sound. Max volume is 1.0
     */
-   public play(): Promise<boolean> {
+   public play(volume?: number): Promise<boolean> {
       if (this._isLoaded) {
          var resumed = [];
 
@@ -293,7 +294,12 @@ export class Sound implements ILoadable, IAudio {
          // push a new track
          var newTrack = this.sound.createInstance(this._data);
          newTrack.setLoop(this._loop);
-         newTrack.setVolume(this._volume);
+         if (volume) {
+           newTrack.setVolume(Util.clamp(volume, 0, 1.0));
+         } else {
+           newTrack.setVolume(this._volume);
+         }
+         
 
          this._tracks.push(newTrack);
 

--- a/src/spec/SoundSpec.ts
+++ b/src/spec/SoundSpec.ts
@@ -144,6 +144,16 @@ describe('Sound resource', () => {
          
          expect(audioInstance.volume).toBe(0.5);
       });
+      
+      it('should set volume with argument sent to play', () => {
+         var audioInstance = new MockAudioInstance();
+         
+         spyOn(audioMock, 'createInstance').and.returnValue(audioInstance);
+
+         sut.play(0.5);
+         
+         expect(audioInstance.volume).toBe(0.5);
+      });
 
       it('should play once and then finish', (done) => {
          sut.play().then(() => {            


### PR DESCRIPTION

Closes #801 

## Changes:

- Added optional volume argument to `Sound.play(volume?: number)`, which will play the Audio file
+at anywhere from mute (`volume` is 0.0) to full volume (`volume` is 1.0).

