### PR TITLE
[#1078] Fix issue early offscreen culling related to zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue of early offscreen culling related to zooming in and out [#1078](https://github.com/excaliburjs/Excalibur/issues/1078)
+
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 
 ## [0.20.0] - 2018-12-10

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -11,6 +11,7 @@
       <li><a href="html/index.html">Sandbox Platformer</a></li>
       <li><a href="tests/animation/animation.html">Animations</a></li>
       <li><a href="tests/culling/culling.html">Sprite Culling</a></li>
+      <li><a href="tests/culling/culling2.html">Zoom Culling</a></li>
       <li><a href="tests/sprite/sprite.html">Sprite</a></li>
       <li><a href="tests/kill/kill.html">Kill</a></li>
       <li><a href="tests/input/index.html"> Input</a></li>

--- a/sandbox/tests/culling/culling2.html
+++ b/sandbox/tests/culling/culling2.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Actor Culling Test on Zoom</title>
+</head>
+<body>
+    <canvas id="game"></canvas>
+    <script src="../../lib/excalibur.js"></script>
+    <script src="culling2.js"></script>
+    <p>Actors should stay onscreen and not be culled early or late</p>
+    <p>Check the console, onscreen should be printed when onscreen, and offscreen when offscreen.</p>
+</body>
+</html>

--- a/sandbox/tests/culling/culling2.ts
+++ b/sandbox/tests/culling/culling2.ts
@@ -1,0 +1,60 @@
+/// <reference path='../../lib/excalibur.d.ts' />
+var game = new ex.Engine({
+  canvasElementId: 'game',
+  width: 400,
+  height: 400,
+  backgroundColor: ex.Color.fromHex('454545')
+});
+
+// let background = new ex.Actor(
+//   game.canvasWidth / 2,
+//   game.canvasHeight / 2,
+//   game.canvasWidth,
+//   game.canvasHeight,
+//   ex.Color.fromHex('454545')
+// );
+// game.add(background);
+
+let person = new ex.Actor(275, 250, 15, 15, ex.Color.White);
+game.add(person);
+
+let soontobeoffscreen = new ex.Actor(375, 250, 15, 15, ex.Color.White);
+game.add(soontobeoffscreen);
+soontobeoffscreen.on('exitviewport', () => {
+  console.log('offscreen');
+});
+
+soontobeoffscreen.on('enterviewport', () => {
+  console.log('onscreen');
+});
+
+// for (let i = 0 ; i < 10 ; i++) {
+//   let yPos = (i + 1 ) * 10;
+//   let line = new ex.Actor(game.canvasWidth / 2, (game.canvasHeight / 100) * yPos, game.canvasWidth, 1, ex.Color.White);
+//   game.add(line);
+// }
+
+// for (let i = 0; i < 12 ; i++) {
+//   let pos = i + 1;
+//   let yPos = pos + 1;
+//   let x = (i * 40);
+//   let y = game.canvasHeight / 2;
+//   var label = new ex.Label(':)', x, y, '10px Arial');
+//   label.color = ex.Color.White;
+//   label.fontFamily = 'Arial';
+//   label.fontSize = 20;
+//   game.add(label);
+// }
+game.start();
+
+// loop zooming in and out
+let zoomed = false;
+setInterval(() => {
+  if (zoomed) {
+    game.currentScene.camera.zoom(1, 3500);
+    zoomed = false;
+  } else {
+    game.currentScene.camera.zoom(2, 3500);
+    zoomed = true;
+  }
+}, 4000);

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -7,6 +7,7 @@ import { removeItemFromArray } from './Util/Util';
 import { ICanUpdate, ICanInitialize } from './Interfaces/LifecycleEvents';
 import { PreUpdateEvent, PostUpdateEvent, GameEvent, InitializeEvent } from './Events';
 import { Class } from './Class';
+import { BoundingBox } from './Collision/BoundingBox';
 
 /**
  * Interface that describes a custom camera strategy for tracking targets
@@ -377,6 +378,19 @@ export class BaseCamera extends Class implements ICanUpdate, ICanInitialize {
   }
 
   /**
+   * Gets the boundingbox of the viewport of this camera in world coordinates
+   */
+  public get viewport(): BoundingBox {
+    if (this._engine) {
+      let halfWidth = this._engine.halfDrawWidth;
+      let halfHeight = this._engine.halfDrawHeight;
+
+      return new BoundingBox(this.x - halfHeight, this.y - halfHeight, this.x + halfWidth, this.y + halfHeight);
+    }
+    return new BoundingBox(0, 0, 0, 0);
+  }
+
+  /**
    * Adds a new camera strategy to this camera
    * @param cameraStrategy Instance of an [[ICameraStrategy]]
    */
@@ -439,6 +453,7 @@ export class BaseCamera extends Class implements ICanUpdate, ICanInitialize {
     // Overridable
   }
 
+  private _engine: Engine;
   private _isInitialized = false;
   public get isInitialized() {
     return this._isInitialized;
@@ -449,6 +464,7 @@ export class BaseCamera extends Class implements ICanUpdate, ICanInitialize {
       this.onInitialize(_engine);
       super.emit('initialize', new InitializeEvent(_engine, this));
       this._isInitialized = true;
+      this._engine = _engine;
     }
   }
 

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -311,6 +311,10 @@ export class Scene extends Class implements ICanInitialize, ICanActivate, ICanDe
    */
   public update(engine: Engine, delta: number) {
     this._preupdate(engine, delta);
+    if (this.camera) {
+      this.camera.update(engine, delta);
+    }
+
     var i: number, len: number;
     // Remove timers in the cancel queue before updating them
     for (i = 0, len = this._cancelQueue.length; i < len; i++) {
@@ -378,10 +382,6 @@ export class Scene extends Class implements ICanInitialize, ICanActivate, ICanDe
 
     this._processKillQueue(this._killQueue, this.actors);
     this._processKillQueue(this._triggerKillQueue, this.triggers);
-
-    if (this.camera) {
-      this.camera.update(engine, delta);
-    }
 
     this._postupdate(engine, delta);
   }

--- a/src/engine/Traits/OffscreenCulling.ts
+++ b/src/engine/Traits/OffscreenCulling.ts
@@ -2,53 +2,28 @@ import { CullingBox } from './../Util/CullingBox';
 import { IActorTrait } from '../Interfaces/IActorTrait';
 import { Actor } from '../Actor';
 import { Engine } from '../Engine';
-import { Vector } from '../Algebra';
 import { ExitViewPortEvent, EnterViewPortEvent } from '../Events';
 
 export class OffscreenCulling implements IActorTrait {
   public cullingBox: CullingBox = new CullingBox();
 
   public update(actor: Actor, engine: Engine) {
-    var eventDispatcher = actor.eventDispatcher;
-    var anchor = actor.anchor;
-    var globalScale = actor.getGlobalScale();
-    var width = (globalScale.x * actor.getWidth()) / actor.scale.x;
-    var height = (globalScale.y * actor.getHeight()) / actor.scale.y;
-    var cameraPos = engine.currentScene.camera.pos;
-    var worldPos = actor.getWorldPos();
-    var actorScreenCoords = engine.worldToScreenCoordinates(new Vector(worldPos.x - anchor.x * width, worldPos.y - anchor.y * height));
-    var cameraScreenCoords = engine.worldToScreenCoordinates(cameraPos);
+    const events = actor.eventDispatcher;
 
-    var zoom = 1.0;
-    if (actor.scene && actor.scene.camera) {
-      zoom = Math.abs(actor.scene.camera.getZoom());
-    }
-
-    var isSpriteOffScreen = true;
+    let isSpriteOffScreen = true;
     if (actor.currentDrawing != null) {
       isSpriteOffScreen = this.cullingBox.isSpriteOffScreen(actor, engine);
     }
+    let actorBoundsOffscreen = !engine.currentScene.camera.viewport.collides(actor.getBounds(true));
 
     if (!actor.isOffScreen) {
-      if (
-        (actorScreenCoords.x + width * zoom < 0 ||
-          actorScreenCoords.y + height * zoom < 0 ||
-          actorScreenCoords.x > engine.halfDrawWidth + cameraScreenCoords.x ||
-          actorScreenCoords.y > engine.halfDrawHeight + cameraScreenCoords.y) &&
-        isSpriteOffScreen
-      ) {
-        eventDispatcher.emit('exitviewport', new ExitViewPortEvent(actor));
+      if (actorBoundsOffscreen && isSpriteOffScreen) {
+        events.emit('exitviewport', new ExitViewPortEvent(actor));
         actor.isOffScreen = true;
       }
     } else {
-      if (
-        (actorScreenCoords.x + width * zoom > 0 &&
-          actorScreenCoords.y + height * zoom > 0 &&
-          actorScreenCoords.x < engine.halfDrawWidth + cameraScreenCoords.x &&
-          actorScreenCoords.y < engine.halfDrawHeight + cameraScreenCoords.y) ||
-        !isSpriteOffScreen
-      ) {
-        eventDispatcher.emit('enterviewport', new EnterViewPortEvent(actor));
+      if (!actorBoundsOffscreen || !isSpriteOffScreen) {
+        events.emit('enterviewport', new EnterViewPortEvent(actor));
         actor.isOffScreen = false;
       }
     }


### PR DESCRIPTION
<!-- 
Hi, and thanks for contributing to Excalibur! 
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md
especially the "Submitting Changes" section: 
https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->
===:clipboard: PR Checklist :clipboard:===
- [x] :pushpin: issue exists in github for these changes 
- [x] :microscope: existing tests still pass
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1078

## Changes:

- Add new `viewport` property to camera to return a world space bounding box of the current visible area
- Add visual tests

## TODO:

* [ ] Add unit test w/ image diff
* [ ] Refactor cullbox on sprites to use bounding boxes
