### PR TITLE
[bugfix] Prevent negative scaling in hidpi/non-hidpi hybrid scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Fixed
 - Added missing variable assignments to TileMapImpl constructor ([#957](https://github.com/excaliburjs/Excalibur/pull/957))
 - Correct setting audio volume level from `value` to `setValueAtTime` to comply with deprecation warning in Chrome 59 ([#953](https://github.com/excaliburjs/Excalibur/pull/953))
+- Force HiDPI scaling to always be at least 1 to prevent visual artifacts in some browsers
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -312,6 +312,11 @@ export class Engine extends Class implements ICanInitialize, ICanUpdate, ICanDra
       if (this._suppressHiDPIScaling) {
          return 1;
       }
+
+      if (window.devicePixelRatio < 1) {
+         return 1;
+      }
+
       let devicePixelRatio = window.devicePixelRatio || 1;
 
       let pixelRatio = devicePixelRatio;


### PR DESCRIPTION
Currently Chrome and possibly other browsers can incorrectly report the scaling as less than a pixel, which never makes sense. This seems to happen if you have monitors that are HiDPI and non-HiDPI connected at the same time. This change forces scaling to be at least 1 to prevent odd visual artifacts.

## Changes:

- Force the minimum dpi scale to be at least 1
