### PR TITLE
[#981] Fix scene remove should kill actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Changed
 - Refactored Easing functions to be reversable ([#944](https://github.com/excaliburjs/Excalibur/pull/944))
-- Scene.Remove(Actor) now starts the Actor.Kill event cycle.([#981](https://github.com/excaliburjs/Excalibur/issues/981))
+- Scene.remove(Actor) now starts the Actor.Kill event cycle.([#981](https://github.com/excaliburjs/Excalibur/issues/981))
 
 ## Deprecated
 
@@ -46,7 +46,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - New Class `GlobalCoordinates` that contains Vectors for the world, the page, and the screen.
    - Added property `ICapturePointerConfig.captureDragEvents` which controls whether to emit drag events to the actor
    - Added property `PointerEvent.pointer` which equals the original pointer object
- 
+
 ## Deprecated
 
 - `Sprite.sx`, `Sprite.sy`, `Sprite.swidth`, `Sprite.sheight` has be deprecated in favor of `Sprite.x`, `Sprite.y`, `Sprite.width`, `Sprite.height` ([#918](https://github.com/excaliburjs/Excalibur/issues/918))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Changed
 - Refactored Easing functions to be reversable ([#944](https://github.com/excaliburjs/Excalibur/pull/944))
+- Scene.Remove(Actor) now starts the Actor.Kill event cycle.([#981](https://github.com/excaliburjs/Excalibur/issues/981))
 
 ## Deprecated
 

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -702,8 +702,8 @@ export class ActorImpl extends Class implements IActionable, IEvented, IPointerE
       if (this.scene) {
          this._prekill(this.scene);
          this.emit('kill', new KillEvent(this));
-         this.scene.remove(this);
          this._isKilled = true;
+         this.scene.remove(this);
          this._postkill(this.scene);
       } else {
          this.logger.warn('Cannot kill actor, it was never added to the Scene');

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -566,9 +566,16 @@ export class Scene extends Class implements ICanInitialize, ICanActivate, ICanDe
          this.removeUIActor(entity);
          return;
       }
+      
       if (entity instanceof Actor) {
-         this._broadphase.untrack(entity.body);
-         this._removeChild(entity);
+
+         if(this._killQueue.indexOf(entity) == -1) {
+            this._removeChild(entity);
+         }
+
+         if (!entity.isKilled()) {
+            entity.kill();
+         }
       }
       if (entity instanceof Timer) {
          this.removeTimer(entity);

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -566,13 +566,9 @@ export class Scene extends Class implements ICanInitialize, ICanActivate, ICanDe
          this.removeUIActor(entity);
          return;
       }
-      
+
       if (entity instanceof Actor) {
-
-         if(this._killQueue.indexOf(entity) == -1) {
-            this._removeChild(entity);
-         }
-
+         this._removeChild(entity);
          if (!entity.isKilled()) {
             entity.kill();
          }

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -619,7 +619,7 @@ describe('A game actor', () => {
       expect(parent.contains(550, 50)).toBeTruthy();
       expect(parent.contains(650, 150)).toBeTruthy();
 
-      // in world coordinates this should be false 
+      // in world coordinates this should be false
       expect(child.contains(50, 50)).toBeFalsy();
 
       // in world coordinates this should be true
@@ -1317,7 +1317,7 @@ describe('A game actor', () => {
          let s = texture.asSprite();
          s.scale.setTo(1, 1);
          actor.addDrawing(s);
-         
+
          let a1 = new ex.Actor({scale: new ex.Vector(3, 3)});
          a1.scale.setTo(3, 3);
          a1.addDrawing(texture);
@@ -1325,22 +1325,22 @@ describe('A game actor', () => {
          let a2 = new ex.Actor({scale: new ex.Vector(3, 3)});
          a1.scale.setTo(3, 3);
          a2.addDrawing(texture);
-         
+
 
          a1.draw(engine.ctx, 100);
          a2.draw(engine.ctx, 100);
          actor.draw(engine.ctx, 100);
          engine.ctx.fillRect(0, 0, 200, 200);
-         
+
          a1.draw(engine.ctx, 100);
          a2.draw(engine.ctx, 100);
          actor.draw(engine.ctx, 100);
          engine.ctx.fillRect(0, 0, 200, 200);
-         
+
 
          a1.draw(engine.ctx, 100);
          a2.draw(engine.ctx, 100);
-         
+
          engine.ctx.clearRect(0, 0, 200, 200);
          actor.draw(engine.ctx, 100);
 
@@ -1348,12 +1348,22 @@ describe('A game actor', () => {
 
       });
    });
-   
+
+   it('when killed should not be killed again by the scene removing it', () => {
+      spyOn(actor, 'kill').and.callThrough();
+
+
+      scene.add(actor);
+      actor.kill();
+
+
+      expect(actor.kill).toHaveBeenCalledTimes(1);
+   });
 
    describe('lifecycle overrides', () => {
 
       let actor: ex.Actor = null;
-      
+
       beforeEach(() => {
          actor = new ex.Actor({
             pos: new ex.Vector(10, 10),
@@ -1365,7 +1375,7 @@ describe('A game actor', () => {
       it('can have onInitialize overriden safely', () => {
          let initCalled = false;
          actor.on('initialize', () => { initCalled = true; });
-         actor.onInitialize = (engine) => { 
+         actor.onInitialize = (engine) => {
             expect(engine).not.toBe(null);
          };
 
@@ -1378,7 +1388,7 @@ describe('A game actor', () => {
          expect(actor.onInitialize).toHaveBeenCalledTimes(1);
          expect(initCalled).toBe(true);
          expect(actor.isInitialized).toBe(true);
-         
+
       });
 
       it('can have onPostUpdate overriden safely', () => {
@@ -1395,7 +1405,7 @@ describe('A game actor', () => {
          expect(actor._postupdate).toHaveBeenCalledTimes(2);
          expect(actor.onPostUpdate).toHaveBeenCalledTimes(2);
       });
-   
+
       it('can have onPreUpdate overriden safely', () => {
          actor.onPreUpdate = (engine, delta) => {
             expect(engine).not.toBe(null);
@@ -1472,5 +1482,5 @@ describe('A game actor', () => {
       });
 
    });
- 
+
 });

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -1352,12 +1352,19 @@ describe('A game actor', () => {
    it('when killed should not be killed again by the scene removing it', () => {
       spyOn(actor, 'kill').and.callThrough();
 
+      scene.add(actor);
+      actor.kill();
+
+      expect(actor.kill).toHaveBeenCalledTimes(1);
+   });
+
+   it('when killed should be removed from the scene', () => {
+      spyOn(scene, 'remove').and.callThrough();
 
       scene.add(actor);
       actor.kill();
 
-
-      expect(actor.kill).toHaveBeenCalledTimes(1);
+      expect(scene.remove).toHaveBeenCalledWith(actor);
    });
 
    describe('lifecycle overrides', () => {

--- a/src/spec/SceneSpec.ts
+++ b/src/spec/SceneSpec.ts
@@ -127,8 +127,8 @@ describe('A scene', () => {
       var sceneInitialized = false;
       var sceneActivated = false;
       var actorInitialized = false;
-      scene.on('initialize', (evt) => { 
-         sceneInitialized = true; 
+      scene.on('initialize', (evt) => {
+         sceneInitialized = true;
          expect(actorInitialized).toBe(true, 'Actor should be initialized before scene initilization');
       });
       var actor = new ex.Actor();
@@ -286,6 +286,27 @@ describe('A scene', () => {
       expect(updated).toBe(true, 'UIActor was not updated after timer callback');
    });
 
+   it('will kill the actor if the actor is removed from the scene', () => {
+      scene.add(actor);
+
+      spyOn(actor, 'kill').and.callThrough();
+
+      scene.remove(actor);
+
+      expect(actor.isKilled()).toBe(true);
+      expect(actor.kill).toHaveBeenCalledTimes(1);
+   });
+
+   it('will not kill the actor if it is already dead', () => {
+      scene.add(actor);
+      (actor as any)._isKilled = true;
+
+      spyOn(actor, 'kill').and.callThrough();
+
+      scene.remove(actor);
+      expect(actor.kill).toHaveBeenCalledTimes(0);
+   });
+
    it('will update TileMaps that were added in a Timer callback', () => {
       var updated = false;
       var tilemap = new ex.TileMap(0, 0, 1, 1, 1, 1);
@@ -336,7 +357,7 @@ describe('A scene', () => {
 
          engine.goToScene('root');
          (<any>engine)._update(100);
-            
+
          expect(initCalled).toBe(true);
          expect(scene.onInitialize).toHaveBeenCalledTimes(1);
       });
@@ -356,7 +377,7 @@ describe('A scene', () => {
          expect(scene._postupdate).toHaveBeenCalledTimes(2);
          expect(scene.onPostUpdate).toHaveBeenCalledTimes(2);
       });
-   
+
       it('can have onPreUpdate overriden safely', () => {
          scene.onPreUpdate = (engine, delta) => {
             expect(engine).not.toBe(null);
@@ -368,7 +389,7 @@ describe('A scene', () => {
 
          scene.update(engine, 100);
          scene.update(engine, 100);
-         
+
          expect(scene._preupdate).toHaveBeenCalledTimes(2);
          expect(scene.onPreUpdate).toHaveBeenCalledTimes(2);
       });


### PR DESCRIPTION
Closes #981 

## Changes:

- Actor sets _isKilled to true before calling scene remove
- Scene.Remove calls entity.kill() if it isn't already dead (i.e. it was triggered through a process other than actor.kill()
- Scene.Remove this._broadphase.untrack(entity.body) is redudant to this._removeChild(entity) which also calls this method

## Note:
Have not created/run unit tests.  This is forthcoming.