### PR TITLE
[#975] Fix collision pair generation to ensure ordering doesnt matter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed issue where sprites do not work in Firefox ([#980](https://github.com/excaliburjs/Excalibur/issues/978))
+- Fixed issue where collision pairs could sometimes be incorrect ([#975](https://github.com/excaliburjs/Excalibur/issues/975))
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -12,6 +12,7 @@
       <li><a href="tests/animation/animation.html">Animations</a></li>
       <li><a href="tests/culling/culling.html">Sprite Culling</a></li>
       <li><a href="tests/sprite/sprite.html">Sprite</a></li>
+      <li><a href="tests/kill/kill.html">Kill</a></li>
       <li><a href="tests/input/index.html"> Input</a></li>
       <li><a href="tests/input/keyboard.html">Keyboard Input</a></li>
       <li><a href="tests/loader/pauseafter/index.html">Loader - PauseAfterLoader</a></li>

--- a/sandbox/tests/kill/kill.html
+++ b/sandbox/tests/kill/kill.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+   <meta charset="UTF-8">
+   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+   <meta http-equiv="X-UA-Compatible" content="ie=edge">
+   <title>Kill test</title>
+</head>
+<body>
+   <canvas id="game"></canvas>
+   <br/>
+   Actors should be removed when they collide with top
+   <script src="../../lib/excalibur.js"></script>
+   <script src="kill.js"></script>
+</body>
+</html>

--- a/sandbox/tests/kill/kill.ts
+++ b/sandbox/tests/kill/kill.ts
@@ -1,0 +1,40 @@
+/// <reference path='../../lib/excalibur.d.ts' />
+
+var game = new ex.Engine({ width: 800, height: 300, canvasElementId: 'game' });
+
+var topActor = new ex.Actor({
+  x: game.halfDrawWidth,
+  y: 0,
+  width: game.drawWidth,
+  height: 20,
+  collisionType: ex.CollisionType.Fixed,
+  color: ex.Color.Black
+});
+
+game.add(topActor);
+
+var spawnTimer = new ex.Timer(
+  () => {
+    let a = new ex.Actor({
+      x: game.halfDrawWidth,
+      y: game.halfDrawHeight,
+      width: 10,
+      height: 10,
+      color: ex.Color.Red,
+      vel: new ex.Vector(100, 0).rotate(ex.Util.randomInRange(0, Math.PI * 2)),
+      collisionType: ex.CollisionType.Active
+    });
+    a.on('exitviewport', () => a.kill());
+    a.on('precollision', () => {
+      a.kill();
+      console.log('boom!');
+    });
+    game.add(a);
+  },
+  200,
+  true,
+  -1
+);
+
+game.add(spawnTimer);
+game.start();

--- a/src/engine/Collision/DynamicTreeCollisionBroadphase.ts
+++ b/src/engine/Collision/DynamicTreeCollisionBroadphase.ts
@@ -40,7 +40,7 @@ export class DynamicTreeCollisionBroadphase implements ICollisionBroadphase {
     this._dynamicCollisionTree.untrackBody(target);
   }
 
-  private _canCollide(actorA: Actor, actorB: Actor) {
+  private _shouldGenerateCollisionPair(actorA: Actor, actorB: Actor) {
     // if the collision pair has been calculated already short circuit
     var hash = Pair.calculatePairHash(actorA.body, actorB.body);
     if (this._collisionHash[hash]) {
@@ -52,8 +52,13 @@ export class DynamicTreeCollisionBroadphase implements ICollisionBroadphase {
       return false;
     }
 
-    // if the other is prevent collision or is dead short circuit
-    if (actorB.collisionType === CollisionType.PreventCollision || actorB.isKilled()) {
+    // if the either is prevent collision short circuit
+    if (actorB.collisionType === CollisionType.PreventCollision || actorA.collisionType === CollisionType.PreventCollision) {
+      return false;
+    }
+
+    // if either is dead short circuit
+    if (actorA.isKilled() || actorB.isKilled()) {
       return false;
     }
 
@@ -83,7 +88,7 @@ export class DynamicTreeCollisionBroadphase implements ICollisionBroadphase {
 
       // Query the collision tree for potential colliders
       this._dynamicCollisionTree.query(actor.body, (other: Body) => {
-        if (this._canCollide(actor, other.actor)) {
+        if (this._shouldGenerateCollisionPair(actor, other.actor)) {
           var pair = new Pair(actor.body, other);
           this._collisionHash[pair.id] = true;
           this._collisionPairCache.push(pair);

--- a/src/engine/Collision/DynamicTreeCollisionBroadphase.ts
+++ b/src/engine/Collision/DynamicTreeCollisionBroadphase.ts
@@ -47,23 +47,7 @@ export class DynamicTreeCollisionBroadphase implements ICollisionBroadphase {
       return false; // pair exists easy exit return false
     }
 
-    // if both are fixed short circuit
-    if (actorA.collisionType === CollisionType.Fixed && actorB.collisionType === CollisionType.Fixed) {
-      return false;
-    }
-
-    // if the either is prevent collision short circuit
-    if (actorB.collisionType === CollisionType.PreventCollision || actorA.collisionType === CollisionType.PreventCollision) {
-      return false;
-    }
-
-    // if either is dead short circuit
-    if (actorA.isKilled() || actorB.isKilled()) {
-      return false;
-    }
-
-    // they can collide
-    return true;
+    return Pair.canCollide(actorA, actorB);
   }
 
   /**

--- a/src/engine/Collision/Pair.ts
+++ b/src/engine/Collision/Pair.ts
@@ -2,7 +2,7 @@ import { Physics } from './../Physics';
 import { Color } from './../Drawing/Color';
 import { Body } from './Body';
 import { CollisionContact } from './CollisionContact';
-import { CollisionType } from '../Actor';
+import { CollisionType, Actor } from '../Actor';
 import { CollisionResolutionStrategy } from '../Physics';
 import * as DrawUtil from '../Util/DrawUtil';
 
@@ -17,23 +17,32 @@ export class Pair {
     this.id = Pair.calculatePairHash(bodyA, bodyB);
   }
 
+  public static canCollide(actorA: Actor, actorB: Actor) {
+    // if both are fixed short circuit
+    if (actorA.collisionType === CollisionType.Fixed && actorB.collisionType === CollisionType.Fixed) {
+      return false;
+    }
+
+    // if the either is prevent collision short circuit
+    if (actorB.collisionType === CollisionType.PreventCollision || actorA.collisionType === CollisionType.PreventCollision) {
+      return false;
+    }
+
+    // if either is dead short circuit
+    if (actorA.isKilled() || actorB.isKilled()) {
+      return false;
+    }
+
+    return true;
+  }
+
   /**
    * Returns whether or not it is possible for the pairs to collide
    */
   public get canCollide(): boolean {
     let actorA = this.bodyA.actor;
     let actorB = this.bodyB.actor;
-    // if both are fixed short circuit
-    if (actorA.collisionType === CollisionType.Fixed && actorB.collisionType === CollisionType.Fixed) {
-      return false;
-    }
-
-    // if the other is prevent collision or is dead short circuit
-    if (actorB.collisionType === CollisionType.PreventCollision || actorB.isKilled()) {
-      return false;
-    }
-
-    return true;
+    return Pair.canCollide(actorA, actorB);
   }
 
   /**

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -575,9 +575,6 @@ export class Scene extends Class implements ICanInitialize, ICanActivate, ICanDe
 
     if (entity instanceof Actor) {
       this._removeChild(entity);
-      if (!entity.isKilled()) {
-        entity.kill();
-      }
     }
     if (entity instanceof Timer) {
       this.removeTimer(entity);
@@ -644,10 +641,16 @@ export class Scene extends Class implements ICanInitialize, ICanActivate, ICanDe
    * Removes an actor from the scene, it will no longer be drawn or updated.
    */
   protected _removeChild(actor: Actor) {
+    if (!Util.contains(this.actors, actor)) {
+      return;
+    }
     this._broadphase.untrack(actor.body);
     if (actor instanceof Trigger) {
       this._triggerKillQueue.push(actor);
     } else {
+      if (!actor.isKilled()) {
+        actor.kill();
+      }
       this._killQueue.push(actor);
     }
 

--- a/src/spec/CollisionSpec.ts
+++ b/src/spec/CollisionSpec.ts
@@ -50,6 +50,91 @@ describe('A Collision', () => {
     expect(actor2Collision).toBe(1);
   });
 
+  it('should order of actors collision should not matter when an Active and Active Collision', () => {
+    let collisionTree = new ex.DynamicTreeCollisionBroadphase();
+
+    actor1.collisionType = ex.CollisionType.Active;
+    actor2.collisionType = ex.CollisionType.Active;
+    collisionTree.track(actor1.body);
+    collisionTree.track(actor2.body);
+
+    let pairs = collisionTree.broadphase([actor1, actor2], 200);
+
+    expect(pairs.length).toBe(1);
+
+    pairs = collisionTree.broadphase([actor2, actor1], 200);
+
+    expect(pairs.length).toBe(1);
+  });
+
+  it('should order of actors collision should not matter when an Active and Passive Collision', () => {
+    let collisionTree = new ex.DynamicTreeCollisionBroadphase();
+
+    actor1.collisionType = ex.CollisionType.Active;
+    actor2.collisionType = ex.CollisionType.Passive;
+    collisionTree.track(actor1.body);
+    collisionTree.track(actor2.body);
+
+    let pairs = collisionTree.broadphase([actor1, actor2], 200);
+
+    expect(pairs.length).toBe(1);
+
+    pairs = collisionTree.broadphase([actor2, actor1], 200);
+
+    expect(pairs.length).toBe(1);
+  });
+
+  it('should order of actors collision should not matter when an Active and PreventCollision', () => {
+    let collisionTree = new ex.DynamicTreeCollisionBroadphase();
+
+    actor1.collisionType = ex.CollisionType.Active;
+    actor2.collisionType = ex.CollisionType.PreventCollision;
+    collisionTree.track(actor1.body);
+    collisionTree.track(actor2.body);
+
+    let pairs = collisionTree.broadphase([actor1, actor2], 200);
+
+    expect(pairs.length).toBe(0);
+
+    pairs = collisionTree.broadphase([actor2, actor1], 200);
+
+    expect(pairs.length).toBe(0);
+  });
+
+  it('should order of actors collision should not matter when an Active and Fixed', () => {
+    let collisionTree = new ex.DynamicTreeCollisionBroadphase();
+
+    actor1.collisionType = ex.CollisionType.Active;
+    actor2.collisionType = ex.CollisionType.Fixed;
+    collisionTree.track(actor1.body);
+    collisionTree.track(actor2.body);
+
+    let pairs = collisionTree.broadphase([actor1, actor2], 200);
+
+    expect(pairs.length).toBe(1);
+
+    pairs = collisionTree.broadphase([actor2, actor1], 200);
+
+    expect(pairs.length).toBe(1);
+  });
+
+  it('should order of actors collision should not matter when an Fixed and Fixed', () => {
+    let collisionTree = new ex.DynamicTreeCollisionBroadphase();
+
+    actor1.collisionType = ex.CollisionType.Fixed;
+    actor2.collisionType = ex.CollisionType.Fixed;
+    collisionTree.track(actor1.body);
+    collisionTree.track(actor2.body);
+
+    let pairs = collisionTree.broadphase([actor1, actor2], 200);
+
+    expect(pairs.length).toBe(0);
+
+    pairs = collisionTree.broadphase([actor2, actor1], 200);
+
+    expect(pairs.length).toBe(0);
+  });
+
   it('should only trigger one collision event per actor when an Active and Passive collide', () => {
     var actor1Collision = 0;
     var actor2Collision = 0;

--- a/src/spec/CollisionSpec.ts
+++ b/src/spec/CollisionSpec.ts
@@ -50,7 +50,7 @@ describe('A Collision', () => {
     expect(actor2Collision).toBe(1);
   });
 
-  it('should order of actors collision should not matter when an Active and Active Collision', () => {
+  it('order of actors collision should not matter when an Active and Active Collision', () => {
     let collisionTree = new ex.DynamicTreeCollisionBroadphase();
 
     actor1.collisionType = ex.CollisionType.Active;
@@ -67,7 +67,7 @@ describe('A Collision', () => {
     expect(pairs.length).toBe(1);
   });
 
-  it('should order of actors collision should not matter when an Active and Passive Collision', () => {
+  it('order of actors collision should not matter when an Active and Passive Collision', () => {
     let collisionTree = new ex.DynamicTreeCollisionBroadphase();
 
     actor1.collisionType = ex.CollisionType.Active;
@@ -84,7 +84,7 @@ describe('A Collision', () => {
     expect(pairs.length).toBe(1);
   });
 
-  it('should order of actors collision should not matter when an Active and PreventCollision', () => {
+  it('order of actors collision should not matter when an Active and PreventCollision', () => {
     let collisionTree = new ex.DynamicTreeCollisionBroadphase();
 
     actor1.collisionType = ex.CollisionType.Active;
@@ -101,7 +101,7 @@ describe('A Collision', () => {
     expect(pairs.length).toBe(0);
   });
 
-  it('should order of actors collision should not matter when an Active and Fixed', () => {
+  it('order of actors collision should not matter when an Active and Fixed', () => {
     let collisionTree = new ex.DynamicTreeCollisionBroadphase();
 
     actor1.collisionType = ex.CollisionType.Active;
@@ -118,7 +118,7 @@ describe('A Collision', () => {
     expect(pairs.length).toBe(1);
   });
 
-  it('should order of actors collision should not matter when an Fixed and Fixed', () => {
+  it('order of actors collision should not matter when an Fixed and Fixed', () => {
     let collisionTree = new ex.DynamicTreeCollisionBroadphase();
 
     actor1.collisionType = ex.CollisionType.Fixed;

--- a/src/spec/SceneSpec.ts
+++ b/src/spec/SceneSpec.ts
@@ -329,6 +329,15 @@ describe('A scene', () => {
     expect(actor.kill).toHaveBeenCalledTimes(0);
   });
 
+  it('will remove an actor from a scene if actor is killed', () => {
+    scene.add(actor);
+    spyOn(scene, 'remove').and.callThrough();
+
+    actor.kill();
+    expect(scene.remove).toHaveBeenCalledTimes(1);
+    expect(actor.isKilled()).toBe(true);
+  });
+
   it('will update TileMaps that were added in a Timer callback', () => {
     var updated = false;
     var tilemap = new ex.TileMap(0, 0, 1, 1, 1, 1);


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===
- [x] :pushpin: issue exists in github for these changes 
- [x] :microscope: existing tests still pass
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #975

## Changes:

- Checks both sides of the collision
- Handles edge case with kill
- Adds tests
