### PR TITLE
[#979] prevent removal of actors that are killed and readded during the same frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix issue where Actors would not be properly added to a scene if they were removed from that scene during the same frame ([#979](https://github.com/excaliburjs/Excalibur/issues/979))
+
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 
 ## [0.17.0] - 2018-06-04

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -390,10 +390,13 @@ export class Scene extends Class implements ICanInitialize, ICanActivate, ICanDe
     // Remove actors from scene graph after being killed
     var actorIndex: number;
     for (let killed of killQueue) {
-      actorIndex = collection.indexOf(killed);
-      if (actorIndex > -1) {
-        this._sortedDrawingTree.removeByComparable(killed);
-        collection.splice(actorIndex, 1);
+      //don't remove actors that were readded during the same frame they were killed
+      if (killed.isKilled()) {
+        actorIndex = collection.indexOf(killed);
+        if (actorIndex > -1) {
+          this._sortedDrawingTree.removeByComparable(killed);
+          collection.splice(actorIndex, 1);
+        }
       }
     }
     killQueue.length = 0;


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===
- [X] :pushpin: issue exists in github for these changes 
- [X] :microscope: existing tests still pass
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [X] :page_facing_up: changelog entry added (or not needed)

Closes #979

## Changes:

- Add check to ensure Actor is still killed before removing it from drawing tree.
