### PR TITLE
[#920] Use setTargetAtTime to set volume for Sound

### DIFF
--- a/src/engine/Resources/Sound.ts
+++ b/src/engine/Resources/Sound.ts
@@ -567,7 +567,11 @@ class WebAudioInstance implements IAudio {
 
    public setVolume(value: number) {
       this._volume = value;
-      this._volumeNode.gain.value = Util.clamp(value, 0, 1.0);
+      if (this._volumeNode.gain.setTargetAtTime) {
+         this._volumeNode.gain.setTargetAtTime(Util.clamp(value, 0, 1.0), audioContext.currentTime, 0);
+      } else {
+         this._volumeNode.gain.value = Util.clamp(value, 0, 1.0);
+      }
    }
 
    public setLoop(value: boolean) {


### PR DESCRIPTION
Closes #920

## Changes:
- Use `GainNode.gain.setTargetAtTime` as recommended instead of setting `GainNode.gain.value` directly where possible
