### PR TITLE
[#1151] Update Bounding Box constructor to allow passing coordinate...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add new option for constructing bounding boxes. You can now construct with an options
+  object rather than only individual coordinate parameters. [#1151] https://github.com/excaliburjs/Excalibur/issues/1151
+- Add new interface for specifying the type of the options object passed to the
+  bounding box constructor.
+
 ### Changed
 
 ### Deprecated
@@ -23,7 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 
-- `ex.Actor.scale`, `ex.Actor.sx/sy`, `ex.Actor.actions.scaleTo/scaleBy` will not work as expected with new collider implementation, set width and height directly. These features will be completely removed in v0.24.0. 
+- `ex.Actor.scale`, `ex.Actor.sx/sy`, `ex.Actor.actions.scaleTo/scaleBy` will not work as expected with new collider implementation, set width and height directly. These features will be completely removed in v0.24.0.
 
 ### Added
 

--- a/src/engine/Collision/BoundingBox.ts
+++ b/src/engine/Collision/BoundingBox.ts
@@ -6,17 +6,44 @@ import { Color } from '../Drawing/Color';
 import { obsolete } from '../Util/Decorators';
 import { Side } from './Side';
 
+export interface BoundingBoxOptions {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
 /**
  * Axis Aligned collision primitive for Excalibur.
  */
 export class BoundingBox {
+  public top: number;
+  public right: number;
+  public bottom: number;
+  public left: number;
+
   /**
-   * @param left    x coordinate of the left edge
+   * Constructor allows passing of either an object with all coordinate components,
+   * or the coordinate components passed separately.
+   * @param leftOrOptions    Either x coordinate of the left edge or an options object
+   * containing the four coordinate components.
    * @param top     y coordinate of the top edge
    * @param right   x coordinate of the right edge
    * @param bottom  y coordinate of the bottom edge
    */
-  constructor(public left: number = 0, public top: number = 0, public right: number = 0, public bottom: number = 0) {}
+  constructor(leftOrOptions: number | BoundingBoxOptions = 0, top: number = 0, right: number = 0, bottom: number = 0) {
+    if (typeof leftOrOptions === 'object') {
+      this.left = leftOrOptions.left;
+      this.top = leftOrOptions.top;
+      this.right = leftOrOptions.right;
+      this.bottom = leftOrOptions.bottom;
+    } else if (typeof leftOrOptions === 'number') {
+      this.left = leftOrOptions;
+      this.top = top;
+      this.right = right;
+      this.bottom = bottom;
+    }
+  }
 
   /**
    * Given bounding box A & B, returns the side relative to A when intersection is performed.

--- a/src/spec/BoundingBoxSpec.ts
+++ b/src/spec/BoundingBoxSpec.ts
@@ -1,209 +1,247 @@
 import * as ex from '../../build/dist/excalibur';
 
-describe('A Bounding Box', () => {
-  // left, top, right, bottom
+describe('A Bounding Box constructed with no parameters', function() {
   let bb: ex.BoundingBox;
-  beforeEach(() => {
-    bb = new ex.BoundingBox(0, 0, 10, 10);
-  });
 
-  it('has a width', () => {
-    expect(bb.width).toBe(10);
-    bb.right = 20;
-    expect(bb.width).toBe(20);
-    bb.left = -20;
-    expect(bb.width).toBe(40);
-    bb.top = -20;
-    expect(bb.width).toBe(40);
-  });
+  bb = new ex.BoundingBox();
 
-  it('has a height', () => {
-    expect(bb.height).toBe(10);
-    bb.right = 20;
-    expect(bb.height).toBe(10);
-    bb.bottom = 20;
-    expect(bb.height).toBe(20);
-    bb.top = -20;
-    expect(bb.height).toBe(40);
-  });
-
-  it('can contain points', () => {
+  it('has a left', () => {
     expect(bb.left).toBe(0);
-    expect(bb.right).toBe(10);
-    bb.right = 20;
-    bb.bottom = 20;
-
-    expect(bb.contains(new ex.Vector(10, 10))).toBe(true);
-
-    expect(bb.contains(new ex.Vector(0, 0))).toBe(true);
-
-    expect(bb.contains(new ex.Vector(20, 20))).toBe(true);
-
-    expect(bb.contains(new ex.Vector(21, 20))).toBe(false);
-    expect(bb.contains(new ex.Vector(20, 21))).toBe(false);
-
-    expect(bb.contains(new ex.Vector(0, -1))).toBe(false);
-    expect(bb.contains(new ex.Vector(-1, 0))).toBe(false);
-    expect(bb.contains(new ex.Vector(10, 0))).toBe(true);
-    expect(bb.contains(new ex.Vector(10, 20))).toBe(true);
   });
 
-  it('can collide with other bounding boxes', () => {
-    const b2 = new ex.BoundingBox(2, 0, 20, 10);
-    const b3 = new ex.BoundingBox(12, 0, 28, 10);
-
-    // bb should resolve by being displaced -8 to the left against b2
-    expect(bb.intersect(b2).x).toBe(-8);
-
-    // b2 should resolve by being displaced -8 to the left against b3
-    expect(b2.intersect(b3).x).toBe(-8);
-
-    // bb should not collide with b3, they are only touching
-    expect(bb.intersect(b3)).toBeFalsy();
-
-    b2.top = 5;
-    b2.left = 6;
-    b2.right = 15;
-    b2.bottom = 15;
-
-    // bb should be displaced up and out by -5 against b2
-    expect(bb.intersect(b2).x).toBe(-4);
+  it('has a top', () => {
+    expect(bb.top).toBe(0);
   });
 
-  it('can collide with other bounding boxes with width/height (0,0)', () => {
-    const bb = new ex.BoundingBox(18, 15, 18, 15); // point bounding box
-    const bb2 = new ex.BoundingBox(0, 0, 20, 20); // square bounding box;
-
-    expect(bb2.intersect(bb)).not.toBe(null, 'Point bounding boxes should still collide');
-    expect(bb2.intersect(bb).x).toBe(-2);
-    expect(bb2.intersect(bb).y).toBe(0);
+  it('has a right', () => {
+    expect(bb.right).toBe(0);
   });
 
-  describe('when in full containment', () => {
-    it('closest right', () => {
-      const bb = new ex.BoundingBox(0, 0, 50, 50);
-      const bb1 = new ex.BoundingBox(40, 8, 49, 12);
-      expect(bb.intersect(bb1)).not.toBe(null);
-      expect(bb.intersect(bb1).x).toBe(-10, 'X should be -10');
-      expect(bb.intersect(bb1).y).toBe(0, 'Y should be 0');
-    });
-
-    it('closet left', () => {
-      const bb = new ex.BoundingBox(0, 0, 50, 50);
-      const bb1 = new ex.BoundingBox(1, 15, 10, 20);
-      expect(bb.intersect(bb1)).not.toBe(null);
-      expect(bb.intersect(bb1).x).toBe(10, 'X should be 10');
-      expect(bb.intersect(bb1).y).toBe(0, 'Y should be 0');
-    });
-
-    it('closest top', () => {
-      const bb = new ex.BoundingBox(0, 0, 50, 50);
-      const bb1 = new ex.BoundingBox(10, 1, 12, 10);
-      expect(bb.intersect(bb1)).not.toBe(null);
-      expect(bb.intersect(bb1).x).toBe(0, 'X should be 0');
-      expect(bb.intersect(bb1).y).toBe(10, 'Y should be 0');
-    });
-
-    it('closest bottom', () => {
-      const bb = new ex.BoundingBox(0, 0, 50, 50);
-      const bb1 = new ex.BoundingBox(10, 40, 12, 49);
-      expect(bb.intersect(bb1)).not.toBe(null);
-      expect(bb.intersect(bb1).x).toBe(0, 'X should be 0');
-      expect(bb.intersect(bb1).y).toBe(-10, 'Y should be -10');
-    });
-  });
-
-  it('can collide with other bounding boxes of the same width/height', () => {
-    const bb1 = new ex.BoundingBox(0, 0, 10, 10);
-    const bb2 = new ex.BoundingBox(0, 0, 10, 10);
-
-    expect(bb2.intersect(bb1)).not.toBe(null);
-    expect(bb2.intersect(bb1).x).toBe(0);
-    expect(bb2.intersect(bb1).y).toBe(-10);
-  });
-
-  it('can combine with other bounding boxes', () => {
-    const b2 = new ex.BoundingBox(2, 0, 20, 10);
-    const b3 = new ex.BoundingBox(12, 0, 28, 10);
-    const newBB = b2.combine(b3);
-
-    expect(newBB.width).toBe(26);
-    expect(newBB.height).toBe(10);
-
-    expect(newBB.left).toBe(2);
-    expect(newBB.right).toBe(28);
-    expect(newBB.top).toBe(0);
-    expect(newBB.bottom).toBe(10);
-  });
-
-  it('ray cast can hit a bounding box', () => {
-    const bb = new ex.BoundingBox(0, 0, 10, 10);
-
-    const ray = new ex.Ray(new ex.Vector(-10, 5), ex.Vector.Right);
-
-    expect(bb.rayCast(ray)).toBe(true);
-  });
-
-  it('ray cast can miss a bounding box', () => {
-    const bb = new ex.BoundingBox(0, 0, 10, 10);
-
-    const ray = new ex.Ray(new ex.Vector(-10, 5), ex.Vector.Left);
-
-    expect(bb.rayCast(ray)).toBe(false);
-  });
-
-  it('ray cast can miss a box far away', () => {
-    const bb = new ex.BoundingBox(1176, 48, 1200, 72);
-
-    const ray = new ex.Ray(new ex.Vector(48, 72), ex.Vector.Down);
-    expect(bb.rayCast(ray)).toBe(false);
-  });
-
-  it('ray cast can hit bounding box on the edge', () => {
-    const bb = new ex.BoundingBox(0, 0, 10, 10);
-
-    const ray = new ex.Ray(new ex.Vector(0, -5), ex.Vector.Down);
-
-    expect(bb.rayCast(ray)).toBe(true);
-  });
-
-  it('ray cast can originate from inside the box', () => {
-    const bb = new ex.BoundingBox(0, 0, 10, 10);
-
-    const ray = new ex.Ray(new ex.Vector(5, 5), ex.Vector.Down);
-
-    expect(bb.rayCast(ray)).toBe(true);
-  });
-
-  it('ray cast in the correct direction but that are not long enough dont hit', () => {
-    const bb = new ex.BoundingBox(0, 0, 10, 10);
-
-    const ray = new ex.Ray(new ex.Vector(-10, 5), ex.Vector.Right);
-
-    expect(bb.rayCast(ray, ray.dir.magnitude())).toBe(false);
-  });
-
-  it('ray cast when the origin is on the boundary', () => {
-    const bb = new ex.BoundingBox(0, 0, 10, 10);
-
-    const ray = new ex.Ray(new ex.Vector(0, 5), ex.Vector.Right);
-
-    expect(bb.rayCast(ray)).toBe(true);
-  });
-
-  it('can ray cast and get the intersection time', () => {
-    const bb = new ex.BoundingBox(0, 0, 10, 10);
-
-    const ray = new ex.Ray(new ex.Vector(0, -5), ex.Vector.Down);
-
-    expect(bb.rayCastTime(ray)).toBe(5);
-  });
-
-  it('can ray cast but if past far clip returns -1', () => {
-    const bb = new ex.BoundingBox(0, 0, 10, 10);
-
-    const ray = new ex.Ray(new ex.Vector(0, -5), ex.Vector.Down);
-
-    expect(bb.rayCastTime(ray, 4)).toBe(-1);
+  it('has a bottom', () => {
+    expect(bb.bottom).toBe(0);
   });
 });
+
+describe('A Bounding Box', function() {
+  function createBBFromOption() {
+    return new ex.BoundingBox({ left: 0, top: 0, right: 10, bottom: 10 });
+  }
+
+  function createBBFromParameters() {
+    return new ex.BoundingBox(0, 0, 10, 10);
+  }
+
+  runBoundingBoxTests('Constructed from option object', createBBFromOption);
+  runBoundingBoxTests('Constructed from parameters', createBBFromParameters);
+});
+
+function runBoundingBoxTests(creationType: string, createBoundingBox: Function) {
+  describe(creationType, function() {
+    let bb: ex.BoundingBox;
+
+    beforeEach(function() {
+      //create an instance by invoking the constructor function
+      bb = createBoundingBox();
+    });
+
+    it('has a width', () => {
+      expect(bb.width).toBe(10);
+      bb.right = 20;
+      expect(bb.width).toBe(20);
+      bb.left = -20;
+      expect(bb.width).toBe(40);
+      bb.top = -20;
+      expect(bb.width).toBe(40);
+    });
+
+    it('has a height', () => {
+      expect(bb.height).toBe(10);
+      bb.right = 20;
+      expect(bb.height).toBe(10);
+      bb.bottom = 20;
+      expect(bb.height).toBe(20);
+      bb.top = -20;
+      expect(bb.height).toBe(40);
+    });
+
+    it('can contain points', () => {
+      expect(bb.left).toBe(0);
+      expect(bb.right).toBe(10);
+      bb.right = 20;
+      bb.bottom = 20;
+
+      expect(bb.contains(new ex.Vector(10, 10))).toBe(true);
+
+      expect(bb.contains(new ex.Vector(0, 0))).toBe(true);
+
+      expect(bb.contains(new ex.Vector(20, 20))).toBe(true);
+
+      expect(bb.contains(new ex.Vector(21, 20))).toBe(false);
+      expect(bb.contains(new ex.Vector(20, 21))).toBe(false);
+
+      expect(bb.contains(new ex.Vector(0, -1))).toBe(false);
+      expect(bb.contains(new ex.Vector(-1, 0))).toBe(false);
+      expect(bb.contains(new ex.Vector(10, 0))).toBe(true);
+      expect(bb.contains(new ex.Vector(10, 20))).toBe(true);
+    });
+
+    it('can collide with other bounding boxes', () => {
+      const b2 = new ex.BoundingBox(2, 0, 20, 10);
+      const b3 = new ex.BoundingBox(12, 0, 28, 10);
+
+      // bb should resolve by being displaced -8 to the left against b2
+      expect(bb.intersect(b2).x).toBe(-8);
+
+      // b2 should resolve by being displaced -8 to the left against b3
+      expect(b2.intersect(b3).x).toBe(-8);
+
+      // bb should not collide with b3, they are only touching
+      expect(bb.intersect(b3)).toBeFalsy();
+
+      b2.top = 5;
+      b2.left = 6;
+      b2.right = 15;
+      b2.bottom = 15;
+
+      // bb should be displaced up and out by -5 against b2
+      expect(bb.intersect(b2).x).toBe(-4);
+    });
+
+    it('can collide with other bounding boxes with width/height (0,0)', () => {
+      const bb = new ex.BoundingBox(18, 15, 18, 15); // point bounding box
+      const bb2 = new ex.BoundingBox(0, 0, 20, 20); // square bounding box;
+
+      expect(bb2.intersect(bb)).not.toBe(null, 'Point bounding boxes should still collide');
+      expect(bb2.intersect(bb).x).toBe(-2);
+      expect(bb2.intersect(bb).y).toBe(0);
+    });
+
+    describe('when in full containment', () => {
+      it('closest right', () => {
+        const bb = new ex.BoundingBox(0, 0, 50, 50);
+        const bb1 = new ex.BoundingBox(40, 8, 49, 12);
+        expect(bb.intersect(bb1)).not.toBe(null);
+        expect(bb.intersect(bb1).x).toBe(-10, 'X should be -10');
+        expect(bb.intersect(bb1).y).toBe(0, 'Y should be 0');
+      });
+
+      it('closet left', () => {
+        const bb = new ex.BoundingBox(0, 0, 50, 50);
+        const bb1 = new ex.BoundingBox(1, 15, 10, 20);
+        expect(bb.intersect(bb1)).not.toBe(null);
+        expect(bb.intersect(bb1).x).toBe(10, 'X should be 10');
+        expect(bb.intersect(bb1).y).toBe(0, 'Y should be 0');
+      });
+
+      it('closest top', () => {
+        const bb = new ex.BoundingBox(0, 0, 50, 50);
+        const bb1 = new ex.BoundingBox(10, 1, 12, 10);
+        expect(bb.intersect(bb1)).not.toBe(null);
+        expect(bb.intersect(bb1).x).toBe(0, 'X should be 0');
+        expect(bb.intersect(bb1).y).toBe(10, 'Y should be 0');
+      });
+
+      it('closest bottom', () => {
+        const bb = new ex.BoundingBox(0, 0, 50, 50);
+        const bb1 = new ex.BoundingBox(10, 40, 12, 49);
+        expect(bb.intersect(bb1)).not.toBe(null);
+        expect(bb.intersect(bb1).x).toBe(0, 'X should be 0');
+        expect(bb.intersect(bb1).y).toBe(-10, 'Y should be -10');
+      });
+    });
+
+    it('can collide with other bounding boxes of the same width/height', () => {
+      const bb1 = new ex.BoundingBox(0, 0, 10, 10);
+      const bb2 = new ex.BoundingBox(0, 0, 10, 10);
+
+      expect(bb2.intersect(bb1)).not.toBe(null);
+      expect(bb2.intersect(bb1).x).toBe(0);
+      expect(bb2.intersect(bb1).y).toBe(-10);
+    });
+
+    it('can combine with other bounding boxes', () => {
+      const b2 = new ex.BoundingBox(2, 0, 20, 10);
+      const b3 = new ex.BoundingBox(12, 0, 28, 10);
+      const newBB = b2.combine(b3);
+
+      expect(newBB.width).toBe(26);
+      expect(newBB.height).toBe(10);
+
+      expect(newBB.left).toBe(2);
+      expect(newBB.right).toBe(28);
+      expect(newBB.top).toBe(0);
+      expect(newBB.bottom).toBe(10);
+    });
+
+    it('ray cast can hit a bounding box', () => {
+      const bb = new ex.BoundingBox(0, 0, 10, 10);
+
+      const ray = new ex.Ray(new ex.Vector(-10, 5), ex.Vector.Right);
+
+      expect(bb.rayCast(ray)).toBe(true);
+    });
+
+    it('ray cast can miss a bounding box', () => {
+      const bb = new ex.BoundingBox(0, 0, 10, 10);
+
+      const ray = new ex.Ray(new ex.Vector(-10, 5), ex.Vector.Left);
+
+      expect(bb.rayCast(ray)).toBe(false);
+    });
+
+    it('ray cast can miss a box far away', () => {
+      const bb = new ex.BoundingBox(1176, 48, 1200, 72);
+
+      const ray = new ex.Ray(new ex.Vector(48, 72), ex.Vector.Down);
+      expect(bb.rayCast(ray)).toBe(false);
+    });
+
+    it('ray cast can hit bounding box on the edge', () => {
+      const bb = new ex.BoundingBox(0, 0, 10, 10);
+
+      const ray = new ex.Ray(new ex.Vector(0, -5), ex.Vector.Down);
+
+      expect(bb.rayCast(ray)).toBe(true);
+    });
+
+    it('ray cast can originate from inside the box', () => {
+      const bb = new ex.BoundingBox(0, 0, 10, 10);
+
+      const ray = new ex.Ray(new ex.Vector(5, 5), ex.Vector.Down);
+
+      expect(bb.rayCast(ray)).toBe(true);
+    });
+
+    it('ray cast in the correct direction but that are not long enough dont hit', () => {
+      const bb = new ex.BoundingBox(0, 0, 10, 10);
+
+      const ray = new ex.Ray(new ex.Vector(-10, 5), ex.Vector.Right);
+
+      expect(bb.rayCast(ray, ray.dir.magnitude())).toBe(false);
+    });
+
+    it('ray cast when the origin is on the boundary', () => {
+      const bb = new ex.BoundingBox(0, 0, 10, 10);
+
+      const ray = new ex.Ray(new ex.Vector(0, 5), ex.Vector.Right);
+
+      expect(bb.rayCast(ray)).toBe(true);
+    });
+
+    it('can ray cast and get the intersection time', () => {
+      const bb = new ex.BoundingBox(0, 0, 10, 10);
+
+      const ray = new ex.Ray(new ex.Vector(0, -5), ex.Vector.Down);
+
+      expect(bb.rayCastTime(ray)).toBe(5);
+    });
+
+    it('can ray cast but if past far clip returns -1', () => {
+      const bb = new ex.BoundingBox(0, 0, 10, 10);
+
+      const ray = new ex.Ray(new ex.Vector(0, -5), ex.Vector.Down);
+
+      expect(bb.rayCastTime(ray, 4)).toBe(-1);
+    });
+  });
+}


### PR DESCRIPTION
…parameters in an object

Updated constructor is backwards compatible, still allows users to call it with coordinates as individual parameters.  Main bounding box tests run for boxes constructed using both methods.  Add new interface for specifying the type of the coordinate parameters object.

Resolves: #1151.

<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #

## Changes:

- change 1
- change 2
