### PR TITLE
Skip font-based label tests

### DIFF
--- a/src/spec/LabelSpec.ts
+++ b/src/spec/LabelSpec.ts
@@ -48,7 +48,8 @@ describe('A label', () => {
       expect(label.color.toString()).toBe(ex.Color.Black.toString());
    });
 
-   it('can change color', (done) => {
+   //TODO resolve image diff discrepancies with fonts
+   xit('can change color', (done) => {
       label.text = 'some blue text';
       label.fontSize = 30;
       label.color = ex.Color.Blue.clone();
@@ -63,7 +64,8 @@ describe('A label', () => {
       imagediff.expectCanvasImageMatches(isLinux() ? 'LabelSpec/bluetext-linux.png' : 'LabelSpec/bluetext.png', engine.canvas, done);
    });
 
-   it('to enable italic fontStyle', (done) => {
+   //TODO resolve image diff discrepancies with fonts
+   xit('to enable italic fontStyle', (done) => {
       label.text = 'some italic text';
       label.fontSize = 30;
       label.color = ex.Color.Black;
@@ -73,7 +75,8 @@ describe('A label', () => {
       imagediff.expectCanvasImageMatches(isLinux() ? 'LabelSpec/italictext-linux.png' : 'LabelSpec/italictext.png', engine.canvas, done);
    });
 
-   it('to enable oblique fontStyle', (done) => {
+   //TODO resolve image diff discrepancies with fonts
+   xit('to enable oblique fontStyle', (done) => {
       label.text = 'some oblique text';
       label.fontSize = 30;
       label.color = ex.Color.Black;
@@ -84,7 +87,8 @@ describe('A label', () => {
       
    });
 
-   it('to enable normal fontStyle', (done) => {
+   //TODO resolve image diff discrepancies with fonts
+   xit('to enable normal fontStyle', (done) => {
       label.text = 'some normal text';
       label.fontFamily = 'Arial';
       label.fontSize = 30;
@@ -96,7 +100,8 @@ describe('A label', () => {
       imagediff.expectCanvasImageMatches(isLinux() ? 'LabelSpec/normaltext-linux.png' : 'LabelSpec/normaltext.png', engine.canvas, done);
    });
 
-   it('to enable bold text', (done) => {
+   //TODO resolve image diff discrepancies with fonts
+   xit('to enable bold text', (done) => {
       label.text = 'some bold text';
       label.fontFamily = 'Arial';
       label.fontSize = 30;
@@ -107,7 +112,8 @@ describe('A label', () => {
       imagediff.expectCanvasImageMatches(isLinux() ? 'LabelSpec/boldtext-linux.png' : 'LabelSpec/boldtext.png', engine.canvas, done);
    });
 
-   it('to enable right aligned text', (done) => {
+   //TODO resolve image diff discrepancies with fonts
+   xit('to enable right aligned text', (done) => {
       label.x = 200;
       label.text = 'some right aligned text';
       label.fontSize = 30;
@@ -118,7 +124,8 @@ describe('A label', () => {
       imagediff.expectCanvasImageMatches(isLinux() ? 'LabelSpec/righttext-linux.png' : 'LabelSpec/righttext.png', engine.canvas, done);
    });
 
-   it('to enable left aligned text', (done) => {
+   //TODO resolve image diff discrepancies with fonts
+   xit('to enable left aligned text', (done) => {
       label.x = 200;
       label.text = 'some left aligned text';
       label.fontSize = 30;
@@ -129,7 +136,8 @@ describe('A label', () => {
       imagediff.expectCanvasImageMatches(isLinux() ? 'LabelSpec/lefttext-linux.png' : 'LabelSpec/lefttext.png', engine.canvas, done);
    });
 
-   it('to enable center aligned text', (done) => {
+   //TODO resolve image diff discrepancies with fonts
+   xit('to enable center aligned text', (done) => {
       label.x = 200;
       label.text = 'some center aligned text';
       label.fontSize = 30;


### PR DESCRIPTION
There is a rendering discrepancy on a recent version of Windows that causes these tests to fail locally.

Note: This is a temporary skip of these tests to prevent confusion for new contributors when they run the tests locally. 

Related issues:  #833
