### PR TITLE
Fixed wrong scaling on HiDPI screens when engine option suppressHiDPIScaling is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+Fixed wrong `Camera` and `Loader` scaling on HiDPI screens when option `suppressHiDPIScaling` is set.
+
 <!--- Bug fixes here --->
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -584,7 +584,7 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
     let focus = this.getFocus();
     let canvasWidth = ctx.canvas.width;
     let canvasHeight = ctx.canvas.height;
-    let pixelRatio = window.devicePixelRatio;
+    let pixelRatio = this._engine ? this._engine.pixelRatio : window.devicePixelRatio;
     let zoom = this.getZoom();
 
     var newCanvasWidth = canvasWidth / zoom / pixelRatio;

--- a/src/engine/Loader.ts
+++ b/src/engine/Loader.ts
@@ -296,8 +296,8 @@ export class Loader extends Class implements CanLoad {
    * to customize the drawing, or just override entire method.
    */
   public draw(ctx: CanvasRenderingContext2D) {
-    let canvasHeight = this._engine.canvasHeight / window.devicePixelRatio;
-    let canvasWidth = this._engine.canvasWidth / window.devicePixelRatio;
+    let canvasHeight = this._engine.canvasHeight / this._engine.pixelRatio;
+    let canvasWidth = this._engine.canvasWidth / this._engine.pixelRatio;
 
     if (this._playButtonRootElement) {
       let left = ctx.canvas.offsetLeft;


### PR DESCRIPTION


===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #1120

## Changes

Fixed wrong `Camera` and `Loader` scaling on HiDPI screens when engine option `suppressHiDPIScaling` is set.