### PR TITLE
[#1078] Fix issue with offscreen culling on left side of screen

### DIFF
--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -386,7 +386,7 @@ export class Camera extends Class implements ICanUpdate, ICanInitialize {
       let halfWidth = this._engine.halfDrawWidth;
       let halfHeight = this._engine.halfDrawHeight;
 
-      return new BoundingBox(this.x - halfHeight, this.y - halfHeight, this.x + halfWidth, this.y + halfHeight);
+      return new BoundingBox(this.x - halfWidth, this.y - halfHeight, this.x + halfWidth, this.y + halfHeight);
     }
     return new BoundingBox(0, 0, 0, 0);
   }
@@ -609,6 +609,13 @@ export class Camera extends Class implements ICanUpdate, ICanInitialize {
     ctx.arc(focus.x, focus.y, 5, 0, Math.PI * 2);
     ctx.closePath();
     ctx.stroke();
+
+    ctx.beginPath();
+    ctx.setLineDash([5, 15]);
+    ctx.lineWidth = 5;
+    ctx.strokeStyle = 'white';
+    ctx.strokeRect(this.viewport.left, this.viewport.top, this.viewport.getWidth(), this.viewport.getHeight());
+    ctx.closePath();
   }
 
   private _isDoneShaking(): boolean {

--- a/src/spec/SceneSpec.ts
+++ b/src/spec/SceneSpec.ts
@@ -61,6 +61,133 @@ describe('A scene', () => {
     expect(actor.draw).toHaveBeenCalled();
   });
 
+  it('draws onscreen Actors left', () => {
+    actor.traits.length = 0;
+    actor.traits.push(new ex.Traits.OffscreenCulling());
+    actor.pos.x = -4;
+    actor.pos.y = 0;
+    actor.setWidth(10);
+    actor.setHeight(10);
+
+    scene.add(actor);
+    scene.update(engine, 100);
+    scene.draw(engine.ctx, 100);
+
+    expect(actor.isOffScreen).toBe(false, 'Actor should be onscreen');
+    expect(actor.draw).toHaveBeenCalled();
+  });
+  it('does not draw offscreen Actors left', () => {
+    actor.traits.length = 0;
+    actor.traits.push(new ex.Traits.OffscreenCulling());
+    actor.pos.x = -6;
+    actor.pos.y = 0;
+    actor.setWidth(10);
+    actor.setHeight(10);
+
+    scene.add(actor);
+    scene.update(engine, 100);
+    scene.draw(engine.ctx, 100);
+
+    expect(actor.isOffScreen).toBe(true, 'Actor should be offscreen');
+    expect(actor.draw).not.toHaveBeenCalled();
+  });
+
+  it('draws onscreen Actors top', () => {
+    actor.traits.length = 0;
+    actor.traits.push(new ex.Traits.OffscreenCulling());
+    actor.pos.x = 0;
+    actor.pos.y = -4;
+    actor.setWidth(10);
+    actor.setHeight(10);
+
+    scene.add(actor);
+    scene.update(engine, 100);
+    scene.draw(engine.ctx, 100);
+
+    expect(actor.isOffScreen).toBe(false, 'Actor should be onscreen');
+    expect(actor.draw).toHaveBeenCalled();
+  });
+
+  it('does not draw offscreen Actors top', () => {
+    actor.traits.length = 0;
+    actor.traits.push(new ex.Traits.OffscreenCulling());
+    actor.pos.x = 0;
+    actor.pos.y = -6;
+    actor.setWidth(10);
+    actor.setHeight(10);
+
+    scene.add(actor);
+    scene.update(engine, 100);
+    scene.draw(engine.ctx, 100);
+
+    expect(actor.isOffScreen).toBe(true, 'Actor should be offscreen');
+    expect(actor.draw).not.toHaveBeenCalled();
+  });
+
+  it('draws onscreen Actors right', () => {
+    actor.traits.length = 0;
+    actor.traits.push(new ex.Traits.OffscreenCulling());
+    actor.pos.x = 104;
+    actor.pos.y = 0;
+    actor.setWidth(10);
+    actor.setHeight(10);
+
+    scene.add(actor);
+    scene.update(engine, 100);
+    scene.draw(engine.ctx, 100);
+
+    expect(actor.isOffScreen).toBe(false, 'Actor should be onscreen');
+    expect(actor.draw).toHaveBeenCalled();
+  });
+
+  it('does not draw offscreen Actors right', () => {
+    actor.traits.length = 0;
+    actor.traits.push(new ex.Traits.OffscreenCulling());
+    actor.pos.x = 106;
+    actor.pos.y = 0;
+    actor.setWidth(10);
+    actor.setHeight(10);
+
+    scene.add(actor);
+    scene.update(engine, 100);
+    scene.draw(engine.ctx, 100);
+
+    expect(actor.isOffScreen).toBe(true, 'Actor should be offscreen');
+    expect(actor.draw).not.toHaveBeenCalled();
+  });
+
+  it('draws onscreen Actors bottom', () => {
+    actor.traits.length = 0;
+    actor.traits.push(new ex.Traits.OffscreenCulling());
+    actor.pos.x = 0;
+    actor.pos.y = 104;
+    actor.setWidth(10);
+    actor.setHeight(10);
+
+    scene.add(actor);
+    scene.update(engine, 100);
+    scene.draw(engine.ctx, 100);
+
+    expect(actor.isOffScreen).toBe(false, 'Actor should be onscreen');
+    expect(actor.draw).toHaveBeenCalled();
+  });
+
+  it('does not draw offscreen Actors bottom', () => {
+    actor.traits.length = 0;
+    actor.traits.push(new ex.Traits.OffscreenCulling());
+    actor.pos.x = 0;
+    actor.pos.y = 106;
+    actor.setWidth(10);
+    actor.setHeight(10);
+
+    scene.add(actor);
+    scene.update(engine, 100);
+    scene.draw(engine.ctx, 100);
+
+    expect(actor.isOffScreen).toBe(true, 'Actor should be offscreen');
+    expect(actor.draw).not.toHaveBeenCalled();
+  });
+
   it('does not draw offscreen Actors', () => {
     actor.pos.x = 1000;
     actor.pos.y = 1000;


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===
- [x] :pushpin: issue exists in github for these changes 
- [x] :microscope: existing tests still pass
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1078 

## Changes:

- Correct left side viewport calculation
- Add tests for all sides of culling 
