### PR TITLE
#1172 Fix animation flipping behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix animation flipping behavior [#1172](https://github.com/excaliburjs/Excalibur/issues/1172)
+
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->

--- a/src/engine/Drawing/Animation.ts
+++ b/src/engine/Drawing/Animation.ts
@@ -270,12 +270,8 @@ export class AnimationImpl implements Drawable {
     let currSprite: Sprite;
     if (this.currentFrame < this.sprites.length) {
       currSprite = this.sprites[this.currentFrame];
-      if (this.flipVertical) {
-        currSprite.flipVertical = this.flipVertical;
-      }
-      if (this.flipHorizontal) {
-        currSprite.flipHorizontal = this.flipHorizontal;
-      }
+      currSprite.flipVertical = this.flipVertical;
+      currSprite.flipHorizontal = this.flipHorizontal;
       currSprite.draw(ctx, x, y);
     }
 

--- a/src/spec/AnimationSpec.ts
+++ b/src/spec/AnimationSpec.ts
@@ -2,8 +2,9 @@ import * as ex from '../../build/dist/excalibur';
 import { TestUtils } from './util/TestUtils';
 
 describe('An animation', () => {
-  let animation;
+  let animation: ex.Animation;
   let engine: ex.Engine;
+
   beforeEach(() => {
     animation = new ex.Animation(null, null, 0);
     engine = TestUtils.engine({
@@ -11,6 +12,7 @@ describe('An animation', () => {
       height: 500
     });
   });
+
   afterEach(() => {
     engine.stop();
     engine = null;
@@ -47,5 +49,29 @@ describe('An animation', () => {
     expect(animation.loop).toBe(false);
     expect(animation.speed).toBe(20);
     expect(animation.sprites.length).toBe(0);
+  });
+
+  it('should always pass "flipped" state to the current Sprite', () => {
+    const mockSprite = {
+      anchor: new ex.Vector(1, 1),
+      draw: () => void 0,
+      flipHorizontal: false,
+      flipVertical: false
+    };
+    animation.sprites = [mockSprite];
+
+    // set flipped to true and ensure the Sprite has the same state after drawing
+    animation.flipHorizontal = true;
+    animation.flipVertical = true;
+    animation.draw(engine.ctx, 0, 0);
+    expect(animation.sprites[0].flipHorizontal).toBe(true);
+    expect(animation.sprites[0].flipVertical).toBe(true);
+
+    // set flipped back to false and ensure the Sprite has the same state after drawing
+    animation.flipHorizontal = false;
+    animation.flipVertical = false;
+    animation.draw(engine.ctx, 0, 0);
+    expect(animation.sprites[0].flipHorizontal).toBe(false);
+    expect(animation.sprites[0].flipVertical).toBe(false);
   });
 });


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes https://github.com/excaliburjs/Excalibur/issues/1172

## Changes:

- Updates Animation to remove the conditional around passing `flipHorizontal/Vertical` to its current Sprite instance, as these should _always_ be passed to ensure their "flipped" state is accurate.
- Added tests to ensure that the flag can be flipped in _both_ directions now, as previously it could only be set to `true`
