### PR TITLE
[#445] Implement camera strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Triggers can now draw like other Actors, but are still not visible by default ([#863](https://github.com/excaliburjs/Excalibur/issues/863))
 ## Deprecated
 - `Body.wasTouching` has been deprecated in favor of a new event type `CollisionEnd` ([#863](https://github.com/excaliburjs/Excalibur/issues/863))
-- `SideCamera` and `LockedCamera` have been deprecated in favor of camera strategies
+- `SideCamera` and `LockedCamera` are deprecated in favor of camera strategies
 
 ## Fixed
 - Fixed odd jumping behavior when polygons collided with the end of an edge ([#703](https://github.com/excaliburjs/Excalibur/issues/703))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,17 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Breaking Changes
 
 ## Added
+- New camera strategies implementation for following targets in a scene. Allows for custom strategies to be implemented on top of some prebuilt
+   - `LockCameraToActorStrategy` which behaves like `LockedCamera` and can be switched on with `Camera.strategy.lockToActor(actor)`.
+   - `LockCameraToActorAxisStrategy` which behaves like `SideCamera` and can be switched on with `Camera.strategy.lockToActorAxis(actor, ex.Axis.X)`
+   - `ElasticToActorStrategy` which is a new strategy that elastically moves the camera to an actor and can be switched on with `Camera.strategy.elasticToActor(actor, cameraElasticity, cameraFriction)`
+   - `CircleAroundActorStrategy` which is a new strategy that will follow an actor when a certain radius from the camera focus and can be switched on with `Camera.strategy.circleAroundActor(actor)`
 
 ## Changed
+- `BaseCamera` has been renamed to `Camera`
 
 ## Deprecated
+- `SideCamera` and `LockedCamera` have been deprecated in favor of camera strategies
 
 ## Fixed
 

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -22,6 +22,7 @@
       <li><a href="tests/zoom/zoom.html">Camera Zoom</a></li>
       <li><a href="tests/camera/lerp.html">Camera Lerp</a></li>
       <li><a href="tests/camera/zoom.html">Camera Zoom over time</a></li>
+      <li><a href="tests/camera/strategy.html">Camera Strategies</a></li>
       <li><a href="tests/group/index.html">Groups</a></li>
       <li><a href="tests/audio/index.html">Audio</a></li>
       <li><a href="tests/audio/longsound.html">Audio: Long-running sound muting</a></li>

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -477,7 +477,7 @@ game.input.keyboard.on('up', (evt?: ex.Input.KeyEvent) => {
 });
 
 // Add camera to game
-game.currentScene.camera.strategy.circleAroundActor(player, 100);// .lockToActorAxis(player, ex.Axis.Y); //.elasticToActor(player, .02, .23); // = camera;
+game.currentScene.camera.strategy.lockToActorAxis(player, ex.Axis.X);
 
 // Run the mainloop
 game.start(loader).then(() => {

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -392,8 +392,8 @@ game.on('p', () => {
 });
 
 // Create a camera to track the player
-var camera = new ex.LockedCamera();
-camera.setActorToFollow(player);
+var camera = game.currentScene.camera;// new ex.LockedCamera();
+//camera.setActorToFollow(player);
 // camera.shake(5, 5, 1000);
 // camera.zoom(0.5);
 // camera.zoom(1.5, 10000);
@@ -477,7 +477,7 @@ game.input.keyboard.on('up', (evt?: ex.Input.KeyEvent) => {
 });
 
 // Add camera to game
-game.currentScene.camera = camera;
+game.currentScene.camera.strategy.circleAroundActor(player, 100);// .lockToActorAxis(player, ex.Axis.Y); //.elasticToActor(player, .02, .23); // = camera;
 
 // Run the mainloop
 game.start(loader).then(() => {

--- a/sandbox/tests/camera/strategy.html
+++ b/sandbox/tests/camera/strategy.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Camera Strategy Test</title>
+    <style type="text/css">
+      #lerp-true { display: none; }
+      #lerp-true { color: green; }
+      #lerp-false { color: red; }
+    </style>
+</head>
+<body>
+    
+    <div>
+      <button id="lockToActor">Move camera locked to actor</button>
+      <button id="lockToActorAxisX">Move camera locked to actor X axis</button>
+      <button id="lockToActorAxisY">Move camera locked to actor Y axis</button>
+      <button id="elasticToActor">Move camera elastic to actor</button>
+      <button id="radiusAroundActor">Move camera within radius of actor</button>
+    </div>
+
+
+    <script src="../../Excalibur.js"></script>
+    <script src="strategy.js"></script>
+</body>
+</html>

--- a/sandbox/tests/camera/strategy.ts
+++ b/sandbox/tests/camera/strategy.ts
@@ -1,0 +1,45 @@
+/// <reference path='../../excalibur.d.ts' />
+
+var game = new ex.Engine({
+   width: 600,
+   height: 400,
+   pointerScope: ex.Input.PointerScope.Canvas
+});
+var actor = new ex.Actor(100, 100, 50, 50, ex.Color.Red);
+
+actor.actions.moveTo(300, 300, 100);
+actor.actions.moveTo(100, 100, 100);
+actor.actions.repeatForever();
+
+game.add(actor);
+
+var actor2 = new ex.Actor(80, 80, 10, 10, ex.Color.Black);
+var actor3 = new ex.Actor(320, 320, 10, 10, ex.Color.Black);
+game.add(actor2);
+game.add(actor3);
+
+game.start().then(() => {
+   
+});
+
+
+document.getElementById('lockToActor').addEventListener('click', () => {
+   game.currentScene.camera.clearAllStrategies();
+   game.currentScene.camera.strategy.lockToActor(actor);
+});
+document.getElementById('lockToActorAxisX').addEventListener('click', () => {
+   game.currentScene.camera.clearAllStrategies();
+   game.currentScene.camera.strategy.lockToActorAxis(actor, ex.Axis.X);
+});
+document.getElementById('lockToActorAxisY').addEventListener('click', () => {
+   game.currentScene.camera.clearAllStrategies();
+   game.currentScene.camera.strategy.lockToActorAxis(actor, ex.Axis.Y);
+});
+document.getElementById('elasticToActor').addEventListener('click', () => {
+   game.currentScene.camera.clearAllStrategies();
+   game.currentScene.camera.strategy.elasticToActor(actor, .05, .1);
+});
+document.getElementById('radiusAroundActor').addEventListener('click', () => {
+   game.currentScene.camera.clearAllStrategies();
+   game.currentScene.camera.strategy.radiusAroundActor(actor, 30);
+});

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -16,6 +16,10 @@ export interface ICameraStrategy<T> {
 
    /**
     * Camera strategies perform an action to calculate a new focus returned out of the strategy
+    * @param target The target object to apply this camera strategy (if any)
+    * @param camera The current camera implementation in excalibur running the game
+    * @param engine The current engine running the game
+    * @param delta The elapsed time in milliseconds since the last frame
     */
    action: (target: T, camera: BaseCamera, engine: Engine, delta: number) => Vector;
 }
@@ -46,7 +50,7 @@ export class StrategyContainer {
    }
 
    /**
-    * Creates and adds the [[ElasticAroundActorStrategy]] on the current camera
+    * Creates and adds the [[ElasticToActorStrategy]] on the current camera
     * If cameraElasticity < cameraFriction < 1.0, the behavior will be a dampened spring that will slowly end at the target without bouncing
     * If cameraFriction < cameraElasticity < 1.0, the behavior will be an oscillationg spring that will over 
     * correct and bounce around the target
@@ -60,12 +64,12 @@ export class StrategyContainer {
    }
 
    /**
-    * Creates and adds the [[CircleAroundTargetStrategy]] on the current camera
+    * Creates and adds the [[RadiusAroundActorStrategy]] on the current camera
     * @param target Target actor to follow when it is "radius" pixels away
     * @param radius Number of pixels away before the camera will follow
     */
-   public circleAroundActor(actor: Actor, radius: number) {
-      this.camera.addStrategy(new CircleAroundActorStrategy(actor, radius));
+   public radiusAroundActor(actor: Actor, radius: number) {
+      this.camera.addStrategy(new RadiusAroundActorStrategy(actor, radius));
    }
 }
 
@@ -145,7 +149,7 @@ export class ElasticToActorStrategy implements ICameraStrategy<Actor> {
    }
 }
 
-export class CircleAroundActorStrategy implements ICameraStrategy<Actor> {
+export class RadiusAroundActorStrategy implements ICameraStrategy<Actor> {
    /**
     * 
     * @param target Target actor to follow when it is "radius" pixels away

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -521,7 +521,7 @@ export class BaseCamera {
  * An extension of [[BaseCamera]] that is locked vertically; it will only move side to side.
  * 
  * Common usages: platformers.
- * @deprecated Will be removed in v0.15, please use `BaseCamera.strategy.lockToActorAxis`
+ * @deprecated OBSOLETE: Will be removed in v0.15, please use `BaseCamera.strategy.lockToActorAxis`
  */
 export class SideCamera extends BaseCamera {
    /**
@@ -547,7 +547,7 @@ export class SideCamera extends BaseCamera {
  * center of the screen.
  *
  * Common usages: RPGs, adventure games, top-down games.
- * @deprecated Will be removed in v0.15, please use `BaseCamera.strategy.lockToActor`
+ * @deprecated OBSOLETE: Will be removed in v0.15, please use `BaseCamera.strategy.lockToActor`
  */
 export class LockedCamera extends BaseCamera {
    /**

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -3,6 +3,168 @@ import { EasingFunction, EasingFunctions } from './Util/EasingFunctions';
 import { IPromise, Promise, PromiseState } from './Promises';
 import { Vector } from './Algebra';
 import { Actor } from './Actor';
+import { removeItemFromArray } from './Util/Util';
+
+/**
+ * Interface that describes a custom camera strategy for tracking targets
+ */
+export interface ICameraStrategy<T> {
+   /**
+    * Target of the camera strategy that will be passed to the action
+    */
+   target: T;
+
+   /**
+    * Camera strategies perform an action to calculate a new focus returned out of the strategy
+    */
+   action: (target: T, camera: BaseCamera, engine: Engine, delta: number) => Vector;
+}
+
+
+/**
+ * Container to house convenience strategy methods
+ * @internal
+ */
+export class StrategyContainer {
+   constructor(public camera: BaseCamera) {}
+   
+   /**
+    * Creates and adds the [[LockCameraToActorStrategy]] on the current camera.
+    * @param actor The actor to lock the camera to
+    */
+   public lockToActor(actor: Actor) {
+      this.camera.addStrategy(new LockCameraToActorStrategy(actor));
+   }
+
+   /**
+    * Creates and adds the [[LockCameraToActorAxisStrategy]] on the current camera
+    * @param actor The actor to lock the camera to
+    * @param axis The axis to follow the actor on
+    */
+   public lockToActorAxis(actor: Actor, axis: Axis) {
+      this.camera.addStrategy(new LockCameraToActorAxisStrategy(actor, axis));
+   }
+
+   /**
+    * Creates and adds the [[ElasticAroundActorStrategy]] on the current camera
+    * If cameraElasticity < cameraFriction < 1.0, the behavior will be a dampened spring that will slowly end at the target without bouncing
+    * If cameraFriction < cameraElasticity < 1.0, the behavior will be an oscillationg spring that will over 
+    * correct and bounce around the target
+    * 
+    * @param target Target actor to elastically follow
+    * @param cameraElasticity [0 - 1.0] The higher the elasticity the more force that will drive the camera towards the target
+    * @param cameraFriction [0 - 1.0] The higher the friction the more that the camera will resist motion towards the target
+    */
+   public elasticToActor(actor: Actor, cameraElasticity: number, cameraFriction: number) {
+      this.camera.addStrategy(new ElasticToActorStrategy(actor, cameraElasticity, cameraFriction));
+   }
+
+   /**
+    * Creates and adds the [[CircleAroundTargetStrategy]] on the current camera
+    * @param target Target actor to follow when it is "radius" pixels away
+    * @param radius Number of pixels away before the camera will follow
+    */
+   public circleAroundActor(actor: Actor, radius: number) {
+      this.camera.addStrategy(new CircleAroundActorStrategy(actor, radius));
+   }
+}
+
+
+/**
+ * Camera axis enum
+ */
+export enum Axis {
+   X,
+   Y
+}
+
+/**
+ * Lock a camera to the exact x/y postition of an actor.
+ */
+export class LockCameraToActorStrategy implements ICameraStrategy<Actor> {
+   constructor(public target: Actor) {}
+   public action = (target: Actor, _cam: BaseCamera, _eng: Engine, _delta: number) => {
+      let center = target.getCenter();
+      return center;
+   }
+}
+
+/**
+ * Lock a camera to a specific axis around an actor.
+ */
+export class LockCameraToActorAxisStrategy implements ICameraStrategy<Actor> {
+   constructor(public target: Actor, public axis: Axis) {}
+   public action = (target: Actor, cam: BaseCamera, _eng: Engine, _delta: number) => {
+      let center = target.getCenter();
+      let currentFocus = cam.getFocus();
+      if (this.axis === Axis.X) {
+         return new Vector(center.x, currentFocus.y);
+      } else {
+         return new Vector(currentFocus.x, center.y);
+      }
+   }
+}
+
+
+
+/**
+ * Using [Hook's law](https://en.wikipedia.org/wiki/Hooke's_law), elastically move the camera towards the target actor.
+ */
+export class ElasticToActorStrategy implements ICameraStrategy<Actor> {
+   /**
+    * If cameraElasticity < cameraFriction < 1.0, the behavior will be a dampened spring that will slowly end at the target without bouncing
+    * If cameraFriction < cameraElasticity < 1.0, the behavior will be an oscillationg spring that will over 
+    * correct and bounce around the target
+    * 
+    * @param target Target actor to elastically follow
+    * @param cameraElasticity [0 - 1.0] The higher the elasticity the more force that will drive the camera towards the target
+    * @param cameraFriction [0 - 1.0] The higher the friction the more that the camera will resist motion towards the target
+    */
+   constructor(public target: Actor, public cameraElasticity: number, public cameraFriction: number) {}
+   public action = (target: Actor, cam: BaseCamera, _eng: Engine, _delta: number) => {
+      let position = target.getCenter();
+      let focus = cam.getFocus();
+      let cameraVel = new Vector(cam.dx, cam.dy);
+
+      // Calculate the strech vector, using the spring equation
+      // F = kX
+      // https://en.wikipedia.org/wiki/Hooke's_law
+      // Apply to the current camera velocity
+      var stretch = position.sub(focus).scale(this.cameraElasticity); // stretch is X
+      cameraVel = cameraVel.add(stretch);
+      
+      // Calculate the friction (-1 to apply a force in the opposition of motion)
+      // Apply to the current camera velocity
+      var friction = cameraVel.scale(-1).scale(this.cameraFriction);
+      cameraVel = cameraVel.add(friction);
+      
+      // Update position by velocity deltas
+      focus = focus.add(cameraVel);
+
+      return focus;
+   }
+}
+
+export class CircleAroundActorStrategy implements ICameraStrategy<Actor> {
+   /**
+    * 
+    * @param target Target actor to follow when it is "radius" pixels away
+    * @param radius Number of pixels away before the camera will follow
+    */
+   constructor(public target: Actor, public radius: number) {}
+   public action = (target: Actor, cam: BaseCamera, _eng: Engine, _delta: number) => {
+      let position = target.getCenter();
+      let focus = cam.getFocus();
+
+      let direction = position.sub(focus);
+      let distance = direction.magnitude();
+      if (distance >= this.radius) {
+         let offset = distance - this.radius;
+         return focus.add(direction.normalize().scale(offset));
+      }
+      return focus;
+   }
+}
 
 
 /**
@@ -16,6 +178,10 @@ import { Actor } from './Actor';
  */
 export class BaseCamera {
    protected _follow: Actor;
+
+   private _cameraStrategies: ICameraStrategy<any>[] = [];
+
+   public strategy: StrategyContainer = new StrategyContainer(this);
 
    // camera physical quantities
    public z: number = 1;
@@ -89,11 +255,33 @@ export class BaseCamera {
    }
 
    /**
-    * Sets the [[Actor]] to follow with the camera
-    * @param actor  The actor to follow
+    * Get the camera's position as a vector
     */
-   public setActorToFollow(actor: Actor) {
-      this._follow = actor;
+   public get pos(): Vector {
+      return new Vector(this.x, this.y);
+   }
+
+   /**
+    * Set the cameras position
+    */
+   public set pos(value: Vector) {
+      this.x = value.x;
+      this.y = value.y;
+   }
+
+   /**
+    * Get the camera's velocity as a vector
+    */
+   public get vel() {
+      return new Vector(this.dx, this.dy);
+   }
+
+   /**
+    * Set the camera's velocity
+    */
+   public set vel(value: Vector) {
+      this.dx = value.x;
+      this.dy = value.y;
    }
 
    /**
@@ -183,7 +371,31 @@ export class BaseCamera {
       return this.z;
    }
 
+   /**
+    * Adds a new camera strategy to this camera
+    * @param cameraStrategy Instance of an [[ICameraStrategy]]
+    */
+   public addStrategy<T>(cameraStrategy: ICameraStrategy<T>) {
+      this._cameraStrategies.push(cameraStrategy);
+   }
+
+   /**
+    * Removes a camera strategy by reference
+    * @param cameraStrategy Instance of an [[ICameraStrategy]]
+    */
+   public removeStrategy<T>(cameraStrategy: ICameraStrategy<T>) {
+      removeItemFromArray(cameraStrategy, this._cameraStrategies);
+   }
+
+   /**
+    * Clears all camera strategies from the camera
+    */
+   public clearAllStrategies() {
+      this._cameraStrategies.length = 0;
+   }
+
    public update(_engine: Engine, delta: number) {
+
       // Update placements based on linear algebra
       this._x += this.dx * delta / 1000;
       this._y += this.dy * delta / 1000;
@@ -257,6 +469,10 @@ export class BaseCamera {
          this._xShake = (Math.random() * this._shakeMagnitudeX | 0) + 1;
          this._yShake = (Math.random() * this._shakeMagnitudeY | 0) + 1;
       }
+
+      for (let s of this._cameraStrategies) {
+         this.pos = s.action.call(s, s.target, this, _engine, delta);
+      }
    }
 
    /**
@@ -303,8 +519,16 @@ export class BaseCamera {
  * An extension of [[BaseCamera]] that is locked vertically; it will only move side to side.
  * 
  * Common usages: platformers.
+ * @deprecated Will be removed in v0.15, please use `BaseCamera.strategy.lockToActorAxis`
  */
 export class SideCamera extends BaseCamera {
+   /**
+    * Sets the [[Actor]] to follow with the camera
+    * @param actor  The actor to follow
+    */
+   public setActorToFollow(actor: Actor) {
+      this._follow = actor;
+   }
 
    public getFocus() {
       if (this._follow) {
@@ -321,9 +545,16 @@ export class SideCamera extends BaseCamera {
  * center of the screen.
  *
  * Common usages: RPGs, adventure games, top-down games.
+ * @deprecated Will be removed in v0.15, please use `BaseCamera.strategy.lockToActor`
  */
 export class LockedCamera extends BaseCamera {
-
+   /**
+    * Sets the [[Actor]] to follow with the camera
+    * @param actor  The actor to follow
+    */
+   public setActorToFollow(actor: Actor) {
+      this._follow = actor;
+   }
    public getFocus() {
       if (this._follow) {
          return new Vector(this._follow.pos.x + this._follow.getWidth() / 2, this._follow.pos.y + this._follow.getHeight() / 2);

--- a/src/engine/Docs/Cameras.md
+++ b/src/engine/Docs/Cameras.md
@@ -22,7 +22,7 @@ offset the focal point.
 Cameras can implement a number of strategies to track, follow, or exhibit custom behavior in relation to a target. A common reason to use a 
 strategy is to have the [[Camera]] follow an [[Actor]].
 
-In order to user the different built in strategies, you can access `Camera.strategy`
+In order to user the different built-in strategies, you can access `Camera.strategy`
 
 Lock the camera exactly to the center of the actor's bounding box
 ```typescript
@@ -41,8 +41,33 @@ game.currentScene.camera.strategy.elasticToActor(actor, cameraElasticity, camera
 
 Keep the actor within a circle around the focus
 ```typescript
-game.currentScene.camera.strategy.circleAroundActor(actor, radius);
+game.currentScene.camera.strategy.radiusAroundActor(actor, radius);
 ```
+
+## Custom strategies
+
+Custom strategies can be implemented by extending the ICameraStrategy interface and added to cameras to build novel behavior with `ex.Camera.addStrategy<T>(new MyCameraStrategy<T>())`.
+
+As shown below a camera strategy calculates a new camera position (`ex.Vector`) every frame given a target type, camera, engine, and elapsed delta in milliseconds.
+
+```typescript
+/**
+ * Interface that describes a custom camera strategy for tracking targets
+ */
+export interface ICameraStrategy<T> {
+   /**
+    * Target of the camera strategy that will be passed to the action
+    */
+   target: T;
+
+   /**
+    * Camera strategies perform an action to calculate a new focus returned out of the strategy
+    */
+   action: (target: T, camera: BaseCamera, engine: Engine, delta: number) => Vector;
+}
+```
+
+
 
 ## Camera Shake
 

--- a/src/engine/Docs/Cameras.md
+++ b/src/engine/Docs/Cameras.md
@@ -17,6 +17,33 @@ If a camera is following an [[Actor]], it will ensure the [[Actor]] is always at
 center of the screen. You can use [[x]] and [[y]] instead if you wish to
 offset the focal point.
 
+## Camera strategies
+
+Cameras can implement a number of strategies to track, follow, or exhibit custom behavior in relation to a target. A common reason to use a 
+strategy is to have the [[Camera]] follow an [[Actor]].
+
+In order to user the different built in strategies, you can access `Camera.strategy`
+
+Lock the camera exactly to the center of the actor's bounding box
+```typescript
+game.currentScene.camera.strategy.lockToActor(actor);
+```
+
+Lock the camera to one axis of the actor, in this case follow the actors x position
+```typescript
+game.currentScene.camera.strategy.lockToActorAxis(actor, ex.Axis.X);
+```
+
+Elastically move the camera to an actor in a smooth motion see [[ElasticToActorStrategy]] for details
+```typescript
+game.currentScene.camera.strategy.elasticToActor(actor, cameraElasticity, cameraFriction);
+```
+
+Keep the actor within a circle around the focus
+```typescript
+game.currentScene.camera.strategy.circleAroundActor(actor, radius);
+```
+
 ## Camera Shake
 
 To add some fun effects to your game, the [[shake]] method

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -168,9 +168,7 @@ export class Scene extends Class {
       this.emit('preupdate', new PreUpdateEvent(engine, delta, this));
       var i: number, len: number;
 
-      if (this.camera) {
-         this.camera.update(engine, delta);
-      }
+      
 
       // Remove timers in the cancel queue before updating them
       for (i = 0, len = this._cancelQueue.length; i < len; i++) {
@@ -234,6 +232,10 @@ export class Scene extends Class {
       }
       engine.stats.currFrame.actors.killed = this._killQueue.length;
       this._killQueue.length = 0;
+
+      if (this.camera) {
+         this.camera.update(engine, delta);
+      }
 
       this.emit('postupdate', new PostUpdateEvent(engine, delta, this));
    }

--- a/src/spec/CameraSpec.ts
+++ b/src/spec/CameraSpec.ts
@@ -1,6 +1,8 @@
 /// <reference path="jasmine.d.ts" />
 
-/// <reference path="Mocks.ts" />
+/// <reference path="Mocks.ts" />import { BaseCamera } from "../../build/dist/excalibur";
+
+
 
 describe('A camera', () => {
    
@@ -159,6 +161,95 @@ describe('A camera', () => {
 
       expect(sideCamera._isZooming).toBe(true);
    
+   });
+
+   it('can use built-in locked camera strategy', () => {
+      engine.currentScene.camera = new ex.BaseCamera();
+      let actor = new ex.Actor(0, 0);
+
+      engine.currentScene.camera.strategy.lockToActor(actor);
+
+      engine.currentScene.camera.update(engine, 100);
+      expect(engine.currentScene.camera.x).toBe(0);
+      expect(engine.currentScene.camera.y).toBe(0);
+
+      actor.pos.setTo(100, 100);
+      engine.currentScene.camera.update(engine, 100);
+      expect(engine.currentScene.camera.x).toBe(100);
+      expect(engine.currentScene.camera.y).toBe(100);
+   });
+
+   it('can use built-in locked camera x axis strategy', () => {
+      engine.currentScene.camera = new ex.BaseCamera();
+      let actor = new ex.Actor(0, 0);
+
+      engine.currentScene.camera.strategy.lockToActorAxis(actor, ex.Axis.X);
+
+      engine.currentScene.camera.update(engine, 100);
+      expect(engine.currentScene.camera.x).toBe(0);
+      expect(engine.currentScene.camera.y).toBe(0);
+
+      actor.pos.setTo(100, 100);
+      engine.currentScene.camera.update(engine, 100);
+      expect(engine.currentScene.camera.x).toBe(100);
+      expect(engine.currentScene.camera.y).toBe(0);
+   });
+
+   it('can use built-in locked camera y axis strategy', () => {
+      engine.currentScene.camera = new ex.BaseCamera();
+      let actor = new ex.Actor(0, 0);
+
+      engine.currentScene.camera.strategy.lockToActorAxis(actor, ex.Axis.Y);
+
+      engine.currentScene.camera.update(engine, 100);
+      expect(engine.currentScene.camera.x).toBe(0);
+      expect(engine.currentScene.camera.y).toBe(0);
+
+      actor.pos.setTo(100, 100);
+      engine.currentScene.camera.update(engine, 100);
+      expect(engine.currentScene.camera.x).toBe(0);
+      expect(engine.currentScene.camera.y).toBe(100);
+   });
+
+   it('can use built-in radisu around actor strategy', () => {
+      engine.currentScene.camera = new ex.BaseCamera();
+      let actor = new ex.Actor(0, 0);
+
+      engine.currentScene.camera.strategy.radiusAroundActor(actor, 15);
+
+      engine.currentScene.camera.update(engine, 100);
+      expect(engine.currentScene.camera.x).toBe(0);
+      expect(engine.currentScene.camera.y).toBe(0);
+
+      actor.pos.setTo(100, 100);
+      engine.currentScene.camera.update(engine, 100);
+      let distance = engine.currentScene.camera.pos.distance(actor.pos);
+      expect(distance).toBeCloseTo(15, .01);
+   });
+
+   it('can use built-in elastic around actor strategy', () => {
+      engine.currentScene.camera = new ex.BaseCamera();
+      engine.currentScene.camera.pos.setTo(0, 0);
+      let actor = new ex.Actor(0, 0);
+
+      engine.currentScene.camera.strategy.elasticToActor(actor, .05, .1);
+
+      engine.currentScene.camera.update(engine, 100);
+      expect(engine.currentScene.camera.x).toBe(0);
+      expect(engine.currentScene.camera.y).toBe(0);
+
+      actor.pos.setTo(100, 100);
+      engine.currentScene.camera.update(engine, 100);
+      engine.currentScene.camera.update(engine, 100);
+      engine.currentScene.camera.update(engine, 100);
+      let distance = engine.currentScene.camera.pos.distance(actor.pos);
+      expect(distance).toBeLessThan((new ex.Vector(100, 100).distance()));
+
+      engine.currentScene.camera.update(engine, 100);
+      engine.currentScene.camera.update(engine, 100);
+      engine.currentScene.camera.update(engine, 100);
+      let distance2 = engine.currentScene.camera.pos.distance(actor.pos);
+      expect(distance2).toBeLessThan(distance);
    });
 
    xit('can zoom in over time', (done) => {


### PR DESCRIPTION
Closes #445

TODOS before merge: 
- [x] Merge #909 
- [x] Add tests

## Changes:

- Implements new strategy pattern with some built-in strategies
- Updates documentation
- Deprecates `ex.LockedCamera` and `ex.SideCamera`
