### PR TITLE
Prevent sprite drawing context from being corrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Offscreen culling in HiDPI mode ([#949](https://github.com/excaliburjs/Excalibur/issues/949))
   - Correct bounds check to check drawWidth/drawHeight for HiDPI
   - suppressHiDPIScaling now also suppresses pixel ratio based scaling
+- Extract and separate Sprite width/height from drawWidth/drawHeight ([#951](https://github.com/excaliburjs/Excalibur/pull/951))
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -76,7 +76,13 @@ game.add(heart);
 // Turn on debug diagnostics
 game.isDebug = false;
 //var blockSprite = new ex.Sprite(imageBlocks, 0, 0, 65, 49);
-var blockSprite = new ex.Sprite({image: imageBlocks, x:0, y: 0, width: 65, height: 49});
+var blockSprite = new ex.Sprite({
+   image: imageBlocks, 
+   x: 0, 
+   y: 0, 
+   width: 65, 
+   height: 49
+});
 // Create spritesheet
 //var spriteSheetRun = new ex.SpriteSheet(imageRun, 21, 1, 96, 96);
 var spriteSheetRun = new ex.SpriteSheet({ image: imageRun,

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -1237,8 +1237,8 @@ export class ActorImpl extends Class implements IActionable, IEvented, IPointerE
       if (this.currentDrawing) {
          var drawing = this.currentDrawing;
          // See https://github.com/excaliburjs/Excalibur/pull/619 for discussion on this formula          
-         var offsetX = (this._width - drawing.naturalWidth * drawing.scale.x) * this.anchor.x;
-         var offsetY = (this._height - drawing.naturalHeight * drawing.scale.y) * this.anchor.y;
+         var offsetX = (this._width - drawing.width * drawing.scale.x) * this.anchor.x;
+         var offsetY = (this._height - drawing.height * drawing.scale.y) * this.anchor.y;
 
          if (this._effectsDirty) {
             this._reapplyEffects(this.currentDrawing);

--- a/src/engine/Drawing/Animation.ts
+++ b/src/engine/Drawing/Animation.ts
@@ -59,10 +59,10 @@ export class AnimationImpl implements IDrawable {
     */
    public flipHorizontal: boolean = false;
    
+   public scaledWidth: number = 0;
+   public scaledHeight: number= 0;
    public width: number = 0;
-   public height: number= 0;
-   public naturalWidth: number = 0;
-   public naturalHeight: number = 0;
+   public height: number = 0;
 
    /**
     * Typically you will use a [[SpriteSheet]] to generate an [[Animation]].
@@ -92,11 +92,11 @@ export class AnimationImpl implements IDrawable {
       }
       
       if (sprites && sprites[0]) {
-         this.height = sprites[0] ? sprites[0].height : 0;
-         this.width = sprites[0] ? sprites[0].width : 0;
+         this.scaledHeight = sprites[0] ? sprites[0].scaledHeight : 0;
+         this.scaledWidth = sprites[0] ? sprites[0].scaledWidth : 0;
          
-         this.naturalWidth = sprites[0] ? sprites[0].naturalWidth : 0;
-         this.naturalHeight = sprites[0] ? sprites[0].naturalHeight : 0;
+         this.width = sprites[0] ? sprites[0].width : 0;
+         this.height = sprites[0] ? sprites[0].height : 0;
 
          this.freezeFrame = sprites.length - 1;
       }
@@ -289,8 +289,8 @@ export class AnimationImpl implements IDrawable {
       
       // add the calculated width
       if (currSprite) {
-         this.width = currSprite.width;
-         this.height = currSprite.height;
+         this.scaledWidth = currSprite.scaledWidth;
+         this.scaledHeight = currSprite.scaledHeight;
       }
    }
 

--- a/src/engine/Drawing/Animation.ts
+++ b/src/engine/Drawing/Animation.ts
@@ -59,8 +59,8 @@ export class AnimationImpl implements IDrawable {
     */
    public flipHorizontal: boolean = false;
    
-   public scaledWidth: number = 0;
-   public scaledHeight: number= 0;
+   public drawWidth: number = 0;
+   public drawHeight: number= 0;
    public width: number = 0;
    public height: number = 0;
 
@@ -92,8 +92,8 @@ export class AnimationImpl implements IDrawable {
       }
       
       if (sprites && sprites[0]) {
-         this.scaledHeight = sprites[0] ? sprites[0].scaledHeight : 0;
-         this.scaledWidth = sprites[0] ? sprites[0].scaledWidth : 0;
+         this.drawHeight = sprites[0] ? sprites[0].drawHeight : 0;
+         this.drawWidth = sprites[0] ? sprites[0].drawWidth : 0;
          
          this.width = sprites[0] ? sprites[0].width : 0;
          this.height = sprites[0] ? sprites[0].height : 0;
@@ -289,8 +289,8 @@ export class AnimationImpl implements IDrawable {
       
       // add the calculated width
       if (currSprite) {
-         this.scaledWidth = currSprite.scaledWidth;
-         this.scaledHeight = currSprite.scaledHeight;
+         this.drawWidth = currSprite.drawWidth;
+         this.drawHeight = currSprite.drawHeight;
       }
    }
 

--- a/src/engine/Drawing/Polygon.ts
+++ b/src/engine/Drawing/Polygon.ts
@@ -12,11 +12,11 @@ import { Vector } from '../Algebra';
 export class Polygon implements IDrawable {
    public flipVertical: boolean;
    public flipHorizontal: boolean;
+   public scaledWidth: number;
+   public scaledHeight: number;
+   
    public width: number;
    public height: number;
-   
-   public naturalWidth: number;
-   public naturalHeight: number;
 
    /**
     * The color to use for the lines of the polygon
@@ -53,7 +53,7 @@ export class Polygon implements IDrawable {
          return Math.max(prev, curr.x);
       }, 0);
 
-      this.width = maxX - minX;
+      this.scaledWidth = maxX - minX;
 
       var minY = this._points.reduce((prev: number, curr: Vector) => {
          return Math.min(prev, curr.y);
@@ -62,10 +62,10 @@ export class Polygon implements IDrawable {
          return Math.max(prev, curr.y);
       }, 0);
 
-      this.height = maxY - minY;
+      this.scaledHeight = maxY - minY;
       
-      this.naturalHeight = this.height;
-      this.naturalWidth = this.width;
+      this.height = this.scaledHeight;
+      this.width = this.scaledWidth;
    }
 
    /**
@@ -129,12 +129,12 @@ export class Polygon implements IDrawable {
       ctx.strokeStyle = this.lineColor.toString();
 
       if (this.flipHorizontal) {
-         ctx.translate(this.width, 0);
+         ctx.translate(this.scaledWidth, 0);
          ctx.scale(-1, 1);
       }
 
       if (this.flipVertical) {
-         ctx.translate(0, this.height);
+         ctx.translate(0, this.scaledHeight);
          ctx.scale(1, -1);
       }
 

--- a/src/engine/Drawing/Polygon.ts
+++ b/src/engine/Drawing/Polygon.ts
@@ -12,8 +12,8 @@ import { Vector } from '../Algebra';
 export class Polygon implements IDrawable {
    public flipVertical: boolean;
    public flipHorizontal: boolean;
-   public scaledWidth: number;
-   public scaledHeight: number;
+   public drawWidth: number;
+   public drawHeight: number;
    
    public width: number;
    public height: number;
@@ -53,7 +53,7 @@ export class Polygon implements IDrawable {
          return Math.max(prev, curr.x);
       }, 0);
 
-      this.scaledWidth = maxX - minX;
+      this.drawWidth = maxX - minX;
 
       var minY = this._points.reduce((prev: number, curr: Vector) => {
          return Math.min(prev, curr.y);
@@ -62,10 +62,10 @@ export class Polygon implements IDrawable {
          return Math.max(prev, curr.y);
       }, 0);
 
-      this.scaledHeight = maxY - minY;
+      this.drawHeight = maxY - minY;
       
-      this.height = this.scaledHeight;
-      this.width = this.scaledWidth;
+      this.height = this.drawHeight;
+      this.width = this.drawWidth;
    }
 
    /**
@@ -129,12 +129,12 @@ export class Polygon implements IDrawable {
       ctx.strokeStyle = this.lineColor.toString();
 
       if (this.flipHorizontal) {
-         ctx.translate(this.scaledWidth, 0);
+         ctx.translate(this.drawWidth, 0);
          ctx.scale(-1, 1);
       }
 
       if (this.flipVertical) {
-         ctx.translate(0, this.scaledHeight);
+         ctx.translate(0, this.drawHeight);
          ctx.scale(1, -1);
       }
 

--- a/src/engine/Drawing/Sprite.ts
+++ b/src/engine/Drawing/Sprite.ts
@@ -148,12 +148,12 @@ export class SpriteImpl implements IDrawable {
          var naturalHeight = this._texture.image.naturalHeight || 0;
 
          if (this.width > naturalWidth) {
-            this.logger.warn('The sprite width', this.drawWidth, 'exceeds the width', 
-                              naturalWidth, 'of the backing texture', this._texture.path);
+            this.logger.warn(`The sprite width ${this.width} exceeds the width 
+                              ${naturalWidth} of the backing texture ${this._texture.path}`);
          }            
          if (this.height > naturalHeight) {
-            this.logger.warn('The sprite height', this.drawHeight, 'exceeds the height', 
-                              naturalHeight, 'of the backing texture', this._texture.path);
+            this.logger.warn(`The sprite height ${this.height} exceeds the height 
+                              ${naturalHeight} of the backing texture ${this._texture.path}`);
          }
          this._spriteCtx.drawImage(this._texture.image, 
             clamp(this.x, 0, naturalWidth), 
@@ -404,11 +404,11 @@ export interface ISpriteArgs extends Partial<SpriteImpl> {
    y?: number;
    /** @obsolete ex.[[Sprite.sy]] will be deprecated in 0.17.0 use ex.[[Sprite.y]] */
    sy?: number;
-   drawWidth?: number;
-   /** @obsolete ex.[[Sprite.swidth]] will be deprecated in 0.17.0 use ex.[[Sprite.swidth]] */
+   width?: number;
+   /** @obsolete ex.[[Sprite.swidth]] will be deprecated in 0.17.0 use ex.[[Sprite.width]] */
    swidth?: number;
-   drawHeight?: number;
-   /** @obsolete ex.[[Sprite.sheight]] will be deprecated in 0.17.0 use ex.[[Sprite.sheight]] */
+   height?: number;
+   /** @obsolete ex.[[Sprite.sheight]] will be deprecated in 0.17.0 use ex.[[Sprite.height]] */
    sheight?: number;
    rotation?: number;
    anchor?: Vector;

--- a/src/engine/Drawing/Sprite.ts
+++ b/src/engine/Drawing/Sprite.ts
@@ -349,8 +349,8 @@ export class SpriteImpl implements IDrawable {
       
       // calculating current dimensions      
       ctx.save();
-      var xpoint = this.width * this.anchor.x;
-      var ypoint = this.height * this.anchor.y;
+      var xpoint = this.drawWidth * this.anchor.x;
+      var ypoint = this.drawHeight * this.anchor.y;
       ctx.translate(x, y);
       ctx.rotate(this.rotation);
       

--- a/src/engine/Drawing/Sprite.ts
+++ b/src/engine/Drawing/Sprite.ts
@@ -20,11 +20,11 @@ export class SpriteImpl implements IDrawable {
    public y: number = 0;
 
 
-   public get scaledWidth(): number {
+   public get drawWidth(): number {
       return this.width * this.scale.x;
    }
 
-   public get scaledHeight(): number {
+   public get drawHeight(): number {
       return this.height * this.scale.y;
    }
 
@@ -112,8 +112,8 @@ export class SpriteImpl implements IDrawable {
       if (imageOrConfig && !(imageOrConfig instanceof Texture)) {
          x = imageOrConfig.x || imageOrConfig.sx;
          y = imageOrConfig.y || imageOrConfig.sy;
-         width = imageOrConfig.scaledWidth || imageOrConfig.swidth;
-         height = imageOrConfig.scaledHeight || imageOrConfig.sheight;
+         width = imageOrConfig.drawWidth || imageOrConfig.swidth;
+         height = imageOrConfig.drawHeight || imageOrConfig.sheight;
          image = imageOrConfig.image;
          if (!image) {
             const message = 'An image texture is required to contsruct a sprite';
@@ -147,19 +147,19 @@ export class SpriteImpl implements IDrawable {
          var naturalWidth = this._texture.image.naturalWidth || 0;
          var naturalHeight = this._texture.image.naturalHeight || 0;
 
-         if (this.scaledWidth > naturalWidth) {
-            this.logger.warn('The sprite width', this.scaledWidth, 'exceeds the width', 
+         if (this.width > naturalWidth) {
+            this.logger.warn('The sprite width', this.drawWidth, 'exceeds the width', 
                               naturalWidth, 'of the backing texture', this._texture.path);
          }            
-         if (this.scaledHeight > naturalHeight) {
-            this.logger.warn('The sprite height', this.scaledHeight, 'exceeds the height', 
+         if (this.height > naturalHeight) {
+            this.logger.warn('The sprite height', this.drawHeight, 'exceeds the height', 
                               naturalHeight, 'of the backing texture', this._texture.path);
          }
          this._spriteCtx.drawImage(this._texture.image, 
             clamp(this.x, 0, naturalWidth), 
             clamp(this.y, 0, naturalHeight),
-            clamp(this.scaledWidth, 0, naturalWidth),
-            clamp(this.scaledHeight, 0, naturalHeight),
+            clamp(this.width, 0, naturalWidth),
+            clamp(this.height, 0, naturalHeight),
             0, 0, this.width, this.height);
 
          this._pixelsLoaded = true;
@@ -285,19 +285,20 @@ export class SpriteImpl implements IDrawable {
       var naturalHeight = this._texture.image.naturalHeight || 0;
 
       this._spriteCtx.clearRect(0, 0, this.width, this.height);
-      this._spriteCtx.drawImage(this._texture.image, clamp(this.x, 0, naturalWidth),
+      this._spriteCtx.drawImage(this._texture.image, 
+         clamp(this.x, 0, naturalWidth),
          clamp(this.y, 0, naturalHeight),
-         clamp(this.scaledWidth, 0, naturalWidth),
-         clamp(this.scaledHeight, 0, naturalHeight),
+         clamp(this.width, 0, naturalWidth),
+         clamp(this.height, 0, naturalHeight),
          0, 0, this.width, this.height);
       this._pixelData = this._spriteCtx.getImageData(0, 0, this.width, this.height);
 
       var i = 0, x = 0, y = 0, len = this.effects.length;
       for (i; i < len; i++) {
          y = 0;
-         for (y; y < this.scaledHeight; y++) {
+         for (y; y < this.height; y++) {
             x = 0;
-            for (x; x < this.scaledWidth; x++) {
+            for (x; x < this.width; x++) {
                this.effects[i].updatePixel(x, y, this._pixelData);
             }
          }
@@ -327,11 +328,11 @@ export class SpriteImpl implements IDrawable {
       ctx.save();
       ctx.translate(x, y);
       ctx.rotate(this.rotation);
-      var xpoint = this.scaledWidth * this.anchor.x;
-      var ypoint = this.scaledHeight * this.anchor.y;
+      var xpoint = this.drawWidth * this.anchor.x;
+      var ypoint = this.drawHeight * this.anchor.y;
 
       ctx.strokeStyle = Color.Black.toString();
-      ctx.strokeRect(-xpoint, -ypoint, this.scaledWidth, this.scaledHeight);
+      ctx.strokeRect(-xpoint, -ypoint, this.drawWidth, this.drawHeight);
       ctx.restore();
    }
 
@@ -355,20 +356,20 @@ export class SpriteImpl implements IDrawable {
       
       // todo cache flipped sprites
       if (this.flipHorizontal) {
-         ctx.translate(this.scaledWidth, 0);
+         ctx.translate(this.drawWidth, 0);
          ctx.scale(-1, 1);
       }
 
       if (this.flipVertical) {
-         ctx.translate(0, this.scaledHeight);
+         ctx.translate(0, this.drawHeight);
          ctx.scale(1, -1);
       }
 
       ctx.drawImage(this._spriteCanvas, 0, 0, this.width, this.height, 
          -xpoint, 
          -ypoint, 
-         this.scaledWidth,
-         this.scaledHeight);
+         this.drawWidth,
+         this.drawHeight);
       
       ctx.restore();
    }
@@ -377,7 +378,7 @@ export class SpriteImpl implements IDrawable {
     * Produces a copy of the current sprite
     */
    public clone(): SpriteImpl {
-      var result = new Sprite(this._texture, this.x, this.y, this.width, this.scaledHeight);
+      var result = new Sprite(this._texture, this.x, this.y, this.width, this.height);
       result.scale = this.scale.clone();
       result.rotation = this.rotation;
       result.flipHorizontal = this.flipHorizontal;
@@ -403,10 +404,10 @@ export interface ISpriteArgs extends Partial<SpriteImpl> {
    y?: number;
    /** @obsolete ex.[[Sprite.sy]] will be deprecated in 0.17.0 use ex.[[Sprite.y]] */
    sy?: number;
-   scaledWidth?: number;
+   drawWidth?: number;
    /** @obsolete ex.[[Sprite.swidth]] will be deprecated in 0.17.0 use ex.[[Sprite.swidth]] */
    swidth?: number;
-   scaledHeight?: number;
+   drawHeight?: number;
    /** @obsolete ex.[[Sprite.sheight]] will be deprecated in 0.17.0 use ex.[[Sprite.sheight]] */
    sheight?: number;
    rotation?: number;

--- a/src/engine/Drawing/SpriteSheet.ts
+++ b/src/engine/Drawing/SpriteSheet.ts
@@ -151,15 +151,15 @@ export class SpriteSheetImpl {
          let coord = spriteCoordinates[i];
          // no need to pass image again if using a spritesheet
          coord.image = coord.image || this.image;
-         maxWidth = Math.max(maxWidth, coord.width);
-         maxHeight = Math.max(maxHeight, coord.height);
+         maxWidth = Math.max(maxWidth, coord.scaledWidth);
+         maxHeight = Math.max(maxHeight, coord.scaledHeight);
          sprites[i] = new Sprite(coord);
       }
 
       let anim = new Animation(engine, sprites, speed);
 
-      anim.width = maxWidth;
-      anim.height = maxHeight;
+      anim.scaledWidth = maxWidth;
+      anim.scaledHeight = maxHeight;
       return anim;
    }
 }
@@ -308,12 +308,12 @@ export class SpriteFontImpl extends SpriteSheet {
       var sprite = this.sprites[0];
       
       // find the current height fo the text in pixels
-      var height = sprite.height;
+      var height = sprite.scaledHeight;
       
       // calculate appropriate scale for font size
       var scale = options.fontSize / height;
       
-      var length = (text.length * sprite.width * scale) + (text.length * options.letterSpacing);
+      var length = (text.length * sprite.scaledWidth * scale) + (text.length * options.letterSpacing);
 
       var currX = x;
       if (options.textAlign === TextAlign.Left || options.textAlign === TextAlign.Start) {
@@ -354,7 +354,7 @@ export class SpriteFontImpl extends SpriteSheet {
             charSprite.scale.x = scale;
             charSprite.scale.y = scale;
             charSprite.draw(ctx, currX, currY);
-            currX += (charSprite.width + options.letterSpacing);
+            currX += (charSprite.scaledWidth + options.letterSpacing);
          } catch (e) {
             Logger.getInstance().error(`SpriteFont Error drawing char ${character}`);
          }

--- a/src/engine/Drawing/SpriteSheet.ts
+++ b/src/engine/Drawing/SpriteSheet.ts
@@ -151,15 +151,15 @@ export class SpriteSheetImpl {
          let coord = spriteCoordinates[i];
          // no need to pass image again if using a spritesheet
          coord.image = coord.image || this.image;
-         maxWidth = Math.max(maxWidth, coord.scaledWidth);
-         maxHeight = Math.max(maxHeight, coord.scaledHeight);
+         maxWidth = Math.max(maxWidth, coord.drawWidth);
+         maxHeight = Math.max(maxHeight, coord.drawHeight);
          sprites[i] = new Sprite(coord);
       }
 
       let anim = new Animation(engine, sprites, speed);
 
-      anim.scaledWidth = maxWidth;
-      anim.scaledHeight = maxHeight;
+      anim.drawWidth = maxWidth;
+      anim.drawHeight = maxHeight;
       return anim;
    }
 }
@@ -308,12 +308,12 @@ export class SpriteFontImpl extends SpriteSheet {
       var sprite = this.sprites[0];
       
       // find the current height fo the text in pixels
-      var height = sprite.scaledHeight;
+      var height = sprite.drawHeight;
       
       // calculate appropriate scale for font size
       var scale = options.fontSize / height;
       
-      var length = (text.length * sprite.scaledWidth * scale) + (text.length * options.letterSpacing);
+      var length = (text.length * sprite.drawWidth * scale) + (text.length * options.letterSpacing);
 
       var currX = x;
       if (options.textAlign === TextAlign.Left || options.textAlign === TextAlign.Start) {
@@ -354,7 +354,7 @@ export class SpriteFontImpl extends SpriteSheet {
             charSprite.scale.x = scale;
             charSprite.scale.y = scale;
             charSprite.draw(ctx, currX, currY);
-            currX += (charSprite.scaledWidth + options.letterSpacing);
+            currX += (charSprite.drawWidth + options.letterSpacing);
          } catch (e) {
             Logger.getInstance().error(`SpriteFont Error drawing char ${character}`);
          }

--- a/src/engine/Interfaces/IDrawable.ts
+++ b/src/engine/Interfaces/IDrawable.ts
@@ -16,11 +16,11 @@ export interface IDrawable {
    /**
     * Indicates the current width of the drawing in pixels, factoring in the scale
     */
-   scaledWidth: number;
+   drawWidth: number;
    /**
     * Indicates the current height of the drawing in pixels, factoring in the scale
     */
-   scaledHeight: number;
+   drawHeight: number;
    
    /**
     * Indicates the natural width of the drawing in pixels, this is the original width of the source image

--- a/src/engine/Interfaces/IDrawable.ts
+++ b/src/engine/Interfaces/IDrawable.ts
@@ -16,20 +16,20 @@ export interface IDrawable {
    /**
     * Indicates the current width of the drawing in pixels, factoring in the scale
     */
-   width: number;
+   scaledWidth: number;
    /**
     * Indicates the current height of the drawing in pixels, factoring in the scale
     */
-   height: number;
+   scaledHeight: number;
    
    /**
     * Indicates the natural width of the drawing in pixels, this is the original width of the source image
     */
-   naturalWidth: number;
+   width: number;
    /**
     * Indicates the natural height of the drawing in pixels, this is the original height of the source image
     */
-   naturalHeight: number;
+   height: number;
 
    /**
     * Adds a new [[ISpriteEffect]] to this drawing.

--- a/src/engine/Resources/Texture.ts
+++ b/src/engine/Resources/Texture.ts
@@ -63,8 +63,8 @@ export class Texture extends Resource<HTMLImageElement> {
          this.image = new Image();
          this.image.addEventListener('load', () => {
             this._isLoaded = true;
-            this.width = this._sprite.width = this._sprite.naturalWidth = this._sprite.width = this.image.naturalWidth;
-            this.height = this._sprite.height = this._sprite.naturalHeight = this._sprite.height = this.image.naturalHeight;
+            this.width = this._sprite.width = this.image.naturalWidth;
+            this.height = this._sprite.height = this.image.naturalHeight;
             this.loaded.resolve(this.image);
             complete.resolve(this.image);
          });

--- a/src/engine/Util/CullingBox.ts
+++ b/src/engine/Util/CullingBox.ts
@@ -22,8 +22,8 @@ export class CullingBox {
    private _yMaxWorld: number;
 
    public isSpriteOffScreen(actor: Actor, engine: Engine): boolean {
-      var drawingWidth = actor.currentDrawing.width;
-      var drawingHeight = actor.currentDrawing.height;
+      var drawingWidth = actor.currentDrawing.scaledWidth;
+      var drawingHeight = actor.currentDrawing.scaledHeight;
       var rotation = actor.rotation;
       var anchor = actor.getCenter();
       var worldPos = actor.getWorldPos();

--- a/src/engine/Util/CullingBox.ts
+++ b/src/engine/Util/CullingBox.ts
@@ -22,8 +22,8 @@ export class CullingBox {
    private _yMaxWorld: number;
 
    public isSpriteOffScreen(actor: Actor, engine: Engine): boolean {
-      var drawingWidth = actor.currentDrawing.scaledWidth;
-      var drawingHeight = actor.currentDrawing.scaledHeight;
+      var drawingWidth = actor.currentDrawing.drawWidth;
+      var drawingHeight = actor.currentDrawing.drawHeight;
       var rotation = actor.rotation;
       var anchor = actor.getCenter();
       var worldPos = actor.getWorldPos();

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -1,3 +1,4 @@
+/// <reference path="support/js-imagediff.d.ts" />
 /// <reference path="jasmine.d.ts" />
 /// <reference path="Mocks.ts" />
 
@@ -10,6 +11,7 @@ describe('A game actor', () => {
    var mock = new Mocks.Mocker();
 
    beforeEach(() => {
+      jasmine.addMatchers(imagediff.jasmine);
       engine = TestUtils.engine({width: 100, height: 100});
       actor = new ex.Actor();
       actor.collisionType = ex.CollisionType.Active;
@@ -1312,7 +1314,7 @@ describe('A game actor', () => {
          a1.draw(engine.ctx, 100);
          a2.draw(engine.ctx, 100);
          
-         engine.ctx.fillRect(0, 0, 200, 200);
+         engine.ctx.clearRect(0, 0, 200, 200);
          actor.draw(engine.ctx, 100);
 
          imagediff.expectCanvasImageMatches('SpriteSpec/iconrotate.png', engine.canvas, done);

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -1256,6 +1256,71 @@ describe('A game actor', () => {
       expect(propSpy).toHaveBeenCalledTimes(1);
    });
 
+   it('should not corrupt shared sprite ctxs', (done) => {
+      engine = TestUtils.engine({
+         width: 62,
+         height: 64,
+         suppressHiDPIScaling: true
+       });
+
+      let texture = new ex.Texture('base/src/spec/images/SpriteSpec/icon.png', true);
+      texture.load().then(() => {
+         let sprite = new ex.Sprite({
+            image: texture,
+            x: 0,
+            y: 0,
+            width: 62,
+            height: 64,
+            scale: new ex.Vector(2, 2)
+            // rotation: Math.PI / 4,
+            // anchor: ex.Vector.Half.clone()
+         });
+
+         var actor = new ex.Actor({
+            x: engine.halfCanvasWidth,
+            y: engine.halfCanvasHeight,
+            width: 10,
+            height: 10,
+            rotation: Math.PI / 4
+         });
+
+         engine.add(actor);
+         let s = texture.asSprite();
+         s.scale.setTo(1, 1);
+         actor.addDrawing(s);
+         
+         let a1 = new ex.Actor({scale: new ex.Vector(3, 3)});
+         a1.scale.setTo(3, 3);
+         a1.addDrawing(texture);
+
+         let a2 = new ex.Actor({scale: new ex.Vector(3, 3)});
+         a1.scale.setTo(3, 3);
+         a2.addDrawing(texture);
+         
+
+         a1.draw(engine.ctx, 100);
+         a2.draw(engine.ctx, 100);
+         actor.draw(engine.ctx, 100);
+         engine.ctx.fillRect(0, 0, 200, 200);
+         
+         a1.draw(engine.ctx, 100);
+         a2.draw(engine.ctx, 100);
+         actor.draw(engine.ctx, 100);
+         engine.ctx.fillRect(0, 0, 200, 200);
+         
+
+         a1.draw(engine.ctx, 100);
+         a2.draw(engine.ctx, 100);
+         
+         engine.ctx.fillRect(0, 0, 200, 200);
+         actor.draw(engine.ctx, 100);
+
+         imagediff.expectCanvasImageMatches('SpriteSpec/iconrotate.png', engine.canvas, done);
+
+      });
+   });
+   
+
    describe('lifecycle overrides', () => {
 
       let actor: ex.Actor = null;


### PR DESCRIPTION
Corrects the sprite regression seen in the v0.16.0 regression tests. Essentially sprite height and width where overloaded and meant both natural and scaled size at different points in time. This PR extracts and separates width/height from drawWidth/drawHeight

## Changes:

- Rename `naturalWidth` & `naturalHeight` to `width` & `height`
- Add a `drawWidth` & `drawHeight` concept matching `Engine`
