### PR TITLE
[#840] Implicitly clone a color when setting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Deprecated
 
 ### Fixed
+- Fixed same instance of color potentially being shared, and thus mutated, between instance actors ([#840](https://github.com/excaliburjs/Excalibur/issues/840))
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -367,7 +367,13 @@ export class Actor extends Class implements IActionable, IEvented {
     * 
     * The default is `null` which prevents a rectangle from being drawn.
     */
-   public color: Color;
+   public get color() : Color {
+      return this._color;
+   }
+   public set color(v : Color) {
+      this._color = v.clone();
+   }
+   private _color : Color;
 
    /**
     * Whether or not to enable the [[CapturePointer]] trait that propagates 
@@ -401,7 +407,7 @@ export class Actor extends Class implements IActionable, IEvented {
       this._width = width || 0;
       this._height = height || 0;
       if (color) {
-         this.color = color.clone();
+         this.color = color;
          // set default opacity of an actor to the color
          this.opacity = color.a;
       }

--- a/src/spec/ActionSpec.ts
+++ b/src/spec/ActionSpec.ts
@@ -64,6 +64,24 @@ describe('Action', () => {
       });   
    });
 
+   describe('color', () => {
+      it('is cloned from constructor', () => {
+         const color = ex.Color.Azure;
+         const sut = new ex.Actor(null, null, null, null, color);
+
+         expect(sut.color).not.toBe(color, 'Color is not expected to be same instance');
+      });
+
+      it('is cloned from property setter', () => {
+         const color = ex.Color.Azure;
+         const sut = new ex.Actor();
+
+         sut.color = color;
+
+         expect(sut.color).not.toBe(color, 'Color is not expected to be same instance');
+      });
+   });
+
    describe('die', () => {
       it('can remove actor from scene', () => {
          scene.add(actor);


### PR DESCRIPTION
Closes #840 

## Changes:

- Made `color` on `Actor` have a getter/setter, which implicitly clones the color value when set