### PR TITLE
[#804] Audio profile first draft

### DIFF
--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -23,6 +23,7 @@
       <li><a href="tests/group/index.html">Groups</a></li>
       <li><a href="tests/audio/index.html">Audio</a></li>
       <li><a href="tests/audio/longsound.html">Audio: Long-running sound muting</a></li>
+      <li><a href="tests/audio/profile.html">Audio: Sound Volume Profile</a></li>
       <li><a href="tests/label/label.html">Label</a></li>
       <li><a href="tests/label/fonts.html">Label - Fonts</a></li>
       <li><a href="tests/collision/index.html">Collision</a></li>

--- a/sandbox/tests/audio/profile.html
+++ b/sandbox/tests/audio/profile.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Audio test</title>
+</head>
+    <body>
+        
+        <script src="../../Excalibur.js"></script>
+        <script src="profile.js"></script>
+    </body>
+</html>

--- a/sandbox/tests/audio/profile.ts
+++ b/sandbox/tests/audio/profile.ts
@@ -1,0 +1,19 @@
+﻿/// <reference path='../../excalibur.d.ts' />
+
+ex.Logger.getInstance().defaultLevel = ex.LogLevel.Debug;
+var game = new ex.Engine();
+var loader = new ex.Loader();
+var testSound = new ex.Sound("loop.mp3");
+loader.addResource(testSound);
+var button = new ex.Actor(100, 100, 100, 100, ex.Color.Red);
+button.enableCapturePointer = true;
+button.on('pointerup', function () {
+    button.color = ex.Color.Green;
+    if (!testSound.isPlaying()) {
+        testSound.play({point1: 1.0, point2: 0.6, point3: 0.3, point4: 0.0}).then(function () {
+            button.color = ex.Color.Red;
+        });
+    }
+});
+game.add(button);
+game.start(loader);

--- a/src/engine/Docs/Sounds.md
+++ b/src/engine/Docs/Sounds.md
@@ -1,7 +1,10 @@
 ## Pre-loading sounds
 
 Pass the [[Sound]] to a [[Loader]] to pre-load the asset. Once a [[Sound]]
-is loaded, you can [[Sound.play|play]] it.
+is loaded, you can [[Sound.play|play]] it. You can pass an argument from as either a string
+or a series of Bezier Points into [[Sound.play|play]] in order to play the sound with a custom volume profile.
+
+
 
 ```js
 // define multiple sources (such as mp3/wav/ogg) as a browser fallback

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -23,6 +23,7 @@ import { obsolete } from './Util/Decorators';
 import * as Util from './Util/Util';
 import * as Events from './Events';
 import { BoundingBox } from './Collision/BoundingBox';
+import { Sound } from './Resources/Sound';
 
 /**
  * Enum representing the different display modes available to Excalibur
@@ -124,6 +125,11 @@ export class Engine extends Class {
     * Access engine input like pointer, keyboard, or gamepad
     */
    public input: Input.IEngineInput;
+   
+   /**
+    * Access any sounds that have profiles for volume changes
+    */
+   public sounds: Sound[] = [];
 
 
    private _hasStarted: boolean = false;
@@ -397,6 +403,22 @@ O|===|* >________________>\n\
     */
    public playAnimation(animation: Animation, x: number, y: number) {
       this._animations.push(new AnimationNode(animation, x, y));
+   }
+   
+   /**
+    * Adds a [[Sound]] whose volume will be updated according to its profile
+    * when the engine updates
+    */
+   public addProfiledSound(sound: Sound) {
+      this.sounds.push(sound);
+   }
+   
+   /**
+    * Removes a [[Sound]] after it has finished playing
+    *
+    */
+   public deleteProfiledSound(sound: Sound) {
+      this.sounds.splice(this.sounds.indexOf(sound), 1);
    }
 
    /**
@@ -854,6 +876,13 @@ O|===|* >________________>\n\
       this.input.keyboard.update();
       this.input.pointers.update();
       this.input.gamepads.update();
+      
+      //update volume on profiled sounds
+      if (this.sounds.length > 0) {
+        this.sounds.forEach(function(sound){
+           sound.update();
+        });
+      }
 
       // Publish update event
       // TODO: Obsolete `update` event on Engine

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -878,10 +878,10 @@ O|===|* >________________>\n\
       this.input.gamepads.update();
       
       //update volume on profiled sounds
-      if (this.sounds.length > 0) {
-        this.sounds.forEach(function(sound){
+      if (this.sounds.length > 0 && this.stats.currFrame.id % 10 === 0 ) {
+        for (var sound of this.sounds){
            sound.update();
-        });
+        };
       }
 
       // Publish update event

--- a/src/engine/Interfaces/IAudio.ts
+++ b/src/engine/Interfaces/IAudio.ts
@@ -49,4 +49,29 @@ export interface IAudio {
     * Stop playing the sound and reset
     */
    stop(): void;
+   
+   
+   /**
+    * File of the HTMLAudioElement
+    */
+    audioElement?: HTMLAudioElement;
+    
+   /**
+    * File of the WebAudio Element
+    */
+   bufferSource?: AudioBufferSourceNode;
+   
+   buffer?: AudioBuffer;
+   /**
+    * System time when the audio file begins playing
+    */
+   absoluteStartTime?: number;
+   
+   /**
+    * Bezier points for adjusting volume through the engine
+    */
+   point1?: number;
+   point2?: number;
+   point3?: number;
+   point4?: number;
 }

--- a/src/engine/Interfaces/IAudio.ts
+++ b/src/engine/Interfaces/IAudio.ts
@@ -24,6 +24,11 @@ export interface IAudio {
     * Will play the sound or resume if paused
     */
    play(): Promise<any>;
+   
+   /**
+    * Will play the sound with a Bezier-type volume profile
+    */
+   playWithProfile(): Promise<any>;
 
    /**
     * Pause the sound

--- a/src/engine/Interfaces/IAudio.ts
+++ b/src/engine/Interfaces/IAudio.ts
@@ -36,7 +36,7 @@ export interface IAudio {
    play(): Promise<any>;
    
    /**
-    * Will play the sound with a Bezier-type volume profile
+    * Will play the sound with a cubic Bezier-type volume profile
     */
    playWithProfile(profile: string | IBezierPoints): Promise<any>;
 

--- a/src/engine/Interfaces/IAudio.ts
+++ b/src/engine/Interfaces/IAudio.ts
@@ -1,6 +1,16 @@
 import { Promise } from './../Promises';
 
 /**
+ * Defines the points which describe a cubic bezier curve for a sound profile
+ */
+export interface IBezierPoints {
+  point1: number;
+  point2: number;
+  point3: number;
+  point4: number;
+}
+
+/**
  * Represents an audio control implementation
  */
 export interface IAudio {
@@ -28,7 +38,7 @@ export interface IAudio {
    /**
     * Will play the sound with a Bezier-type volume profile
     */
-   playWithProfile(): Promise<any>;
+   playWithProfile(profile: string | IBezierPoints): Promise<any>;
 
    /**
     * Pause the sound

--- a/src/engine/Resources/Sound.ts
+++ b/src/engine/Resources/Sound.ts
@@ -276,6 +276,13 @@ export class Sound implements ILoadable, IAudio {
 
    /**
     * Play the sound, returns a promise that resolves when the sound is done playing
+    * Valid string inputs include:
+    * -'linearUp'
+    * -'linearDown'
+    * -'ease'
+    * -'ease-in'
+    * -'ease-out'
+    * -'ease-in-out'
     */
    public play(data?: string | number | IBezierPoints): Promise<boolean> {
       if (this._isLoaded) {

--- a/src/engine/Util/EasingFunctions.ts
+++ b/src/engine/Util/EasingFunctions.ts
@@ -6,6 +6,13 @@ export interface EasingFunction { // tslint:disable-line
 }
 
 /**
+ * A definition of the cubic Bezier curve. See [[EasingFunctions]].    
+ */
+export interface IBezierInput {
+   (currentTime: number, point1: number, point2: number, point3: number, point4: number): number;
+}
+
+/**
  * Standard easing functions for motion in Excalibur, defined on a domain of [0, duration] and a range from [+startValue,+endValue]
  * Given a time, the function will return a value from positive startValue to positive endValue.
  *
@@ -42,6 +49,11 @@ export interface EasingFunction { // tslint:disable-line
  * // acceleration until halfway, then deceleration 
  * function EaseInOutCubic (t) { 
  *    return t < .5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1; 
+ * }
+ *
+ * // the cubic bezier function, which draws a smooth curve according to the provided points
+ * function CubicBezier (t) {
+ *    return Math.pow(1-t, 3) * point1 + 3 * Math.pow(1-t, 2) * t * point2 + 3 * (1-t) * (t * t) * point3 + (t * t * t) * point4;
  * }
  * ```
  */
@@ -96,4 +108,8 @@ export class EasingFunctions {
       return endValue / 2 * (currentTime * currentTime * currentTime + 2) + startValue;
    };
    
+   public static CubicBezier: IBezierInput = (currentTime: number, point1: number, point2: number, point3: number, point4: number) => {
+      return Math.pow(1 - currentTime, 3) * point1 + 3 * Math.pow(1 - currentTime, 2) * currentTime * point2 + 
+             3 * (1 - currentTime) * (currentTime * currentTime) * point3 + (currentTime * currentTime * currentTime) * point4;
+   };
 }

--- a/src/spec/SoundSpec.ts
+++ b/src/spec/SoundSpec.ts
@@ -154,6 +154,16 @@ describe('Sound resource', () => {
 
          expect(sut.isPlaying()).toBe(true);
       });
+      
+      it('should change volume automatically with playWithProfile', (done) => {
+        var audioInstance = new MockAudioInstance();
+        
+        audioInstance.playWithProfile().then(() => {
+          expect(audioInstance.volume).toBe(0);
+          done();
+        });
+        
+      });
 
       it('should play more than once and should be playing until all are done', (done) => {
          var firstDone = false;
@@ -357,23 +367,13 @@ class MockAudioInstance implements ex.IAudio {
         this._startTime = new Date().getTime();
 
         this._playComplete = new ex.Promise<boolean>();
+        this.setVolume(0);
 
         this._playing = setTimeout(() => {
            this._isPlaying = false;
            this._playComplete.resolve(true);
         }, this._duration);
-
-     } else if (this._isPaused) {
-        this._isPlaying = true;
-        this._isPaused = false;
-        this._currentOffset = new Date().getTime() - this._startTime;
-
-        clearTimeout(this._playing);
-        this._playing = setTimeout(() => {
-           this._isPlaying = false;
-           this._playComplete.resolve(true);
-        }, this._duration - this._currentOffset);
-     }
+     } 
      return this._playComplete;
      
    }

--- a/src/spec/SoundSpec.ts
+++ b/src/spec/SoundSpec.ts
@@ -348,7 +348,36 @@ class MockAudioInstance implements ex.IAudio {
 
       return this._playComplete;
    }
+   
+   playWithProfile() {
+     
+     if (!this._isPlaying) {
+        this._isPlaying = true;
+        this._currentOffset = 0;
+        this._startTime = new Date().getTime();
 
+        this._playComplete = new ex.Promise<boolean>();
+
+        this._playing = setTimeout(() => {
+           this._isPlaying = false;
+           this._playComplete.resolve(true);
+        }, this._duration);
+
+     } else if (this._isPaused) {
+        this._isPlaying = true;
+        this._isPaused = false;
+        this._currentOffset = new Date().getTime() - this._startTime;
+
+        clearTimeout(this._playing);
+        this._playing = setTimeout(() => {
+           this._isPlaying = false;
+           this._playComplete.resolve(true);
+        }, this._duration - this._currentOffset);
+     }
+     return this._playComplete;
+     
+   }
+   
    pause() {
       this._isPlaying = false;
       clearTimeout(this._playing);


### PR DESCRIPTION
Begins to deal with #804 

##NOT A COMPLETE REQUEST
- I've made a shot at implementing the sound profiles. The build so far was just to test that I could control volume while the song was playing - no actual user input is configured yet, and I've only got it working for the loop audio file in the sandbox.

I've used the [cubic bezier curve equation](https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Cubic_B.C3.A9zier_curves) in lines 610-640 to change volume as the song is playing, based on 4 possible "points". (points usually require two components, but since there is no x and y with respect to volume - only time and volume - I've omitted the independent variable of time) 

Doing it this way seems really computation hungry - maybe it's best to only update the volume 4 or 5 times throughout the course of the sound? Of course this will kill a lot of the smoothness of volume transition.

Does the `playWithProfile` function idea work well in this context? It's a bit of a repeat of the `play` function, but it is doing a very different thing.

Please let me know your thoughts
