### PR TITLE
Split issue templates into separate files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,12 +34,8 @@ Before reporting a bug, please perform the following basic troubleshooting steps
 4. Try different browsers
 	- The problem you’re seeing may only appear in certain browsers or mobile devices. If you can, please try several different browsers/platforms to see if the issue persists.
 
-When you submit an issue, a markdown template will automatically populate the editor window. Remove the “Other Issues Template” and fill out the “Bug Template”. We’ve included helpful hints for filling out the bug report in the template.
-
 ## Suggesting Improvements
-If you have an idea for a new feature, or an improvement to existing functionality, use the “Other Issues” Template. We’ve included helpful hints for filling out the issue in the template. 
-
-Please look through our [backlog][issues] to see if your improvement has already been suggested. If so, feel free to provide additional comments or thoughts on the existing issue.
+Please do a quick search through our [backlog][issues] to see if your improvement has already been suggested. If so, feel free to provide additional comments or thoughts on the existing issue.
 
 ## Submitting Changes
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,17 +1,21 @@
+---
+name: Bug Report
+about: Something not working as expected? Tell us about it!
+---
+
 <!-- ::: IMPORTANT NOTE ::: 
 
 Hi, this is the Excalibur development team. Please take a moment to read the instructions below:
 
 Please ask any questions you have in our forum: https://groups.google.com/forum/#!forum/excaliburjs
 
-Please do not file a Github issue until you've read through and understand the contributing guidelines. If you're not sure if you should submit an issue, ask your question in the forum linked above.
+Please wait to file a Github issue until after you've read through and understand the contributing guidelines. If you're not sure if you should submit an issue, ask your question in the forum linked above.
 https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#reporting-bugs
-https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#suggesting-improvements
 -->
 
-<!-- BUG TEMPLATE-->
-<!-- If you are submitting a bug, fill out this template and delete the one below it -->
+<!-- Please follow the format below to make it easier for us to help you -->
 <!-- Add relevant pictures/gifs as appropriate -->
+
 ### Steps to Reproduce
 <!-- Detailed steps for reproducing the problem -->
 <!-- If possible, please include a self-contained code snippet that demonstrates the problem -->
@@ -23,7 +27,7 @@ https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#sug
 <!-- What happened instead -->
 
 ### Environment
-<!-- Please fill out all of these fields -->
+<!-- Please fill out these fields -->
 - browsers and versions: <!-- e.x. Chrome (50.0.2883.87), Firefox (50.1.0), Edge (38.14393.0.0), etc. -->
 - operating system: <!-- What OS are you using? -->
 - Excalibur versions: <!-- which version(s) of Excalibur contain the bug?-->
@@ -31,16 +35,3 @@ https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#sug
 
 ### Current Workaround
 <!-- If you have determined a workaround for this issue, please detail it here -->
-
-
-<!---------------------------------------->
-
-<!-- OTHER ISSUES TEMPLATE -->
-<!-- If you are submitting any other type of issue, use this template and delete the one above it -->
-
-### Context
-<!-- Explain the background information for this issue -->
-
-### Proposal
-<!-- Your idea for the new feature, improvement, etc. -->
-<!-- If you have any ideas for implementation or next steps, add those also -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+---
+
+<!-- ::: IMPORTANT NOTE ::: 
+
+Hi, this is the Excalibur development team. Please take a moment to read the instructions below:
+
+Please ask any questions you have in our forum: https://groups.google.com/forum/#!forum/excaliburjs
+
+Please wait to file a Github issue until after you've read through and understand the contributing guidelines. If you're not sure if you should submit an issue, ask your question in the forum linked above.
+https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#suggesting-improvements
+-->
+
+<!-- Please do a quick search through our [backlog][issues] to see if your improvement has already been suggested. If so, feel free to provide additional comments or thoughts on the existing issue. -->
+
+<!-- Please follow the format below to make it easier for us to help you -->
+<!-- Add relevant pictures/gifs as appropriate -->
+
+### Context
+<!-- Explain the background information for this request -->
+
+### Proposal
+<!-- Your idea for the new feature, improvement, etc. -->
+<!-- If you have any ideas for implementation or next steps, add those here -->


### PR DESCRIPTION
It looks like GitHub has added [UI-based support](https://blog.github.com/2018-05-02-issue-template-improvements/) for multiple issues templates (previously only available  via [query strings](https://blog.github.com/2018-01-25-multiple-issue-and-pull-request-templates/)).


![image](https://user-images.githubusercontent.com/675840/42982364-a11247de-8ba6-11e8-8b5c-25ac8884bc62.png)
