### PR TITLE
[#1066] Add EventTypes enum to Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added strongly typed EvenTypes enum to Events.ts to avoid magic strings [#1066](https://github.com/excaliburjs/Excalibur/issues/1058)
+
 ### Changed
 
 - Added parameter on SpriteSheet constructor so you can define how many pixel spacing is between sprites ([#1058] https://github.com/excaliburjs/Excalibur/issues/1058)

--- a/src/engine/Events.ts
+++ b/src/engine/Events.ts
@@ -9,6 +9,78 @@ import { Side } from './Collision/Side';
 import * as Input from './Input/Index';
 import { Pair, BaseCamera } from './index';
 
+export enum EventTypes {
+  Kill = 'kill',
+  PreKill = 'prekill',
+  PostKill = 'postkill',
+
+  PreDraw = 'predraw',
+  PostDraw = 'postdraw',
+
+  PreDebugDraw = 'predebugdraw',
+  PostDebugDraw = 'postdebugdraw',
+
+  PreUpdate = 'preupdate',
+  PostUpdate = 'postupdate',
+
+  PreFrame = 'preframe',
+  PostFrame = 'postframe',
+
+  PreCollision = 'precollision',
+  CollisionStart = 'collisionstart',
+  CollisionEnd = 'collisionend',
+  PostCollision = 'postcollision',
+
+  Initialize = 'initialize',
+  Activate = 'activate',
+  Deactivate = 'deactivate',
+
+  ExitViewport = 'exitviewport',
+  EnterViewport = 'enterviewport',
+
+  ExitTrigger = 'exit',
+  EnterTrigger = 'enter',
+
+  Connect = 'connect',
+  Disconnect = 'disconnect',
+  Button = 'button',
+  Axis = 'axis',
+
+  Subscribe = 'subscribe',
+  Unsubscribe = 'unsubscribe',
+
+  Visible = 'visible',
+  Hidden = 'hidden',
+  Start = 'start',
+  Stop = 'stop',
+
+  PointerUp = 'pointerup',
+  PointerDown = 'pointerdown',
+  PointerMove = 'pointermove',
+  PointerEnter = 'pointerenter',
+  PointerLeave = 'pointerleave',
+  PointerCancel = 'pointercancel',
+  PointerWheel = 'pointerwheel',
+
+  Up = 'up',
+  Down = 'down',
+  Move = 'move',
+  Enter = 'enter',
+  Leave = 'leave',
+  Cancel = 'cancel',
+  Wheel = 'wheel',
+
+  Press = 'press',
+  Release = 'release',
+  Hold = 'hold',
+
+  PointerDragStart = 'pointerdragstart',
+  PointerDragEnd = 'pointerdragend',
+  PointerDragEnter = 'pointerdragenter',
+  PointerDragLeave = 'pointerdragleave',
+  PointerDragMove = 'pointerdragmove'
+}
+
 /* istanbul ignore next */
 /* compiler only: these are internal to lib */
 export type kill = 'kill';


### PR DESCRIPTION
<!-- 
Hi, and thanks for contributing to Excalibur! 
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md
especially the "Submitting Changes" section: 
https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->
===:clipboard: PR Checklist :clipboard:===
- [x] :pushpin: issue exists in github for these changes 
- [x] :microscope: existing tests still pass
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #1066

## Changes:

- Added EvenTypes enum to Events.ts


First time PR Questions:

- Not sure how to test this - if there is a place where I can drop in the enum values to make sure it's encluded do let me know.

- Additionally - I noticed that there two events mapping to the same string value - `EventType.Enter` as well as `EventType.EnterTrigger` - what's the reason for this?
- Do I need to open an issue for this?
- Do I update the changelog?

Tested locally - with this simple scenario and seems good. 
![image](https://user-images.githubusercontent.com/1144752/48315193-fddbe000-e5ca-11e8-8460-fc780d133b3c.png)

![image](https://user-images.githubusercontent.com/1144752/48315249-a38f4f00-e5cb-11e8-9ba4-cd7dd48fa718.png)
