### PR TITLE
[#953] Fix issue to comply with audio deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Fixed
 - Added missing variable assignments to TileMapImpl constructor ([#957](https://github.com/excaliburjs/Excalibur/pull/957))
+- Correct setting audio volume level from `value` to `setValueAtTime` to comply with deprecation warning in Chrome 59 ([#953](https://github.com/excaliburjs/Excalibur/pull/953))
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 

--- a/src/engine/Resources/Sound.ts
+++ b/src/engine/Resources/Sound.ts
@@ -626,7 +626,8 @@ class WebAudioInstance implements IAudio {
       this._bufferSource = audioContext.createBufferSource();
       this._bufferSource.buffer = this._buffer;
       this._bufferSource.loop = this._loop;
-      this._bufferSource.playbackRate.value = 1.0;
+      this._bufferSource.playbackRate.setValueAtTime(1.0, 0);
+      
       this._bufferSource.connect(this._volumeNode);
    }
 


### PR DESCRIPTION
Closes #953

Tested audio locally, observed no warning

## Changes:

- Switch to `setValueAtTime` instead of `value` see https://webaudio.github.io/web-audio-api/#dom-audioparam-setvalueattime
- Update changelog
