### PR TITLE
[#978] Add type info for exit/enter viewport events to actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed missing `exitviewport/enterviewport` events on Actors.on/once/off signatures. ([#978](https://github.com/excaliburjs/Excalibur/issues/978))
+
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 
 ## [0.17.0] - 2018-06-04

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -19,7 +19,9 @@ import {
   PreKillEvent,
   GameEvent,
   ExitTriggerEvent,
-  EnterTriggerEvent
+  EnterTriggerEvent,
+  EnterViewPortEvent,
+  ExitViewPortEvent
 } from './Events';
 import { PointerEvent, WheelEvent, PointerDragEvent } from './Input/Pointer';
 import { Engine } from './Engine';
@@ -662,6 +664,8 @@ export class ActorImpl extends Class implements IActionable, IEvented, IPointerE
   public on(eventName: Events.pointerdragenter, handler: (event?: PointerDragEvent) => void): void;
   public on(eventName: Events.pointerdragleave, handler: (event?: PointerDragEvent) => void): void;
   public on(eventName: Events.pointerdragmove, handler: (event?: PointerDragEvent) => void): void;
+  public on(eventName: Events.enterviewport, handler: (event?: EnterViewPortEvent) => void): void;
+  public on(eventName: Events.exitviewport, handler: (event?: ExitViewPortEvent) => void): void;
   public on(eventName: string, handler: (event?: GameEvent<any>) => void): void;
   public on(eventName: string, handler: (event?: any) => void): void {
     this._checkForPointerOptIn(eventName);
@@ -727,6 +731,8 @@ export class ActorImpl extends Class implements IActionable, IEvented, IPointerE
   public once(eventName: Events.pointerdragenter, handler: (event?: PointerDragEvent) => void): void;
   public once(eventName: Events.pointerdragleave, handler: (event?: PointerDragEvent) => void): void;
   public once(eventName: Events.pointerdragmove, handler: (event?: PointerDragEvent) => void): void;
+  public once(eventName: Events.enterviewport, handler: (event?: EnterViewPortEvent) => void): void;
+  public once(eventName: Events.exitviewport, handler: (event?: ExitViewPortEvent) => void): void;
   public once(eventName: string, handler: (event?: GameEvent<any>) => void): void;
   public once(eventName: string, handler: (event?: any) => void): void {
     this._checkForPointerOptIn(eventName);
@@ -789,6 +795,8 @@ export class ActorImpl extends Class implements IActionable, IEvented, IPointerE
   public off(eventName: Events.preupdate, handler?: (event?: Events.PreUpdateEvent) => void): void;
   public off(eventName: Events.postdraw, handler?: (event?: Events.PostDrawEvent) => void): void;
   public off(eventName: Events.predraw, handler?: (event?: Events.PreDrawEvent) => void): void;
+  public off(eventName: Events.enterviewport, handler?: (event?: EnterViewPortEvent) => void): void;
+  public off(eventName: Events.exitviewport, handler?: (event?: ExitViewPortEvent) => void): void;
   public off(eventName: string, handler?: (event?: GameEvent<any>) => void): void;
   public off(eventName: string, handler?: (event?: any) => void): void {
     super.off(eventName, handler);


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===
- [X] :pushpin: issue exists in github for these changes 
- [X] :microscope: existing tests still pass
- [ ] :triangular_ruler: ~~new tests written and passing / old tests updated with new scenario(s)~~
- [x] :page_facing_up: changelog entry added (or not needed)

Closes #978

## Changes:

- No behavioral changes, just surfaces type info for events that currently need to be handled more "manually". Let me know if this still needs a CHANGELOG entry.
