### PR TITLE
[chore] Fix ci in new travis env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
   - node_shrinkwrap
   - $HOME/.npm
 before_install:
+- google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 - gem install sass -v 3.4.24
 script:
 - node_modules/.bin/grunt travis


### PR DESCRIPTION
Currently CI is broken on master

This corrects it given the new documentation

https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-the-Chrome-addon-in-the-headless-mode

https://travis-ci.org/excaliburjs/Excalibur/builds/327439382