### PR TITLE
[chore] Fix Gruntfile to be compatible with Node 6.x

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -28,12 +28,11 @@ module.exports = function(grunt) {
     //
     webpack: {
       bundle: webpackConfig,
-      bundlemin: {
-        ...webpackConfig,
+      bundlemin: Object.assign({}, webpackConfig, {
         mode: 'production',
-        output: { ...webpackConfig.output, filename: 'excalibur.min.js' }
-      },
-      watch: { ...webpackConfig, watch: true }
+        output: Object.assign({}, webpackConfig.output, { filename: 'excalibur.min.js' })
+      }),
+      watch: Object.assign({}, webpackConfig, { watch: true })
     },
 
     //


### PR DESCRIPTION
<!-- 
Hi, and thanks for contributing to Excalibur! 
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md
especially the "Submitting Changes" section: 
https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->
===PR Checklist===
- [x] issue exists in github for these changes
- [x] existing tests pass
- [x] new tests written and passing
- [x] changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #

## Changes:

- Remove object spread operator since excaliburjs/excaliburjs.github.io still is on Node 6 👎 
