### PR TITLE
[#745] Implement `once` event listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - New pause/unpause feature for timers to help with more robust pausing ([#885](https://github.com/excaliburjs/Excalibur/issues/885))
+- New event listening feature to listen to events only `.once(...)` then unsubscribe automatically ([#745](https://github.com/excaliburjs/Excalibur/issues/745))
 
 ### Changed
 

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -490,6 +490,25 @@ export class Actor extends Class implements IActionable, IEvented {
       this.eventDispatcher.on(eventName, handler);
    }
 
+   public once(eventName: Events.kill, handler: (event?: KillEvent) => void): void;
+   public once(eventName: Events.initialize, handler: (event?: InitializeEvent) => void): void;
+   public once(eventName: Events.preupdate, handler: (event?: PreUpdateEvent) => void): void;
+   public once(eventName: Events.postupdate, handler: (event?: PostUpdateEvent) => void): void;
+   public once(eventName: Events.predraw, handler: (event?: PreDrawEvent) => void): void;
+   public once(eventName: Events.postdraw, handler: (event?: PostDrawEvent) => void): void;
+   public once(eventName: Events.predebugdraw, handler: (event?: PreDebugDrawEvent) => void): void;
+   public once(eventName: Events.postdebugdraw, handler: (event?: PostDebugDrawEvent) => void): void;
+   public once(eventName: Events.pointerup, handler: (event?: PointerEvent) => void): void;
+   public once(eventName: Events.pointerdown, handler: (event?: PointerEvent) => void): void;
+   public once(eventName: Events.pointermove, handler: (event?: PointerEvent) => void): void;
+   public once(eventName: Events.pointercancel, handler: (event?: PointerEvent) => void): void;
+   public once(eventName: Events.pointerwheel, handler: (event?: WheelEvent) => void): void;
+   public once(eventName: string, handler: (event?: GameEvent<any>) => void): void;
+   public once(eventName: string, handler: (event?: GameEvent<any>) => void): void {
+      this._checkForPointerOptIn(eventName);
+      this.eventDispatcher.once(eventName, handler);
+   }
+
    /**
     * If the current actor is a member of the scene, this will remove
     * it from the scene graph. It will no longer be drawn or updated.

--- a/src/engine/Class.ts
+++ b/src/engine/Class.ts
@@ -49,7 +49,7 @@ export class Class implements IEvented {
    }
 
    /**
-    * Once listens to an event once then auto unsubscribes from that event
+    * Once listens to an event one time, then unsubscribes from that event
     *
     * @param eventName The name of the event to subscribe to once
     * @param handler   The handler of the event that will be auto unsubscribed

--- a/src/engine/Class.ts
+++ b/src/engine/Class.ts
@@ -48,6 +48,16 @@ export class Class implements IEvented {
       this.eventDispatcher.emit(eventName, eventObject);
    }
 
+   /**
+    * Once listens to an event once then auto unsubscribes from that event
+    *
+    * @param eventName The name of the event to subscribe to once
+    * @param handler   The handler of the event that will be auto unsubscribed
+    */
+   public once(eventName: string, handler: (event?: GameEvent<any>) => void) {
+      this.eventDispatcher.once(eventName, handler);
+   }
+
 
    /**
     * You may wish to extend native Excalibur functionality in vanilla Javascript. 

--- a/src/engine/EventDispatcher.ts
+++ b/src/engine/EventDispatcher.ts
@@ -107,7 +107,7 @@ export class EventDispatcher implements IEvented {
    }
 
    /**
-    * Once listens to an event once then auto unsubscribes from that event
+    * Once listens to an event one time, then unsubscribes from that event
     *
     * @param eventName The name of the event to subscribe to once
     * @param handler   The handler of the event that will be auto unsubscribed

--- a/src/engine/EventDispatcher.ts
+++ b/src/engine/EventDispatcher.ts
@@ -107,6 +107,25 @@ export class EventDispatcher implements IEvented {
    }
 
    /**
+    * Once listens to an event once then auto unsubscribes from that event
+    *
+    * @param eventName The name of the event to subscribe to once
+    * @param handler   The handler of the event that will be auto unsubscribed
+    */
+   public once(eventName: string, handler: (event?: GameEvent<any>) => void) {
+
+      let metaHandler = (event?: GameEvent<any>) => {
+         let ev = event || new GameEvent();
+         ev.target = ev.target || this._target;
+
+         this.off(eventName, handler);
+         handler.call(ev.target, ev);
+      };
+
+      this.on(eventName, metaHandler);
+   }
+
+   /**
     * Wires this event dispatcher to also recieve events from another
     */
    public wire(eventDispatcher: EventDispatcher): void {

--- a/src/engine/Interfaces/IEvented.ts
+++ b/src/engine/Interfaces/IEvented.ts
@@ -26,4 +26,12 @@ export interface IEvented {
     *
     */
    off(eventName: string, handler: (event?: GameEvent<any>) => void): void;
+
+   /**
+    * Once listens to an event once then auto unsubscribes from that event
+    *
+    * @param eventName The name of the event to subscribe to once
+    * @param handler   The handler of the event that will be auto unsubscribed
+    */
+    once(eventName: string, handler: (event?: GameEvent<any>) => void): void;
 }

--- a/src/spec/EventSpec.ts
+++ b/src/spec/EventSpec.ts
@@ -91,4 +91,20 @@ describe('An Event Dispatcher', () => {
       expect(otherEvent).toBeFalsy();
    });
 
+   it('can listen to a handler only once', () => {
+      let pubsub = new ex.EventDispatcher(null);
+      
+      let callCount = 0;
+      pubsub.once('onlyonce', () => {
+         callCount++;
+      });
+
+      pubsub.emit('onlyonce');
+      pubsub.emit('onlyonce');
+      pubsub.emit('onlyonce');
+
+      expect(callCount).toBe(1, 'There should only be one call to the handler with once.');
+
+   });
+
 }); 


### PR DESCRIPTION
Closes #745

## Changes:

- Implements a new way to listen to events `.once(...)` and then unsubscribe
- Additional tests
