### PR TITLE
[#612] Add position vector to PointerEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Deprecated
+- `PointerEvent.x` and `PointerEvent.y`, in favor of `PointerEvent.pos` ([#612](https://github.com/excaliburjs/Excalibur/issues/612))
 
 ### Fixed
 - Fixed same instance of color potentially being shared, and thus mutated, between instance actors ([#840](https://github.com/excaliburjs/Excalibur/issues/840))

--- a/src/engine/Input/Pointer.ts
+++ b/src/engine/Input/Pointer.ts
@@ -66,9 +66,11 @@ const ScrollWheelNormalizationFactor = -1 / 40;
  */
 export class PointerEvent extends GameEvent<any> {
 
+   public pos: Vector;
+
    /**
-    * @param x            The `x` coordinate of the event (in world coordinates)
-    * @param y            The `y` coordinate of the event (in world coordinates)
+    * @param x            OBSOLETE: This property will be removed in the 0.14.0 release. Please use the pos vector (pos.x). The `x` coordinate of the event (in world coordinates).
+    * @param y            OBSOLETE: This property will be removed in the 0.14.0 release. Please use the pos vector (pos.y). The `y` coordinate of the event (in world coordinates)
     * @param pageX        The `x` coordinate of the event (in document coordinates)
     * @param pageY        The `y` coordinate of the event (in document coordinates)
     * @param screenX      The `x` coordinate of the event (in screen coordinates)
@@ -77,6 +79,7 @@ export class PointerEvent extends GameEvent<any> {
     * @param pointerType  The type of pointer
     * @param button       The button pressed (if [[PointerType.Mouse]])
     * @param ev           The raw DOM event being handled
+    * @param pos          The position of the event (in world coordinates)
     */
    constructor(public x: number,
                public y: number,
@@ -89,6 +92,7 @@ export class PointerEvent extends GameEvent<any> {
                public button: PointerButton,
                public ev: any) {
       super();
+      this.pos = new Vector(x, y);
    }
 };
 

--- a/src/engine/Input/Pointer.ts
+++ b/src/engine/Input/Pointer.ts
@@ -69,8 +69,8 @@ export class PointerEvent extends GameEvent<any> {
    public pos: Vector;
 
    /**
-    * @param x            OBSOLETE: This property will be removed in the 0.14.0 release. Please use the pos vector (pos.x). The `x` coordinate of the event (in world coordinates).
-    * @param y            OBSOLETE: This property will be removed in the 0.14.0 release. Please use the pos vector (pos.y). The `y` coordinate of the event (in world coordinates)
+    * @param x OBSOLETE: Will be removed in the 0.14.0 release. Use pos.x. The `x` coordinate of the event (in world coordinates).
+    * @param y OBSOLETE: Will be removed in the 0.14.0 release. Use pos.y. The `y` coordinate of the event (in world coordinates).
     * @param pageX        The `x` coordinate of the event (in document coordinates)
     * @param pageY        The `y` coordinate of the event (in document coordinates)
     * @param screenX      The `x` coordinate of the event (in screen coordinates)

--- a/src/engine/Input/Pointer.ts
+++ b/src/engine/Input/Pointer.ts
@@ -66,8 +66,6 @@ const ScrollWheelNormalizationFactor = -1 / 40;
  */
 export class PointerEvent extends GameEvent<any> {
 
-   public pos: Vector;
-
    /**
     * @param x OBSOLETE: Will be removed in the 0.14.0 release. Use pos.x. The `x` coordinate of the event (in world coordinates).
     * @param y OBSOLETE: Will be removed in the 0.14.0 release. Use pos.y. The `y` coordinate of the event (in world coordinates).
@@ -79,7 +77,7 @@ export class PointerEvent extends GameEvent<any> {
     * @param pointerType  The type of pointer
     * @param button       The button pressed (if [[PointerType.Mouse]])
     * @param ev           The raw DOM event being handled
-    * @param pos          The position of the event (in world coordinates)
+    * @param pos          (Will be added to signature in 0.14.0 release) The position of the event (in world coordinates)
     */
    constructor(public x: number,
                public y: number,
@@ -92,7 +90,10 @@ export class PointerEvent extends GameEvent<any> {
                public button: PointerButton,
                public ev: any) {
       super();
-      this.pos = new Vector(x, y);
+   }
+
+   public get pos(): Vector {
+      return new Vector(this.x, this.y);
    }
 };
 


### PR DESCRIPTION
Closes #612 

## Changes:

- mark `x` and `y` parameters as obsolete
- add `pos` Vector that will replace `x` and `y`
