### PR TITLE
[#1036] Fix typo in features.rst in rigid body bullet point

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -12,7 +12,7 @@ to build and design your games:
 - Full HTML5 Gamepad API support
 - Full keyboard, mouse, and touch support using a unified Pointers API
 - Support for basic collisions
-- Support for rigid body physics system <https://excaliburjs.com/docs/api/edge/classes/_physics_.physics.html>`_
+- Support for `rigid body physics system <https://excaliburjs.com/docs/api/edge/classes/_physics_.physics.html>`_
 - Cross-platform support using `Electron <http://electron.atom.io/>`_ or `Apache Cordova <https://cordova.apache.org/>`_
 - Simple ``update``/``draw`` pattern to keep logic and drawing separated
 - Simple ``Actor`` model with ``Scenes``, Actions API, cameras, and more


### PR DESCRIPTION
<!-- 
Hi, and thanks for contributing to Excalibur! 
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md
especially the "Submitting Changes" section: 
https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->
===:clipboard: PR Checklist :clipboard:===
- [x] :pushpin: issue exists in github for these changes 
- [x] :microscope: existing tests still pass
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #1036 

## Changes:

- Adds missing back-tick to features doc bullet point about rigid body physics
