### PR TITLE
[#1294] Fix excalibur key events in iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed animation flipping behavior ([#1172](https://github.com/excaliburjs/Excalibur/issues/1172))
 - Fixed actors being drawn when their opacity is 0 ([#875](https://github.com/excaliburjs/Excalibur/issues/875))
+- Fixed iframe event handling, excalibur will respond to keyboard events from the top window ([#1294](https://github.com/excaliburjs/Excalibur/issues/1294))
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -1,13 +1,11 @@
 ﻿<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Excalibur Test Directory</title>
+  </head>
 
-<head>
-   <title>Excalibur Test Directory</title>
-</head>
-
-<body>
-
-   <ul>
+  <body>
+    <ul>
       <li><a href="html/index.html">Sandbox Platformer</a></li>
       <li><a href="tests/animation/animation.html">Animations</a></li>
       <li><a href="tests/gif/animatedGif.html">Animated Gif</a></li>
@@ -18,6 +16,7 @@
       <li><a href="tests/kill/kill.html">Kill</a></li>
       <li><a href="tests/input/index.html"> Input</a></li>
       <li><a href="tests/input/keyboard.html">Keyboard Input</a></li>
+      <li><a href="tests/input/iframe.html">Iframe Input</a></li>
       <li><a href="tests/loader/pauseafter/index.html">Loader - PauseAfterLoader</a></li>
       <li><a href="tests/loader/pauseafter/ios.html">Loader - PauseAfterLoader (iOS-only)</a></li>
       <li><a href="tests/input/pointer.html">Pointer Input</a></li>
@@ -52,26 +51,25 @@
       <li><a href="tests/noise/index.html">Perlin Noise</a></li>
       <li><a href="tests/ui">UI Actors</a></li>
       <li><a href="tests/tilemap/tilemap.html">TileMap</a></li>
-   </ul>
+    </ul>
 
-   <h3>Engine</h3>
+    <h3>Engine</h3>
 
-   <ul>
+    <ul>
       <li><a href="tests/engine/timescale.html">Timescaling</a></li>
-   </ul>
+    </ul>
 
-   <h3>Actions</h3>
+    <h3>Actions</h3>
 
-   <ul>
+    <ul>
       <li><a href="tests/actions/fade.html">Fade</a></li>
-   </ul>
+    </ul>
 
-   <h3>Debug</h3>
+    <h3>Debug</h3>
 
-   <ul>
+    <ul>
       <li><a href="tests/debug/stats.html">Stats</a></li>
       <li><a href="tests/debug/boundingbox.html">Bounding Boxes</a></li>
-   </ul>
-</body>
-
+    </ul>
+  </body>
 </html>

--- a/sandbox/tests/input/iframe.html
+++ b/sandbox/tests/input/iframe.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Iframe Tester</title>
+  </head>
+  <body>
+    <iframe src="./innerframe.html" width="800" height="600"></iframe>
+    <p>Key events should work through the iframe, press keys on the keyboard</p>
+  </body>
+</html>

--- a/sandbox/tests/input/iframe.ts
+++ b/sandbox/tests/input/iframe.ts
@@ -1,0 +1,21 @@
+/// <reference path='../../lib/excalibur.d.ts' />
+
+var game = new ex.Engine({ width: 800, height: 600, canvasElementId: 'game' });
+var label = new ex.Label(null, 400, 300, '48px Arial');
+label.color = ex.Color.Chartreuse;
+label.textAlign = ex.TextAlign.Center;
+
+game.add(label);
+
+game.on('postupdate', (ue: ex.PostUpdateEvent) => {
+  var keys = game.input.keyboard
+    .getKeys()
+    .map((k) => {
+      return (ex.Input.Keys[k] || 'Unknown') + '(' + k.toString() + ')';
+    })
+    .join(', ');
+
+  label.text = keys;
+});
+
+game.start();

--- a/sandbox/tests/input/innerframe.html
+++ b/sandbox/tests/input/innerframe.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Innerframe</title>
+  </head>
+  <body>
+    <canvas id="game"></canvas>
+    <script src="../../lib/excalibur.js"></script>
+    <script src="iframe.js"></script>
+  </body>
+</html>

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -96,6 +96,8 @@ export class Keyboard extends Class {
    * Initialize Keyboard event listeners
    */
   init(global?: GlobalEventHandlers): void {
+    // See https://github.com/excaliburjs/Excalibur/issues/1294
+    // window.top is for the iframe case
     global = global || window.top || window;
     global.addEventListener('blur', () => {
       this._keys.length = 0; // empties array efficiently

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -96,7 +96,7 @@ export class Keyboard extends Class {
    * Initialize Keyboard event listeners
    */
   init(global?: GlobalEventHandlers): void {
-    global = global || window;
+    global = global || window.top || window;
     global.addEventListener('blur', () => {
       this._keys.length = 0; // empties array efficiently
     });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1294

## Changes:

- Listen to `window.top` if available to grab the topmost window
