### PR TITLE
[#948] Detect when CollisionArea geometry must be recalculated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Fixed
 - Added missing variable assignments to TileMapImpl constructor ([#957](https://github.com/excaliburjs/Excalibur/pull/957))
+- Recalculate physics geometry when width/height change on Actor ([#948](https://github.com/excaliburjs/Excalibur/pull/948))
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 

--- a/sandbox/tests/physics/physics.ts
+++ b/sandbox/tests/physics/physics.ts
@@ -22,11 +22,15 @@ function spawnBlock(x: number, y: number) {
    var color = new ex.Color(ex.Util.randomIntInRange(0, 255),
                            ex.Util.randomIntInRange(0, 255),
                            ex.Util.randomIntInRange(0, 255));
-   var block = new ex.Actor(x, y, width, width, color);
+   var block = new ex.Actor(x, y, width, width + 40, color);
+   block.rotation = Math.PI / 8;
    block.body.useBoxCollision();
-   //block.rotation = Math.PI / 4;
+   
    //block.rx = .1;
    block.collisionType = ex.CollisionType.Active;
+   block.on('postcollision', () => {
+      block.sy = .1;
+   });
    game.add(block);
 }
 

--- a/sandbox/tests/physics/physics.ts
+++ b/sandbox/tests/physics/physics.ts
@@ -28,9 +28,6 @@ function spawnBlock(x: number, y: number) {
    
    //block.rx = .1;
    block.collisionType = ex.CollisionType.Active;
-   block.on('postcollision', () => {
-      block.sy = .1;
-   });
    game.add(block);
 }
 

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -984,38 +984,45 @@ export class ActorImpl extends Class implements IActionable, IEvented, IPointerE
    /**
     * Returns the actor's [[BoundingBox]] calculated for this instant in world space.
     */
-   public getBounds(): BoundingBox {
+   public getBounds(rotated: boolean = true): BoundingBox {
       // todo cache bounding box
-      var anchor = this._getCalculatedAnchor();
-      var pos = this.getWorldPos();
+      const anchor = this._getCalculatedAnchor();
+      const pos = this.getWorldPos();
 
-      return new BoundingBox(pos.x - anchor.x,
+      let bb = new BoundingBox(pos.x - anchor.x,
          pos.y - anchor.y,
          pos.x + this.getWidth() - anchor.x,
-         pos.y + this.getHeight() - anchor.y).rotate(this.rotation, pos);
+         pos.y + this.getHeight() - anchor.y); 
+         
+      return rotated ? bb.rotate(this.rotation, pos) : bb;
    }
 
    /**
-    * Returns the actor's [[BoundingBox]] relative to the actors position.
+    * Returns the actor's [[BoundingBox]] relative to the actor's position.
     */
-   public getRelativeBounds() {
+   public getRelativeBounds(rotated: boolean = true): BoundingBox {
       // todo cache bounding box
-      var anchor = this._getCalculatedAnchor();
-      return new BoundingBox(-anchor.x,
+      const anchor = this._getCalculatedAnchor();
+      let bb = new BoundingBox(-anchor.x,
          -anchor.y,
          this.getWidth() - anchor.x,
-         this.getHeight() - anchor.y).rotate(this.rotation);
+         this.getHeight() - anchor.y); 
+      
+      return rotated ? bb.rotate(this.rotation) : bb;
    }
 
    /**
-    * Return the actor's unrotated geometry
+    * Returns the actors unrotated geometry in world coordinates
     */
-   public getRelativeGeometry() {
-      var anchor = this._getCalculatedAnchor();
-      return new BoundingBox(-anchor.x,
-         -anchor.y,
-         this.getWidth() - anchor.x,
-         this.getHeight() - anchor.y).getPoints();
+   public getGeometry(): Vector[] {
+      return this.getBounds(false).getPoints();
+   }
+
+   /**
+    * Return the actor's unrotated geometry relative to the actor's position
+    */
+   public getRelativeGeometry(): Vector[] {
+      return this.getRelativeBounds(false).getPoints();
    }
 
    /**

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -1008,6 +1008,17 @@ export class ActorImpl extends Class implements IActionable, IEvented, IPointerE
    }
 
    /**
+    * Return the actor's unrotated geometry
+    */
+   public getRelativeGeometry() {
+      var anchor = this._getCalculatedAnchor();
+      return new BoundingBox(-anchor.x,
+         -anchor.y,
+         this.getWidth() - anchor.x,
+         this.getHeight() - anchor.y).getPoints();
+   }
+
+   /**
     * Indicates that the actor's collision geometry needs to be recalculated for accurate collisions
     */
    public get isGeometryDirty() {

--- a/src/engine/Collision/Body.ts
+++ b/src/engine/Collision/Body.ts
@@ -141,7 +141,7 @@ export class Body {
          if (this.actor && 
             this.actor.isGeometryDirty && 
             this.collisionArea instanceof PolygonArea) {
-            this.collisionArea.points = this.actor.getRelativeBounds().getPoints();
+            this.collisionArea.points = this.actor.getRelativeGeometry();
          }
 
          this.collisionArea.recalc();
@@ -158,7 +158,7 @@ export class Body {
 
       this.collisionArea = new PolygonArea({
          body: this,
-         points: this.actor.getRelativeBounds().getPoints(),
+         points: this.actor.getRelativeGeometry(),
          pos: center // position relative to actor
       });
 

--- a/src/engine/Collision/Body.ts
+++ b/src/engine/Collision/Body.ts
@@ -137,6 +137,13 @@ export class Body {
     */
    public update() {
       if (this.collisionArea) {
+         // Update the geometry if needed
+         if (this.actor && 
+            this.actor.isGeometryDirty && 
+            this.collisionArea instanceof PolygonArea) {
+            this.collisionArea.points = this.actor.getRelativeBounds().getPoints();
+         }
+
          this.collisionArea.recalc();
       }
    }

--- a/src/engine/Collision/BoundingBox.ts
+++ b/src/engine/Collision/BoundingBox.ts
@@ -76,7 +76,8 @@ export class BoundingBox implements ICollidable {
    }
 
    /**
-    * Rotates a bounding box by and angle and around a point, if no point is specified (0, 0) is used by default
+    * Rotates a bounding box by and angle and around a point, if no point is specified (0, 0) is used by default. The resulting bounding
+    * box is also axis-align. This is useful when a new axis-aligned bounding box is needed for rotated geometry.
     */
    public rotate(angle: number, point: Vector = Vector.Zero.clone()): BoundingBox {
       var points = this.getPoints().map((p) => p.rotate(angle, point));

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -312,6 +312,33 @@ describe('A game actor', () => {
       expect(actor.getBottom()).toBe(200);
    });
 
+   it('should have the correct world geometry if rotated and scaled', () => {
+      let actor = new ex.Actor({pos: new ex.Vector(50, 50), width: 10, height: 10});
+      actor.scale.setTo(2, 2);
+      actor.rotation = Math.PI / 2;
+
+      let geom = actor.getGeometry();
+      expect(geom.length).toBe(4);
+      expect(geom[0].equals(new ex.Vector(40, 40))).toBe(true);
+      expect(geom[1].equals(new ex.Vector(60, 40))).toBe(true);
+      expect(geom[2].equals(new ex.Vector(60, 60))).toBe(true);
+      expect(geom[3].equals(new ex.Vector(40, 60))).toBe(true);
+
+   });
+
+   it('should have the correct relative geometry if rotated and scaled', () => {
+      let actor = new ex.Actor({pos: new ex.Vector(50, 50), width: 10, height: 10});
+      actor.scale.setTo(2, 2);
+      actor.rotation = Math.PI / 2;
+
+      let geom = actor.getRelativeGeometry();
+      expect(geom.length).toBe(4);
+      expect(geom[0].equals(new ex.Vector(-10, -10))).toBe(true);
+      expect(geom[1].equals(new ex.Vector(10, -10))).toBe(true);
+      expect(geom[2].equals(new ex.Vector(10, 10))).toBe(true);
+      expect(geom[3].equals(new ex.Vector(-10, 10))).toBe(true);
+   });
+
    it('can contain points', () => {
       expect(actor.pos.x).toBe(0);
       expect(actor.pos.y).toBe(0);


### PR DESCRIPTION
Closes #948

## Changes:

- Added `isGeometryDirty` check
- Watch both height/width and scale for changes and trip recalculates
