### PR TITLE
[#1085]  Update ex.Color and ex.Vector constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Updated `ex.Color` and `ex.Vector` constants to be static getters that return new instances each time, eliminating a source of bugs in excalibur [#1085](https://github.com/excaliburjs/Excalibur/issues/1085)
+
 ### Deprecated
 
 ### Fixed

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -92,7 +92,7 @@ export class ActorImpl extends Class implements IActionable, IEvented, IPointerE
    * Indicates the next id to be set
    */
   public static defaults: IActorDefaults = {
-    anchor: Vector.Half.clone()
+    anchor: Vector.Half
   };
   /**
    * Indicates the next id to be set
@@ -212,7 +212,7 @@ export class ActorImpl extends Class implements IActionable, IEvented, IPointerE
   /**
    * Gets/sets the acceleration of the actor from the last frame. This does not include the global acc [[Physics.acc]].
    */
-  public oldAcc: Vector = Vector.Zero.clone();
+  public oldAcc: Vector = Vector.Zero;
 
   /**
    * Gets the acceleration vector of the actor in pixels/second/second. An acceleration pointing down such as (0, 100) may be
@@ -348,12 +348,12 @@ export class ActorImpl extends Class implements IActionable, IEvented, IPointerE
   /**
    * The scale vector of the actor
    */
-  public scale: Vector = Vector.One.clone();
+  public scale: Vector = Vector.One;
 
   /**
    * The scale of the actor last frame
    */
-  public oldScale: Vector = Vector.One.clone();
+  public oldScale: Vector = Vector.One;
 
   /**
    * The x scalar velocity of the actor in scale/second

--- a/src/engine/Algebra.ts
+++ b/src/engine/Algebra.ts
@@ -8,36 +8,50 @@ export class Vector {
   /**
    * A (0, 0) vector
    */
-  public static Zero = new Vector(0, 0);
+  public static get Zero() {
+    return new Vector(0, 0);
+  }
 
   /**
    * A (1, 1) vector
    */
-  public static One = new Vector(1, 1);
+  public static get One() {
+    return new Vector(1, 1);
+  }
 
   /**
    * A (0.5, 0.5) vector
    */
-  public static Half = new Vector(0.5, 0.5);
+  public static get Half() {
+    return new Vector(0.5, 0.5);
+  }
 
   /**
    * A unit vector pointing up (0, -1)
    */
-  public static Up = new Vector(0, -1);
+  public static get Up() {
+    return new Vector(0, -1);
+  }
 
   /**
    * A unit vector pointing down (0, 1)
    */
-  public static Down = new Vector(0, 1);
+  public static get Down() {
+    return new Vector(0, 1);
+  }
 
   /**
    * A unit vector pointing left (-1, 0)
    */
-  public static Left = new Vector(-1, 0);
+  public static get Left() {
+    return new Vector(-1, 0);
+  }
   /**
    * A unit vector pointing right (1, 0)
    */
-  public static Right = new Vector(1, 0);
+  public static get Right() {
+    return new Vector(1, 0);
+  }
 
   /**
    * Returns a vector of unit length in the direction of the specified angle in Radians.

--- a/src/engine/Collision/Body.ts
+++ b/src/engine/Collision/Body.ts
@@ -90,7 +90,7 @@ export class Body {
    */
   public rx: number = 0; //radians/sec
 
-  private _totalMtv: Vector = Vector.Zero.clone();
+  private _totalMtv: Vector = Vector.Zero;
 
   /**
    * Add minimum translation vectors accumulated during the current frame to resolve collisions.
@@ -148,7 +148,7 @@ export class Body {
    *
    * By default, the box is center is at (0, 0) which means it is centered around the actors anchor.
    */
-  public useBoxCollision(center: Vector = Vector.Zero.clone()) {
+  public useBoxCollision(center: Vector = Vector.Zero) {
     this.collisionArea = new PolygonArea({
       body: this,
       points: this.actor.getRelativeGeometry(),
@@ -166,7 +166,7 @@ export class Body {
    *
    * By default, the box is center is at (0, 0) which means it is centered around the actors anchor.
    */
-  public usePolygonCollision(points: Vector[], center: Vector = Vector.Zero.clone()) {
+  public usePolygonCollision(points: Vector[], center: Vector = Vector.Zero) {
     this.collisionArea = new PolygonArea({
       body: this,
       points: points,
@@ -182,7 +182,7 @@ export class Body {
    *
    * By default, the box is center is at (0, 0) which means it is centered around the actors anchor.
    */
-  public useCircleCollision(radius?: number, center: Vector = Vector.Zero.clone()) {
+  public useCircleCollision(radius?: number, center: Vector = Vector.Zero) {
     if (!radius) {
       radius = this.actor.getWidth() / 2;
     }

--- a/src/engine/Collision/BoundingBox.ts
+++ b/src/engine/Collision/BoundingBox.ts
@@ -77,7 +77,7 @@ export class BoundingBox implements ICollidable {
    * Rotates a bounding box by and angle and around a point, if no point is specified (0, 0) is used by default. The resulting bounding
    * box is also axis-align. This is useful when a new axis-aligned bounding box is needed for rotated geometry.
    */
-  public rotate(angle: number, point: Vector = Vector.Zero.clone()): BoundingBox {
+  public rotate(angle: number, point: Vector = Vector.Zero): BoundingBox {
     var points = this.getPoints().map((p) => p.rotate(angle, point));
     return BoundingBox.fromPoints(points);
   }
@@ -107,7 +107,7 @@ export class BoundingBox implements ICollidable {
     return new PolygonArea({
       body: actor ? actor.body : null,
       points: this.getPoints(),
-      pos: Vector.Zero.clone()
+      pos: Vector.Zero
     });
   }
 

--- a/src/engine/Collision/CircleArea.ts
+++ b/src/engine/Collision/CircleArea.ts
@@ -198,7 +198,7 @@ export class CircleArea implements ICollisionArea {
   }
 
   /* istanbul ignore next */
-  public debugDraw(ctx: CanvasRenderingContext2D, color: Color = Color.Green.clone()) {
+  public debugDraw(ctx: CanvasRenderingContext2D, color: Color = Color.Green) {
     var pos = this.body ? this.body.pos.add(this.pos) : this.pos;
     var rotation = this.body ? this.body.rotation : 0;
 

--- a/src/engine/Collision/CircleArea.ts
+++ b/src/engine/Collision/CircleArea.ts
@@ -23,7 +23,7 @@ export class CircleArea implements ICollisionArea {
   /**
    * This is the center position of the circle, relative to the body position
    */
-  public pos: Vector = Vector.Zero.clone();
+  public pos: Vector = Vector.Zero;
   /**
    * This is the radius of the circle
    */
@@ -34,7 +34,7 @@ export class CircleArea implements ICollisionArea {
   public body: Body;
 
   constructor(options: ICircleAreaOptions) {
-    this.pos = options.pos || Vector.Zero.clone();
+    this.pos = options.pos || Vector.Zero;
     this.radius = options.radius || 0;
     this.body = options.body || null;
   }

--- a/src/engine/Collision/EdgeArea.ts
+++ b/src/engine/Collision/EdgeArea.ts
@@ -23,8 +23,8 @@ export class EdgeArea implements ICollisionArea {
   end: Vector;
 
   constructor(options: IEdgeAreaOptions) {
-    this.begin = options.begin || Vector.Zero.clone();
-    this.end = options.end || Vector.Zero.clone();
+    this.begin = options.begin || Vector.Zero;
+    this.end = options.end || Vector.Zero;
     this.body = options.body || null;
 
     this.pos = this.getCenter();
@@ -39,7 +39,7 @@ export class EdgeArea implements ICollisionArea {
   }
 
   private _getBodyPos(): Vector {
-    var bodyPos = Vector.Zero.clone();
+    var bodyPos = Vector.Zero;
     if (this.body.pos) {
       bodyPos = this.body.pos;
     }

--- a/src/engine/Collision/EdgeArea.ts
+++ b/src/engine/Collision/EdgeArea.ts
@@ -202,7 +202,7 @@ export class EdgeArea implements ICollisionArea {
   }
 
   /* istanbul ignore next */
-  public debugDraw(ctx: CanvasRenderingContext2D, color: Color = Color.Red.clone()) {
+  public debugDraw(ctx: CanvasRenderingContext2D, color: Color = Color.Red) {
     ctx.strokeStyle = color.toString();
     ctx.beginPath();
     ctx.moveTo(this.begin.x, this.begin.y);

--- a/src/engine/Collision/PolygonArea.ts
+++ b/src/engine/Collision/PolygonArea.ts
@@ -321,7 +321,7 @@ export class PolygonArea implements ICollisionArea {
   }
 
   /* istanbul ignore next */
-  public debugDraw(ctx: CanvasRenderingContext2D, color: Color = Color.Red.clone()) {
+  public debugDraw(ctx: CanvasRenderingContext2D, color: Color = Color.Red) {
     ctx.beginPath();
     ctx.strokeStyle = color.toString();
     // Iterate through the supplied points and construct a 'polygon'

--- a/src/engine/Collision/PolygonArea.ts
+++ b/src/engine/Collision/PolygonArea.ts
@@ -29,7 +29,7 @@ export class PolygonArea implements ICollisionArea {
   private _sides: Line[] = [];
 
   constructor(options: IPolygonAreaOptions) {
-    this.pos = options.pos || Vector.Zero.clone();
+    this.pos = options.pos || Vector.Zero;
     var winding = !!options.clockwiseWinding;
     this.points = (winding ? options.points.reverse() : options.points) || [];
     this.body = options.body || null;

--- a/src/engine/Drawing/Color.ts
+++ b/src/engine/Drawing/Color.ts
@@ -256,97 +256,135 @@ export class Color {
   /**
    * Black (#000000)
    */
-  public static Black: Color = Color.fromHex('#000000');
+  public static get Black(): Color {
+    return Color.fromHex('#000000');
+  }
 
   /**
    * White (#FFFFFF)
    */
-  public static White: Color = Color.fromHex('#FFFFFF');
+  public static get White(): Color {
+    return Color.fromHex('#FFFFFF');
+  }
 
   /**
    * Gray (#808080)
    */
-  public static Gray: Color = Color.fromHex('#808080');
+  public static get Gray(): Color {
+    return Color.fromHex('#808080');
+  }
 
   /**
    * Light gray (#D3D3D3)
    */
-  public static LightGray: Color = Color.fromHex('#D3D3D3');
+  public static get LightGray(): Color {
+    return Color.fromHex('#D3D3D3');
+  }
 
   /**
    * Dark gray (#A9A9A9)
    */
-  public static DarkGray: Color = Color.fromHex('#A9A9A9');
+  public static get DarkGray(): Color {
+    return Color.fromHex('#A9A9A9');
+  }
 
   /**
    * Yellow (#FFFF00)
    */
-  public static Yellow: Color = Color.fromHex('#FFFF00');
+  public static get Yellow(): Color {
+    return Color.fromHex('#FFFF00');
+  }
 
   /**
    * Orange (#FFA500)
    */
-  public static Orange: Color = Color.fromHex('#FFA500');
+  public static get Orange(): Color {
+    return Color.fromHex('#FFA500');
+  }
 
   /**
    * Red (#FF0000)
    */
-  public static Red: Color = Color.fromHex('#FF0000');
+  public static get Red(): Color {
+    return Color.fromHex('#FF0000');
+  }
 
   /**
    * Vermillion (#FF5B31)
    */
-  public static Vermillion: Color = Color.fromHex('#FF5B31');
+  public static get Vermillion(): Color {
+    return Color.fromHex('#FF5B31');
+  }
 
   /**
    * Rose (#FF007F)
    */
-  public static Rose: Color = Color.fromHex('#FF007F');
+  public static get Rose(): Color {
+    return Color.fromHex('#FF007F');
+  }
 
   /**
    * Magenta (#FF00FF)
    */
-  public static Magenta: Color = Color.fromHex('#FF00FF');
+  public static get Magenta(): Color {
+    return Color.fromHex('#FF00FF');
+  }
 
   /**
    * Violet (#7F00FF)
    */
-  public static Violet: Color = Color.fromHex('#7F00FF');
+  public static get Violet(): Color {
+    return Color.fromHex('#7F00FF');
+  }
 
   /**
    * Blue (#0000FF)
    */
-  public static Blue: Color = Color.fromHex('#0000FF');
+  public static get Blue(): Color {
+    return Color.fromHex('#0000FF');
+  }
 
   /**
    * Azure (#007FFF)
    */
-  public static Azure: Color = Color.fromHex('#007FFF');
+  public static get Azure(): Color {
+    return Color.fromHex('#007FFF');
+  }
 
   /**
    * Cyan (#00FFFF)
    */
-  public static Cyan: Color = Color.fromHex('#00FFFF');
+  public static get Cyan(): Color {
+    return Color.fromHex('#00FFFF');
+  }
 
   /**
    * Viridian (#59978F)
    */
-  public static Viridian: Color = Color.fromHex('#59978F');
+  public static get Viridian(): Color {
+    return Color.fromHex('#59978F');
+  }
 
   /**
    * Green (#00FF00)
    */
-  public static Green: Color = Color.fromHex('#00FF00');
+  public static get Green(): Color {
+    return Color.fromHex('#00FF00');
+  }
 
   /**
    * Chartreuse (#7FFF00)
    */
-  public static Chartreuse: Color = Color.fromHex('#7FFF00');
+  public static get Chartreuse(): Color {
+    return Color.fromHex('#7FFF00');
+  }
 
   /**
    * Transparent (#FFFFFF00)
    */
-  public static Transparent: Color = Color.fromHex('#FFFFFF00');
+  public static get Transparent(): Color {
+    return Color.fromHex('#FFFFFF00');
+  }
 }
 
 /**

--- a/src/engine/Drawing/SpriteSheet.ts
+++ b/src/engine/Drawing/SpriteSheet.ts
@@ -212,14 +212,14 @@ export class SpriteSheet extends Configurable(SpriteSheetImpl) {
 }
 
 export class SpriteFontImpl extends SpriteSheet {
-  private _currentColor: Color = Color.Black.clone();
+  private _currentColor: Color = Color.Black;
   private _currentOpacity: Number = 1.0;
   private _sprites: { [key: string]: Sprite } = {};
 
   // text shadow
   private _textShadowOn: boolean = false;
   private _textShadowDirty: boolean = true;
-  private _textShadowColor: Color = Color.Black.clone();
+  private _textShadowColor: Color = Color.Black;
   private _textShadowSprites: { [key: string]: Sprite } = {};
   private _shadowOffsetX: number = 5;
   private _shadowOffsetY: number = 5;
@@ -395,7 +395,7 @@ export class SpriteFontImpl extends SpriteSheet {
     return {
       fontSize: options.fontSize || 10,
       letterSpacing: options.letterSpacing || 0,
-      color: options.color || Color.Black.clone(),
+      color: options.color || Color.Black,
       textAlign: typeof options.textAlign === undefined ? TextAlign.Left : options.textAlign,
       baseAlign: typeof options.baseAlign === undefined ? BaseAlign.Bottom : options.baseAlign,
       maxWidth: options.maxWidth || -1,

--- a/src/engine/Label.ts
+++ b/src/engine/Label.ts
@@ -217,7 +217,7 @@ export class LabelImpl extends Actor {
     }
 
     this.text = text || '';
-    this.color = Color.Black.clone();
+    this.color = Color.Black;
     this.spriteFont = spriteFont;
     this.collisionType = CollisionType.PreventCollision;
     this.fontFamily = fontFamily || 'sans-serif'; // coalesce to default canvas font

--- a/src/engine/Particles.ts
+++ b/src/engine/Particles.ts
@@ -36,8 +36,8 @@ export class ParticleImpl {
   public focus: Vector = null;
   public focusAccel: number = 0;
   public opacity: number = 1;
-  public beginColor: Color = Color.White.clone();
-  public endColor: Color = Color.White.clone();
+  public beginColor: Color = Color.White;
+  public endColor: Color = Color.White;
 
   // Life is counted in ms
   public life: number = 300;
@@ -48,7 +48,7 @@ export class ParticleImpl {
   private _gRate: number = 1;
   private _bRate: number = 1;
   private _aRate: number = 0;
-  private _currentColor: Color = Color.White.clone();
+  private _currentColor: Color = Color.White;
 
   public emitter: ParticleEmitter = null;
   public particleSize: number = 5;
@@ -314,11 +314,11 @@ export class ParticleEmitterImpl extends Actor {
   /**
    * Gets or sets the beginning color of all particles
    */
-  public beginColor: Color = Color.White.clone();
+  public beginColor: Color = Color.White;
   /**
    * Gets or sets the ending color of all particles
    */
-  public endColor: Color = Color.White.clone();
+  public endColor: Color = Color.White;
 
   /**
    * Gets or sets the sprite that a particle should use

--- a/src/engine/TileMap.ts
+++ b/src/engine/TileMap.ts
@@ -229,7 +229,7 @@ export class TileMapImpl extends Class {
       ctx.lineTo(this.x + width, this.y + y * this.cellHeight);
       ctx.stroke();
     }
-    var solid = Color.Red.clone();
+    var solid = Color.Red;
     solid.a = 0.3;
     this.data
       .filter(function(cell) {

--- a/src/engine/Trigger.ts
+++ b/src/engine/Trigger.ts
@@ -30,7 +30,7 @@ export interface ITriggerOptions {
 }
 
 let triggerDefaults: Partial<ITriggerOptions> = {
-  pos: Vector.Zero.clone(),
+  pos: Vector.Zero,
   width: 10,
   height: 10,
   visible: false,

--- a/src/engine/Util/DrawUtil.ts
+++ b/src/engine/Util/DrawUtil.ts
@@ -22,7 +22,7 @@ export type LineCapStyle = 'butt' | 'round' | 'square';
 /* istanbul ignore next */
 export function line(
   ctx: CanvasRenderingContext2D,
-  color: Color = Color.Red.clone(),
+  color: Color = Color.Red,
   x1: number,
   y1: number,
   x2: number,
@@ -44,7 +44,7 @@ export function line(
  * Draw the vector as a point onto the canvas.
  */
 /* istanbul ignore next */
-export function point(ctx: CanvasRenderingContext2D, color: Color = Color.Red.clone(), point: Vector): void {
+export function point(ctx: CanvasRenderingContext2D, color: Color = Color.Red, point: Vector): void {
   ctx.beginPath();
   ctx.strokeStyle = color.toString();
   ctx.arc(point.x, point.y, 5, 0, Math.PI * 2);


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===
- [x] :pushpin: issue exists in github for these changes 
- [x] :microscope: existing tests still pass
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1085

## Changes:

- Changed ex.Color constants to be static getters
- Changed ex.Vector constnats to be static getters
- Updated main source to avoid any unnecessary `.clone()`'s
- Update changelog
