### PR TITLE
[#703] Fix polygon edge collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Breaking Changes
 
 ## Added
+- Added new line utility `Line.normal()` and `Line.distanceToPoint` ([#703](https://github.com/excaliburjs/Excalibur/issues/703))
+- Added new PolygonArea utility `PolygonArea.getClosestFace(point)` ([#703](https://github.com/excaliburjs/Excalibur/issues/703))
 
 ## Changed
 
 ## Deprecated
 
 ## Fixed
+- Fixed odd jumping behavior when polygons collided with the end of an edge ([#703](https://github.com/excaliburjs/Excalibur/issues/703))
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -754,7 +754,7 @@
     "connect": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.3.tgz",
-      "integrity": "sha512-GLSZqgjVxPvGYVD/2vz//gS201MEXk4b7t3nHV6OVnTdDNWi/Gm7Rpxs/ybvljPWvULys/wrzIV3jB3YvEc3nQ==",
+      "integrity": "sha1-9zINRqJbS+e0g6IjZRfySx4n4wE=",
       "dev": true,
       "requires": {
         "debug": "2.6.8",
@@ -1567,7 +1567,7 @@
     "finalhandler": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
-      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+      "integrity": "sha1-GFdPLnxLmLiuOyMMIfIB8xvbP7c=",
       "dev": true,
       "requires": {
         "debug": "2.6.8",

--- a/sandbox/tests/physics/physics.ts
+++ b/sandbox/tests/physics/physics.ts
@@ -48,7 +48,7 @@ function spawnCircle(x: number, y: number) {
 
 var edge = new ex.Actor(0, 0, 5, 5, ex.Color.Blue.clone());
 edge.collisionType = ex.CollisionType.Fixed;
-edge.body.useEdgeCollision(new ex.Vector(300, 200), new ex.Vector(300, 400));
+edge.body.useEdgeCollision(new ex.Vector(200, 300), new ex.Vector(400, 300));
 // edge.rx = .4;
 game.add(edge);
 

--- a/sandbox/tests/physics/physics.ts
+++ b/sandbox/tests/physics/physics.ts
@@ -24,8 +24,8 @@ function spawnBlock(x: number, y: number) {
                            ex.Util.randomIntInRange(0, 255));
    var block = new ex.Actor(x, y, width, width, color);
    block.body.useBoxCollision();
-   block.rotation = Math.PI / 4;
-   block.rx = .1;
+   //block.rotation = Math.PI / 4;
+   //block.rx = .1;
    block.collisionType = ex.CollisionType.Active;
    game.add(block);
 }
@@ -48,7 +48,7 @@ function spawnCircle(x: number, y: number) {
 
 var edge = new ex.Actor(0, 0, 5, 5, ex.Color.Blue.clone());
 edge.collisionType = ex.CollisionType.Fixed;
-edge.body.useEdgeCollision(new ex.Vector(200, 300), new ex.Vector(400, 300));
+edge.body.useEdgeCollision(new ex.Vector(300, 200), new ex.Vector(300, 400));
 // edge.rx = .4;
 game.add(edge);
 
@@ -69,7 +69,7 @@ game.add(rightWall);
 
 game.input.keyboard.on('down', (evt: ex.Input.KeyEvent) => {
    if(evt.key === ex.Input.Keys.B){
-      spawnBlock(300, 0);
+      spawnBlock(280, 0);
    }
 
    if(evt.key === ex.Input.Keys.C){

--- a/src/engine/Algebra.ts
+++ b/src/engine/Algebra.ts
@@ -357,6 +357,13 @@ export class Line {
    }
 
    /**
+    * Gets the normal of the line
+    */
+   public normal(): Vector {
+      return this.end.sub(this.begin).normal();
+   }
+
+   /**
     * Returns the slope of the line in the form of a vector
     */
    public getSlope(): Vector {

--- a/src/engine/Algebra.ts
+++ b/src/engine/Algebra.ts
@@ -384,6 +384,23 @@ export class Line {
    }
 
    /**
+    * Find the perpendicular distance from the line to a point
+    * https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line
+    * @param point 
+    */
+   public distanceToPoint(point: Vector) {
+      let x0 = point.x;
+      let y0 = point.y;
+
+      let l = this.getLength();
+
+      let dy = this.end.y - this.begin.y;
+      let dx = this.end.x - this.begin.x;
+      let distance = Math.abs(dy * x0 - dx * y0 + this.end.x * this.begin.y - this.end.y * this.begin.x) / l;
+      return distance;
+   }
+
+   /**
     * Finds a point on the line given only an X or a Y value. Given an X value, the function returns
     * a new point with the calculated Y value and vice-versa.
     *

--- a/src/engine/Collision/PolygonArea.ts
+++ b/src/engine/Collision/PolygonArea.ts
@@ -222,6 +222,33 @@ export class PolygonArea implements ICollisionArea {
    }
 
    /**
+    * Casts a ray into the polygon and returns the line of the polygonface or null if no collision.
+    */
+    public rayCastFace(ray: Ray, max: number = Infinity): {contact: Vector, face: Line} {
+      // find the minimum contact time greater than 0
+      // contact times less than 0 are behind the ray and we don't want those
+      var sides = this.getSides();
+      var len = sides.length;
+      var minContactTime = Number.MAX_VALUE;
+      var contactIndex = -1;
+      for (var i = 0; i < len; i++) {
+         var contactTime = ray.intersect(sides[i]);
+         if (contactTime >= 0 && contactTime < minContactTime && contactTime <= max) {
+            minContactTime = contactTime;
+            contactIndex = i;
+         }
+      }
+
+      // contact was found
+      if (contactIndex >= 0) {
+         return { contact: ray.getPoint(minContactTime), face: sides[contactIndex] };
+      }
+
+      // no contact found
+      return null;
+   }
+
+   /**
     * Get the axis associated with the edge
     */
    public getAxes(): Vector[] {

--- a/src/engine/Collision/PolygonArea.ts
+++ b/src/engine/Collision/PolygonArea.ts
@@ -152,6 +152,34 @@ export class PolygonArea implements ICollisionArea {
    }
 
    /**
+    * Finds the closes face to the point using perpendicular distance
+    * @param point point to test against polygon
+    */
+   public getClosestFace(point: Vector): {distance: Vector, face: Line } {
+      let sides = this.getSides();
+      let min = Number.POSITIVE_INFINITY;
+      let faceIndex = -1;
+      let distance = -1;
+      for (let i = 0; i < sides.length; i++) {
+         let dist = sides[i].distanceToPoint(point);
+         if (dist < min) {
+            min = dist;
+            faceIndex = i;
+            distance = dist;
+         }
+      }
+
+      if (faceIndex !== -1) {
+         return {
+            distance: sides[faceIndex].normal().scale(distance),
+            face: sides[faceIndex]
+         };
+      }
+
+      return null;
+   }
+
+   /**
     * Get the axis aligned bounding box for the polygon area
     */
    public getBounds(): BoundingBox {
@@ -221,32 +249,6 @@ export class PolygonArea implements ICollisionArea {
       return null;
    }
 
-   /**
-    * Casts a ray into the polygon and returns the line of the polygonface or null if no collision.
-    */
-    public rayCastFace(ray: Ray, max: number = Infinity): {contact: Vector, face: Line} {
-      // find the minimum contact time greater than 0
-      // contact times less than 0 are behind the ray and we don't want those
-      var sides = this.getSides();
-      var len = sides.length;
-      var minContactTime = Number.MAX_VALUE;
-      var contactIndex = -1;
-      for (var i = 0; i < len; i++) {
-         var contactTime = ray.intersect(sides[i]);
-         if (contactTime >= 0 && contactTime < minContactTime && contactTime <= max) {
-            minContactTime = contactTime;
-            contactIndex = i;
-         }
-      }
-
-      // contact was found
-      if (contactIndex >= 0) {
-         return { contact: ray.getPoint(minContactTime), face: sides[contactIndex] };
-      }
-
-      // no contact found
-      return null;
-   }
 
    /**
     * Get the axis associated with the edge

--- a/src/spec/AlgebraSpec.ts
+++ b/src/spec/AlgebraSpec.ts
@@ -297,6 +297,14 @@ describe('Lines', () => {
       expect(line.intercept).toBe(0);
    });
 
+   it('can have a normal', () => {
+      var line = new ex.Line(new ex.Vector(1, 1), new ex.Vector(2, 1));
+
+      var normal = line.normal();
+      expect(normal.x).toBe(0);
+      expect(normal.y).toBe(-1);
+   });
+
    it('can have a length', () => {
       var line = new ex.Line(new ex.Vector(1, -1), new ex.Vector(1, 1));
       expect(line.getLength()).toBe(2);

--- a/src/spec/AlgebraSpec.ts
+++ b/src/spec/AlgebraSpec.ts
@@ -318,6 +318,18 @@ describe('Lines', () => {
       expect(t.x).toBe(1);
    });
 
+   it('can calculate the perpendicular distance from a point', () => {
+      let line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(200, 0));
+      let point = new ex.Vector(100, 100);
+      expect(line.distanceToPoint(point)).toBe(100);
+   });
+
+   it('can calculate the perpendicular distance from a point not above the line', () => {
+      let line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(200, 0));
+      let point = new ex.Vector(-100, 100);
+      expect(line.distanceToPoint(point)).toBe(100);
+   });
+
    it('can determine if point lies on the line by x and y', () => {
       var line = new ex.Line(new ex.Vector(0, 0), new ex.Vector(2, 2));
       var t = line.hasPoint(1, 1);

--- a/src/spec/CollisionAreaSpec.ts
+++ b/src/spec/CollisionAreaSpec.ts
@@ -362,7 +362,69 @@ describe('Collision areas', () => {
 
       });
 
-       it('should not collide with the middle of an edge when not touching', () => {
+      it('can collide with the end of an edge', () => {
+         var actor = new ex.Actor(0, -4, 20, 20);
+         var polyA = new ex.PolygonArea({
+            pos: ex.Vector.Zero.clone(),
+            // specified relative to the position
+            points: [new ex.Vector(-5, -5), new ex.Vector(5, -5), new ex.Vector(5, 5), new ex.Vector(-5, 5)],
+            body: actor.body
+         });
+         polyA.recalc();
+
+
+         var actor2 = new ex.Actor(5, 0, 10, 10);
+         var edge = new ex.EdgeArea({
+            begin: new ex.Vector(0, 0),
+            end: new ex.Vector(0, 10),
+            body: actor2.body
+         });
+         edge.recalc();
+
+         var directionOfBodyB = edge.getCenter().sub(polyA.getCenter());
+         var contact = polyA.collide(edge);
+
+         expect(contact).not.toBe(null);
+          // the normal should be pointing away from bodyA
+         expect(directionOfBodyB.dot(contact.normal)).toBeGreaterThan(0);
+         // the mtv should be pointing away from bodyA
+         expect(directionOfBodyB.dot(contact.mtv)).toBeGreaterThan(0);
+
+
+      });
+
+      it('can collide with the end of an edge regardless of order', () => {
+         var actor = new ex.Actor(0, -4, 20, 20);
+         var polyA = new ex.PolygonArea({
+            pos: ex.Vector.Zero.clone(),
+            // specified relative to the position
+            points: [new ex.Vector(-5, -5), new ex.Vector(5, -5), new ex.Vector(5, 5), new ex.Vector(-5, 5)],
+            body: actor.body
+         });
+         polyA.recalc();
+
+
+         var actor2 = new ex.Actor(5, 0, 10, 10);
+         var edge = new ex.EdgeArea({
+            begin: new ex.Vector(0, 10),
+            end: new ex.Vector(0, 0),
+            body: actor2.body
+         });
+         edge.recalc();
+
+         var directionOfBodyB = edge.getCenter().sub(polyA.getCenter());
+         var contact = polyA.collide(edge);
+
+         expect(contact).not.toBe(null);
+          // the normal should be pointing away from bodyA
+         expect(directionOfBodyB.dot(contact.normal)).toBeGreaterThan(0);
+         // the mtv should be pointing away from bodyA
+         expect(directionOfBodyB.dot(contact.mtv)).toBeGreaterThan(0);
+
+
+      });
+
+      it('should not collide with the middle of an edge when not touching', () => {
          var actor = new ex.Actor(5, 0, 20, 20);
          actor.rotation = Math.PI / 4;
          var polyA = new ex.PolygonArea({
@@ -407,6 +469,47 @@ describe('Collision areas', () => {
          expect(polyA.contains(point)).toBe(true);
          expect(polyA.contains(pointOnEdge)).toBe(true);
          expect(polyA.contains(pointOutside)).toBe(false);
+      });
+
+      it('can calculate the closest face to a point', () => {
+         var polyA = new ex.PolygonArea({
+            pos: ex.Vector.Zero.clone(),
+            // specified relative to the position
+            points: [new ex.Vector(-5, -5), new ex.Vector(5, -5), new ex.Vector(5, 5), new ex.Vector(-5, 5)]
+         });
+         polyA.recalc();
+
+         let point1 = new ex.Vector(-5, 0);
+         let {face: face1} = polyA.getClosestFace(point1);
+
+         let point2 = new ex.Vector(0, -5);
+         let {face: face2} = polyA.getClosestFace(point2);
+
+         let point3 = new ex.Vector(5, 0);
+         let {face: face3} = polyA.getClosestFace(point3);
+
+         let point4 = new ex.Vector(0, 5);
+         let {face: face4} = polyA.getClosestFace(point4);
+
+         expect(face1.begin.x).toBe(-5);
+         expect(face1.begin.y).toBe(-5);
+         expect(face1.end.x).toBe(-5);
+         expect(face1.end.y).toBe(5);
+
+         expect(face2.begin.x).toBe(5);
+         expect(face2.begin.y).toBe(-5);
+         expect(face2.end.x).toBe(-5);
+         expect(face2.end.y).toBe(-5);
+
+         expect(face3.begin.x).toBe(5);
+         expect(face3.begin.y).toBe(5);
+         expect(face3.end.x).toBe(5);
+         expect(face3.end.y).toBe(-5);
+
+         expect(face4.begin.x).toBe(-5);
+         expect(face4.begin.y).toBe(5);
+         expect(face4.end.x).toBe(5);
+         expect(face4.end.y).toBe(5);
       });
 
       it('can have ray cast to detect if the ray hits the polygon', () => {


### PR DESCRIPTION
Closes #703

## Changes:
- Corrects odd behavior shown in the bug
- Added tests around fix and new utilities
- Implement new utilities to assist in collision calculations
   * `Line.normal` calculates the positive normal of the line
   * `Line.distanceToPoint` calculates the perpendicular distance from a point to a line
   * `PolygonArea.getClosestFace` finds the face with the lowest perpendicular distance to the point

