### PR TITLE
[#1199] Fix flakey test, possible for wrong sprite sheet to be loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3112,7 +3112,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {

--- a/src/spec/SpriteSheetSpec.ts
+++ b/src/spec/SpriteSheetSpec.ts
@@ -4,7 +4,6 @@ import { TestUtils } from './util/TestUtils';
 
 describe('A spritesheet', () => {
   let engine: ex.Engine;
-  let texture: ex.Texture;
   beforeEach(() => {
     jasmine.addMatchers(ExcaliburMatchers);
     engine = TestUtils.engine({
@@ -12,7 +11,7 @@ describe('A spritesheet', () => {
       height: 96
     });
 
-    texture = new ex.Texture('base/src/spec/images/SpriteSheetSpec/PlayerRun.png', true);
+    
   });
   afterEach(() => {
     engine.stop();
@@ -20,6 +19,7 @@ describe('A spritesheet', () => {
   });
 
   it('should have props set by the constructor', (done) => {
+    const texture = new ex.Texture('base/src/spec/images/SpriteSheetSpec/PlayerRun.png', true);
     texture.load().then(() => {
       const ss = new ex.SpriteSheet({
         image: texture,
@@ -47,6 +47,7 @@ describe('A spritesheet', () => {
   });
 
   it('should getAnimationByIndices', () => {
+    const texture = new ex.Texture('base/src/spec/images/SpriteSheetSpec/PlayerRun.png', true);
     texture.load().then(() => {
       const ss = new ex.SpriteSheet({
         image: texture,
@@ -66,6 +67,7 @@ describe('A spritesheet', () => {
   });
 
   it('should getAnimationBetween', () => {
+    const texture = new ex.Texture('base/src/spec/images/SpriteSheetSpec/PlayerRun.png', true);
     texture.load().then(() => {
       const ss = new ex.SpriteSheet({
         image: texture,
@@ -84,6 +86,7 @@ describe('A spritesheet', () => {
   });
 
   it('should getAnimationForAll', () => {
+    const texture = new ex.Texture('base/src/spec/images/SpriteSheetSpec/PlayerRun.png', true);
     texture.load().then(() => {
       const ss = new ex.SpriteSheet({
         image: texture,
@@ -102,6 +105,7 @@ describe('A spritesheet', () => {
   });
 
   it('should getSprite at an index', (done) => {
+    const texture = new ex.Texture('base/src/spec/images/SpriteSheetSpec/PlayerRun.png', true);
     texture.load().then(() => {
       const ss = new ex.SpriteSheet({
         image: texture,
@@ -133,7 +137,7 @@ describe('A spritesheet', () => {
       width: 162 + 89,
       height: 94
     });
-    texture = new ex.Texture('base/src/spec/images/SpriteSheetSpec/genericItems_spritesheet_colored.png', true);
+    const texture = new ex.Texture('base/src/spec/images/SpriteSheetSpec/genericItems_spritesheet_colored.png', true);
     texture.load().then(() => {
       const ss = new ex.SpriteSheet({
         image: texture,
@@ -177,7 +181,7 @@ describe('A spritesheet', () => {
       width: 32,
       height: 32
     });
-    texture = new ex.Texture('base/src/spec/images/SpriteSheetSpec/SpriteSheetSpacing.png', true);
+    const texture = new ex.Texture('base/src/spec/images/SpriteSheetSpec/SpriteSheetSpacing.png', true);
     texture.load().then(() => {
       const ss = new ex.SpriteSheet({
         image: texture,
@@ -207,6 +211,7 @@ describe('A spritesheet', () => {
 
   it('should throw Error SpriteSheet specified is wider than image width', (done) => {
     let error: any;
+    const texture = new ex.Texture('base/src/spec/images/SpriteSheetSpec/PlayerRun.png', true);
     texture.load().then(() => {
       try {
         const ss = new ex.SpriteSheet({
@@ -228,6 +233,7 @@ describe('A spritesheet', () => {
 
   it('should throw Error SpriteSheet specified is higher than image height', (done) => {
     let error: any;
+    const texture = new ex.Texture('base/src/spec/images/SpriteSheetSpec/PlayerRun.png', true);
     texture.load().then(() => {
       try {
         const ss = new ex.SpriteSheet({


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================


Closes #1199

It was possible for the wrong sprite sheet to be loaded during the test depending on test execution order

## Changes:

- Explicitly load the sprite sheet texture for each test
