### PR TITLE
[#1317] Don't ramp volume when set at start of playback

### DIFF
--- a/src/engine/Resources/Sound/AudioInstance.ts
+++ b/src/engine/Resources/Sound/AudioInstance.ts
@@ -193,7 +193,7 @@ export class WebAudioInstance extends AudioInstance {
 
     this._volume = value;
 
-    if (this._volumeNode.gain.setTargetAtTime) {
+    if (this._isPlaying && this._volumeNode.gain.setTargetAtTime) {
       // https://developer.mozilla.org/en-US/docs/Web/API/AudioParam/setTargetAtTime
       // After each .1 seconds timestep, the target value will ~63.2% closer to the target value.
       // This exponential ramp provides a more pleasant trasition in gain

--- a/src/spec/WebAudioInstanceSpec.ts
+++ b/src/spec/WebAudioInstanceSpec.ts
@@ -31,6 +31,12 @@ describe('A webaudio instance', () => {
         setValueAtTime: () => {
           /*empty*/
         }
+      },
+      start: () => {
+        /*empty*/
+      },
+      stop: () => {
+        /*empty*/
       }
     };
 
@@ -54,5 +60,11 @@ describe('A webaudio instance', () => {
   it('should set volume immediately', () => {
     webaudio.volume = 0.5;
     expect(mockGainNode.gain.value).toEqual(0.5);
+  });
+
+  it('should ramp volume when set during playback', () => {
+    webaudio.play();
+    webaudio.volume = 0.25;
+    expect(mockGainNode.gain.setTargetAtTime).toHaveBeenCalledWith(webaudio.volume, 0, 0.1);
   });
 });

--- a/src/spec/WebAudioInstanceSpec.ts
+++ b/src/spec/WebAudioInstanceSpec.ts
@@ -60,6 +60,7 @@ describe('A webaudio instance', () => {
   it('should set volume immediately', () => {
     webaudio.volume = 0.5;
     expect(mockGainNode.gain.value).toEqual(0.5);
+    expect(mockGainNode.gain.setTargetAtTime).not.toHaveBeenCalled();
   });
 
   it('should ramp volume when set during playback', () => {

--- a/src/spec/WebAudioInstanceSpec.ts
+++ b/src/spec/WebAudioInstanceSpec.ts
@@ -51,8 +51,8 @@ describe('A webaudio instance', () => {
     expect(webaudio).toBeDefined();
   });
 
-  it('should use specific settings for volume', () => {
-    webaudio.volume = 1;
-    expect(mockGainNode.gain.setTargetAtTime).toHaveBeenCalledWith(webaudio.volume, 0, 0.1);
+  it('should set volume immediately', () => {
+    webaudio.volume = 0.5;
+    expect(mockGainNode.gain.value).toEqual(0.5);
   });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1317

## Changes:

- Only apply volume ramp if sound is already playing.