### PR TITLE
[#566] Implement safe timer reset method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 ### Added
+ - Added `reset` to `ex.Timer` to reuse and change timer intervals safely. ([#566](https://github.com/excaliburjs/Excalibur/issues/))
 ### Changed
 ### Deprecated
 ### Fixed

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -180,10 +180,9 @@ export class Scene extends Class {
       this._cancelQueue.length = 0;
 
       // Cycle through timers updating timers
-      this._timers = this._timers.filter(timer => {
+      for (var timer of this._timers) {
          timer.update(delta);
-         return !timer.complete;
-      });
+      };
 
       // Cycle through actors updating UI actors
       for (i = 0, len = this.uiActors.length; i < len; i++) {
@@ -508,7 +507,7 @@ export class Scene extends Class {
     * Tests whether a [[Timer]] is active in the scene
     */
    public isTimerActive(timer: Timer): boolean {
-      return (this._timers.indexOf(timer) > -1);
+      return (this._timers.indexOf(timer) > -1 && !timer.complete);
    }
 
    /**

--- a/src/engine/Timer.ts
+++ b/src/engine/Timer.ts
@@ -34,7 +34,7 @@ export class Timer {
    public update(delta: number) {
       this._totalTimeAlive += delta;
       this._elapsedTime += delta;
-      if (this._elapsedTime > this.interval) {
+      if (!this.complete && this._elapsedTime > this.interval) {
          this.fcn.call(this);
          if (this.repeats) {
             this._elapsedTime = 0;
@@ -42,6 +42,19 @@ export class Timer {
             this.complete = true;
          }
       }
+   }
+
+   /**
+    * Resets the timer so that it can be reused, and optionally reconfigure the timers interval.
+    * @param newInterval If specified, sets a new non-negative interval in milliseconds to refire the callback
+    */
+   public reset(newInterval?: number) {
+      if (!!newInterval && newInterval >= 0) {
+         this.interval = newInterval;
+      }
+      this.complete = false;
+      this._elapsedTime = 0;
+      
    }
 
    public getTimeRunning(): number {

--- a/src/spec/TimerSpec.ts
+++ b/src/spec/TimerSpec.ts
@@ -61,7 +61,7 @@ describe('A Timer', () => {
       expect(count).toBe(3);
    });
 
-   it('is removed from the scene when it is completed', () => {
+   it('is no longer active in the scene when it is completed', () => {
       scene.addTimer(timer);
 
       expect(scene.isTimerActive(timer)).toBeTruthy();
@@ -95,6 +95,69 @@ describe('A Timer', () => {
       expect(count).toBe(3);
       expect(timer.repeats).toBeTruthy();
       expect(timer.complete).toBeFalsy();
+   });
+
+   it('can be reset at the same interval', () => {
+      var count = 0;
+      // non-repeating timer
+      timer = new ex.Timer(function(){ count++; }, 500, false);
+      scene.add(timer);
+
+      // tick the timer
+      scene.update(engine, 501);
+      expect(count).toBe(1);
+
+      // tick the timer again, but it shouldn't fire until reset
+      scene.update(engine, 501);
+      expect(count).toBe(1);
+      expect(timer.complete).toBe(true);
+
+      // once reset the timer should fire again
+      timer.reset();
+      expect(timer.complete).toBe(false);
+      scene.update(engine, 501);
+      expect(count).toBe(2);
+   });
+
+   it('can be reset at a different interval', () => {
+      var count = 0;
+      // non-repeating timer
+      timer = new ex.Timer(function(){ count++; }, 500, false);
+      scene.add(timer);
+
+      // tick the timer
+      scene.update(engine, 501);
+      expect(count).toBe(1);
+
+      // tick the timer again, but it shouldn't fire until reset
+      scene.update(engine, 501);
+      expect(count).toBe(1);
+      expect(timer.complete).toBe(true);
+
+      // once reset at a larger the timer should fire again
+      timer.reset(900);
+      expect(timer.complete).toBe(false);
+      scene.update(engine, 901);
+      expect(count).toBe(2);
+   });
+
+   it('can be reset on a repeating timer', () => {
+      var count = 0;
+      // non-repeating timer
+      timer = new ex.Timer(function(){ count++; }, 500, true);
+      scene.add(timer);
+
+      // tick the timer
+      scene.update(engine, 501);
+      expect(count).toBe(1);
+
+      timer.reset(30);
+
+      for (var i = 0; i < 100; i++) {
+         scene.update(engine, 31);
+         expect(count).toBe(2 + i);
+         expect(timer.complete).toBe(false);
+      }
    });
 
 });


### PR DESCRIPTION
One caveat to this PR is that reseting timers violated a previous assumption that timers were no longer needed after they fired once. But now that we can reset timers, we don't know if the user meant to be done permanently with a timer. This means that timers have the potential to hang around in the scene if not cleaned up over time with `.cancel()` 

Closes #566

## Changes:

- Implement `ex.Timer.reset` that allows for reuse of timers, reset also allows a safe way to change the interval of a timer
- Added unit tests checking both finite and repeating timers
