### PR TITLE
[#949] Fix offscreen culling in hidpi mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Fixed
 
 - Added missing lifecycle event handlers on Actors, Triggers, Scenes, Engine, and Camera ([#582](https://github.com/excaliburjs/Excalibur/issues/582))
+- Offscreen culling in HiDPI mode ([#949](https://github.com/excaliburjs/Excalibur/issues/949))
+  - Correct bounds check to check drawWidth/drawHeight for HiDPI
+  - suppressHiDPIScaling now also suppresses pixel ratio based scaling
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -302,11 +302,16 @@ export class Engine extends Class implements ICanInitialize, ICanUpdate, ICanDra
     */
    public displayMode: DisplayMode = DisplayMode.FullScreen;
 
+
+   private _suppressHiDPIScaling: boolean = false;
    /**
     * Returns the calculated pixel ration for use in rendering
     */
    public get pixelRatio(): number
    {
+      if (this._suppressHiDPIScaling) {
+         return 1;
+      }
       let devicePixelRatio = window.devicePixelRatio || 1;
 
       let pixelRatio = devicePixelRatio;
@@ -965,6 +970,7 @@ O|===|* >________________>\n\
 
       this.ctx = <CanvasRenderingContext2D>this.canvas.getContext('2d');
 
+      this._suppressHiDPIScaling = !!options.suppressHiDPIScaling;
       if (!options.suppressHiDPIScaling) {
          this._initializeHiDpi();
       }

--- a/src/engine/Traits/OffscreenCulling.ts
+++ b/src/engine/Traits/OffscreenCulling.ts
@@ -32,8 +32,8 @@ export class OffscreenCulling implements IActorTrait {
       if (!actor.isOffScreen) {
          if ((actorScreenCoords.x + width * zoom < 0 || 
             actorScreenCoords.y + height * zoom < 0 ||
-            actorScreenCoords.x > engine.canvasWidth ||
-            actorScreenCoords.y > engine.canvasHeight) &&
+            actorScreenCoords.x > engine.drawWidth ||
+            actorScreenCoords.y > engine.drawHeight) &&
             isSpriteOffScreen ) {
             
             eventDispatcher.emit('exitviewport', new ExitViewPortEvent(actor));
@@ -42,8 +42,8 @@ export class OffscreenCulling implements IActorTrait {
       } else {
          if ((actorScreenCoords.x + width * zoom > 0 &&
             actorScreenCoords.y + height * zoom > 0 &&
-            actorScreenCoords.x < engine.canvasWidth &&
-            actorScreenCoords.y < engine.canvasHeight) ||
+            actorScreenCoords.x < engine.drawWidth &&
+            actorScreenCoords.y < engine.drawHeight) ||
             !isSpriteOffScreen) {
             
             eventDispatcher.emit('enterviewport', new EnterViewPortEvent(actor));               

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -230,7 +230,7 @@ describe('The engine', () => {
 
       engine.start().then(() => {
          // Assert
-         expect(engine.isHiDpi).toBe(true);
+         expect(engine.isHiDpi).toBe(false);
          expect((<any>engine)._initializeHiDpi).not.toHaveBeenCalled();
          (<any>window).devicePixelRatio = 1;
          done();


### PR DESCRIPTION
Closes #949

## Changes:

- Correct bounds check to check `drawWidth/drawHeight` in a hidpi scenario
- `suppressHiDPIScaling` now also suppresses pixel ratio based scaling
