### PR TITLE
Changed pointer initialization to match same initialization as keyboard in order to make mocking for tests possible.

### DIFF
--- a/sandbox/tests/input/keyboard.html
+++ b/sandbox/tests/input/keyboard.html
@@ -16,7 +16,7 @@
 <body>
     <canvas id="game"></canvas>
    
-    <script src="../../Excalibur.js"></script>
+    <script src="../../excalibur.js"></script>
     <script src="keyboard.js"></script>
 </body>
 </html>

--- a/sandbox/tests/input/pointer.html
+++ b/sandbox/tests/input/pointer.html
@@ -29,7 +29,7 @@
         <dd id="pointer-world-pos"></dd>
     </dl>
 
-    <script src="../../Excalibur.js"></script>
+    <script src="../../excalibur.js"></script>
     <script src="pointer.js"></script>
 </body>
 </html>

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -872,7 +872,7 @@ O|===|* >________________>\n\
          gamepads: new Input.Gamepads(this)
       };
       this.input.keyboard.init();
-      this.input.pointers.init(options ? options.pointerScope : Input.PointerScope.Document);
+      this.input.pointers.init(options && options.pointerScope === Input.PointerScope.Document ? document : this.canvas);
       this.input.gamepads.init();
 
       // Issue #385 make use of the visibility api

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -101,7 +101,7 @@ export class Keyboard extends Class {
    /**
     * Initialize Keyboard event listeners
     */
-   init(global?: any): void {
+   init(global?: GlobalEventHandlers): void {
       global = global || window;
       global.addEventListener('blur', () => {
          this._keys.length = 0; // empties array efficiently

--- a/src/engine/Input/Pointer.ts
+++ b/src/engine/Input/Pointer.ts
@@ -121,8 +121,8 @@ export class Pointers extends Class {
    /**
     * Initializes pointer event listeners
     */
-   public init(target?: any): void {
-      target = target || <any>this._engine.canvas;
+   public init(target?: GlobalEventHandlers): void {
+      target = target || this._engine.canvas;
 
       // Touch Events
       target.addEventListener('touchstart', this._handleTouchEvent('down', this._pointerDown));

--- a/src/engine/Input/Pointer.ts
+++ b/src/engine/Input/Pointer.ts
@@ -121,13 +121,8 @@ export class Pointers extends Class {
    /**
     * Initializes pointer event listeners
     */
-   public init(scope: PointerScope = PointerScope.Document): void {
-      var target = <any>document;
-      if (scope === PointerScope.Document) {
-         target = document;
-      } else {
-         target = <any>this._engine.canvas;
-      }
+   public init(target?: any): void {
+      target = target || <any>this._engine.canvas;
 
       // Touch Events
       target.addEventListener('touchstart', this._handleTouchEvent('down', this._pointerDown));


### PR DESCRIPTION
I started to write tests for Pointer, but quickly realized that the init function for the Pointers class was not able to easily be mocked.

I changed it to match the same method that Keyboard uses, which is to pass in the "target" instead of an option to define what it is binding to.