### PR TITLE
[bugfix] Fix doc type references

### DIFF
--- a/src/engine/Actions/ActionContext.ts
+++ b/src/engine/Actions/ActionContext.ts
@@ -9,7 +9,7 @@ import { EasingFunction, EasingFunctions } from '../Util/EasingFunctions';
  * The fluent Action API allows you to perform "actions" on
  * [[Actor|Actors]] such as following, moving, rotating, and
  * more. You can implement your own actions by implementing
- * the [[IAction]] interface.
+ * the [[Action]] interface.
  *
  * [[include:Actions.md]]
  */

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -419,7 +419,7 @@ export class ActorImpl extends Class implements Actionable, Eventable, PointerEv
 
   /**
    * Sets the color of the actor. A rectangle of this color will be
-   * drawn if no [[IDrawable]] is specified as the actors drawing.
+   * drawn if no [[Drawable]] is specified as the actors drawing.
    *
    * The default is `null` which prevents a rectangle from being drawn.
    */

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -439,7 +439,7 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
 
   /**
    * Adds a new camera strategy to this camera
-   * @param cameraStrategy Instance of an [[ICameraStrategy]]
+   * @param cameraStrategy Instance of an [[CameraStrategy]]
    */
   public addStrategy<T>(cameraStrategy: CameraStrategy<T>) {
     this._cameraStrategies.push(cameraStrategy);
@@ -447,7 +447,7 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
 
   /**
    * Removes a camera strategy by reference
-   * @param cameraStrategy Instance of an [[ICameraStrategy]]
+   * @param cameraStrategy Instance of an [[CameraStrategy]]
    */
   public removeStrategy<T>(cameraStrategy: CameraStrategy<T>) {
     removeItemFromArray(cameraStrategy, this._cameraStrategies);

--- a/src/engine/Collision/Collider.ts
+++ b/src/engine/Collision/Collider.ts
@@ -24,7 +24,8 @@ export function isCollider(x: Actor | Collider): x is Collider {
 
 export interface ColliderOptions {
   /**
-   * Optional [[shape|Shape]] to use with this collider, the shape defines the collidable region along with the [[bounding box|BoundingBox]]
+   * Optional [[CollisionShape|Shape]] to use with this collider, the shape defines the collidable
+   * region along with the [[BoundingBox|bounding box]]
    */
   shape?: CollisionShape;
   /**
@@ -40,7 +41,7 @@ export interface ColliderOptions {
    */
   group?: CollisionGroup;
   /**
-   * Optional [[collision type|CollisionType]], if not specified the default is [[CollisionType.PreventCollision]]
+   * Optional [[CollisionType|collision type]], if not specified the default is [[CollisionType.PreventCollision]]
    */
   type?: CollisionType;
   /**

--- a/src/engine/Collision/Shape.ts
+++ b/src/engine/Collision/Shape.ts
@@ -23,7 +23,7 @@ export class Shape {
   }
 
   /**
-   * Creates a new [[arbitrary polygon|ConvexPolygon]] collision shape
+   * Creates a new [[ConvexPolygon|arbitrary polygon]] collision shape
    * @param points Points specified in counter clockwise
    * @param clockwiseWinding Optionally changed the winding of points, by default false meaning counter-clockwise winding.
    * @param offset Optional offset relative to the collider in local coordinates
@@ -49,7 +49,7 @@ export class Shape {
   }
 
   /**
-   * Creates a new [[edge|Edge]] collision shape
+   * Creates a new [[Edge|edge]] collision shape
    * @param begin Beginning of the edge in local coordinates to the collider
    * @param end Ending of the edge in local coordinates to the collider
    */

--- a/src/engine/Debug.ts
+++ b/src/engine/Debug.ts
@@ -153,13 +153,13 @@ export class Debug implements DebugFlags {
   public stats: DebugStats = {
     /**
      * Current frame statistics. Engine reuses this instance, use [[FrameStats.clone]] to copy frame stats.
-     * Best accessed on [[postframe]] event. See [[IFrameStats]]
+     * Best accessed on [[postframe]] event. See [[FrameStats]]
      */
     currFrame: new FrameStats(),
 
     /**
      * Previous frame statistics. Engine reuses this instance, use [[FrameStats.clone]] to copy frame stats.
-     * Best accessed on [[preframe]] event. Best inspected on engine event `preframe`. See [[IFrameStats]]
+     * Best accessed on [[preframe]] event. Best inspected on engine event `preframe`. See [[FrameStats]]
      */
     prevFrame: new FrameStats()
   };

--- a/src/engine/Docs/Actions.md
+++ b/src/engine/Docs/Actions.md
@@ -77,7 +77,7 @@ to automatically generate the actions needed to do pathing.
 
 ## Custom Actions
 
-The API does allow you to implement new actions by implementing the [[IAction]]
+The API does allow you to implement new actions by implementing the [[Action]]
 interface, but this will be improved in future versions as right now it
 is meant for the Excalibur team and can be advanced to implement.
 

--- a/src/engine/Docs/BoxAndPolygonShape.md
+++ b/src/engine/Docs/BoxAndPolygonShape.md
@@ -1,8 +1,8 @@
 ## Box and ConvexPolygon Collision Shapes
 
-Excalibur has a [[shape|Shape]] static helper to create boxes and [[polygons|ConvexPolygon]] for collisions in your game.
+Excalibur has a [[CollisionShape|Shape]] static helper to create boxes and [[ConvexPolygon|polygons]] for collisions in your game.
 
-The default shape for a collider is a box, a custom box shape and [[collider|Collider]] can be created for an [[actor|Actor]] [[body|Body]]. The `ex.Shape.Box` helper actually creates a [[ConvexPolygon]] shape in Excalibur.
+The default shape for a collider is a box, a custom box shape and [[collider|Collider]] can be created for an [[Actor|actor]] [[Body|body]]. The `ex.Shape.Box` helper actually creates a [[ConvexPolygon]] shape in Excalibur.
 
 ```typescript
 const block = new ex.Actor({
@@ -17,11 +17,11 @@ const block = new ex.Actor({
 });
 ```
 
-Creating a custom [[convex polygon|ConvexPolygon]] shape is just as simple. Excalibur only supports arbitrary convex shapes as a ConvexPolygon, this means no "cavities" in the shape, for example "pac-man" is not a convex shape.
+Creating a custom [[ConvexPolygon|convex polygon]] shape is just as simple. Excalibur only supports arbitrary convex shapes as a ConvexPolygon, this means no "cavities" in the shape, for example "pac-man" is not a convex shape.
 
-The `points` in a [[convex polygon|ConvexPolygon]] have counter-clockwise winding by default, this means the points must be listed in counter-clockwise order around the shape to work. This can be switched by supplying `true` or `false` to the winding argument `ex.Shape.Polygon([...], true)` for clockwise winding.
+The `points` in a [[ConvexPolygon|convex polygon]] have counter-clockwise winding by default, this means the points must be listed in counter-clockwise order around the shape to work. This can be switched by supplying `true` or `false` to the winding argument `ex.Shape.Polygon([...], true)` for clockwise winding.
 
-**Keep in mind**, points are defined local to the [[body|Body]] or [[actor|Actor]]. Meaning that the triangle defined below is centered around `ex.Vector(400, 400)` in world space.
+**Keep in mind**, points are defined local to the [[Body|body]] or [[Actor|actor]]. Meaning that the triangle defined below is centered around `ex.Vector(400, 400)` in world space.
 
 ```typescript
 const triangle = new ex.Actor({

--- a/src/engine/Docs/Cameras.md
+++ b/src/engine/Docs/Cameras.md
@@ -44,7 +44,7 @@ game.currentScene.camera.strategy.radiusAroundActor(actor, radius);
 
 ## Custom strategies
 
-Custom strategies can be implemented by extending the ICameraStrategy interface and added to cameras to build novel behavior with `ex.Camera.addStrategy<T>(new MyCameraStrategy<T>())`.
+Custom strategies can be implemented by extending the [[CameraStrategy]] interface and added to cameras to build novel behavior with `ex.Camera.addStrategy<T>(new MyCameraStrategy<T>())`.
 
 As shown below a camera strategy calculates a new camera position (`ex.Vector`) every frame given a target type, camera, engine, and elapsed delta in milliseconds.
 

--- a/src/engine/Docs/CircleShape.md
+++ b/src/engine/Docs/CircleShape.md
@@ -1,8 +1,8 @@
 ## Circle Collision Shape
 
-Excalibur has a [[shape|Shape]] static helper to create [[circles|Circle]] for collisions in your game.
+Excalibur has a [[CollisionShape|Shape]] static helper to create [[Circle|circles]] for collisions in your game.
 
-The default shape for a collider is a box, however a custom [[circle|Circle]] shape and [[collider|Collider]] can be created for an [[actor|Actor]] [[body|Body]].
+The default shape for a collider is a box, however a custom [[Circle|circle]] shape and [[Collider|collider]] can be created for an [[Actor|actor]] [[Body|body]].
 
 This example creates a circle of `radius = 50`.
 

--- a/src/engine/Docs/EdgeShape.md
+++ b/src/engine/Docs/EdgeShape.md
@@ -1,12 +1,12 @@
 ## Edge Collision Shape
 
-Excalibur has a [[shape|Shape]] static helper to create [[edges|Edge]] for collisions in your game.
+Excalibur has a [[CollisionShape|Shape]] static helper to create [[Edge|edges]] for collisions in your game.
 
-The default shape for a collider is a box, however a custom [[edge|Edge]] shape and [[collider|Collider]] can be created for an [[actor|Actor]] [[body|Body]].
+The default shape for a collider is a box, however a custom [[Edge|edge]] shape and [[collider|Collider]] can be created for an [[Actor|actor]] [[Body|body]].
 
-[[Edges|Edge]] are useful for creating walls, barriers, or platforms in your game.
+[[Edge|Edges]] are useful for creating walls, barriers, or platforms in your game.
 
-**Keep in mind**, edges are defined local to the [[body|Body]] or [[actor|Actor]]. Meaning that the edge defined below starts at `ex.Vector(100, 100)` and goes to `ex.Vector(130, 400)` in world space. It is recommended when defining edges to leave the first coordinate `ex.Vector.Zero` to avoid confusion.
+**Keep in mind**, edges are defined local to the [[Body|body]] or [[Actor|actor]]. Meaning that the edge defined below starts at `ex.Vector(100, 100)` and goes to `ex.Vector(130, 400)` in world space. It is recommended when defining edges to leave the first coordinate `ex.Vector.Zero` to avoid confusion.
 
 ```typescript
 const wall = new ex.Actor({

--- a/src/engine/Docs/Engine.md
+++ b/src/engine/Docs/Engine.md
@@ -105,12 +105,12 @@ you want to provide HTML UI on top or as part of your game.
 
 You can use [[DisplayMode.Position]] to specify where the game window will be displayed on screen. if
 this DisplayMode is selected, then a [[position]] option _must_ be provided to the Engine constructor.
-The [[position]] option can be a String or an [[IAbsolutePosition]]. The first word in a String _must_
+The [[position]] option can be a String or an [[AbsolutePosition]]. The first word in a String _must_
 be the desired vertical alignment of the window. The second (optional) word is the desired horizontal
 alignment.
 
 Valid String examples: "top left", "top", "bottom", "middle", "middle center", "bottom right"
-Valid IAbsolutePosition examples: {top: 5, right: 10%}, {bottom: 49em, left: 10px}, {left: 10, bottom: 40}
+Valid AbsolutePosition examples: {top: 5, right: 10%}, {bottom: 49em, left: 10px}, {left: 10, bottom: 40}
 
 ## Extending the Engine
 

--- a/src/engine/Docs/Index.md
+++ b/src/engine/Docs/Index.md
@@ -23,7 +23,7 @@ familiar with.
   - [[Trigger|Triggers]]
   - [[UIActor|UI Actors (HUD)]]
   - [[ActionContext|Action API]]
-  - [[Group|Groups]]
+  - [[CollisionGroup|Collision Groups]]
 - [[Physics|Working with Physics]]
 
 ## Working with Resources

--- a/src/engine/Docs/Loadables.md
+++ b/src/engine/Docs/Loadables.md
@@ -1,6 +1,6 @@
 ## Advanced: Custom loadables
 
-You can implement the [[ILoadable]] interface to create your own custom loadables.
+You can implement the [[Loadable]] interface to create your own custom loadables.
 
 This is an advanced feature, as the [[Resource]] class already wraps logic around
 blob/plain data for usages like JSON, configuration, levels, etc through XHR (Ajax).

--- a/src/engine/Docs/Resources.md
+++ b/src/engine/Docs/Resources.md
@@ -1,4 +1,4 @@
-[[Resource]] is an [[ILoadable]] so it can be passed to a [[Loader]] to pre-load before
+[[Resource]] is an [[Loadable]] so it can be passed to a [[Loader]] to pre-load before
 a level or game.
 
 Example usages: JSON, compressed files, blobs.

--- a/src/engine/Docs/SpriteEffects.md
+++ b/src/engine/Docs/SpriteEffects.md
@@ -2,4 +2,4 @@ Because these manipulate raw pixels, there is a performance impact to applying
 too many effects. Excalibur tries its best to by using caching to mitigate
 performance issues.
 
-Create your own effects by implementing [[ISpriteEffect]].
+Create your own effects by implementing [[SpriteEffect]].

--- a/src/engine/Drawing/Animation.ts
+++ b/src/engine/Drawing/Animation.ts
@@ -165,7 +165,7 @@ export class AnimationImpl implements Drawable {
   }
 
   /**
-   * Add a [[ISpriteEffect]] manually
+   * Add a [[SpriteEffect]] manually
    */
   public addEffect(effect: Effects.SpriteEffect) {
     for (const i in this.sprites) {
@@ -174,7 +174,7 @@ export class AnimationImpl implements Drawable {
   }
 
   /**
-   * Removes an [[ISpriteEffect]] from this animation.
+   * Removes an [[SpriteEffect]] from this animation.
    * @param effect Effect to remove from this animation
    */
   public removeEffect(effect: Effects.SpriteEffect): void;

--- a/src/engine/Drawing/Sprite.ts
+++ b/src/engine/Drawing/Sprite.ts
@@ -202,7 +202,7 @@ export class SpriteImpl implements Drawable {
   }
 
   /**
-   * Adds a new [[ISpriteEffect]] to this drawing.
+   * Adds a new [[SpriteEffect]] to this drawing.
    * @param effect  Effect to add to the this drawing
    */
   public addEffect(effect: Effects.SpriteEffect) {
@@ -217,7 +217,7 @@ export class SpriteImpl implements Drawable {
   }
 
   /**
-   * Removes a [[ISpriteEffect]] from this sprite.
+   * Removes a [[SpriteEffect]] from this sprite.
    * @param effect  Effect to remove from this sprite
    */
   public removeEffect(effect: Effects.SpriteEffect): void;

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -160,11 +160,11 @@ export interface EngineOptions {
 
   /**
    * Specify how the game window is to be positioned when the [[DisplayMode.Position]] is chosen. This option MUST be specified
-   * if the DisplayMode is set as [[DisplayMode.Position]]. The position can be either a string or an [[IAbsolutePosition]].
+   * if the DisplayMode is set as [[DisplayMode.Position]]. The position can be either a string or an [[AbsolutePosition]].
    * String must be in the format of css style background-position. The vertical position must precede the horizontal position in strings.
    *
    * Valid String examples: "top left", "top", "bottom", "middle", "middle center", "bottom right"
-   * Valid [[IAbsolutePosition]] examples: `{top: 5, right: 10%}`, `{bottom: 49em, left: 10px}`, `{left: 10, bottom: 40}`
+   * Valid [[AbsolutePosition]] examples: `{top: 5, right: 10%}`, `{bottom: 49em, left: 10px}`, `{left: 10, bottom: 40}`
    */
   position?: string | AbsolutePosition;
 
@@ -1308,7 +1308,7 @@ O|===|* >________________>\n\
   /**
    * Starts the internal game loop for Excalibur after loading
    * any provided assets.
-   * @param loader  Optional [[ILoader]] to use to load resources. The default loader is [[Loader]], override to provide your own
+   * @param loader  Optional [[Loader]] to use to load resources. The default loader is [[Loader]], override to provide your own
    * custom loader.
    */
   public start(loader?: CanLoad): Promise<any> {
@@ -1429,7 +1429,7 @@ O|===|* >________________>\n\
    * Another option available to you to load resources into the game.
    * Immediately after calling this the game will pause and the loading screen
    * will appear.
-   * @param loader  Some [[ILoadable]] such as a [[Loader]] collection, [[Sound]], or [[Texture]].
+   * @param loader  Some [[Loadable]] such as a [[Loader]] collection, [[Sound]], or [[Texture]].
    */
   public load(loader: Loadable): Promise<any> {
     const complete = new Promise<any>();

--- a/src/engine/Loader.ts
+++ b/src/engine/Loader.ts
@@ -18,7 +18,7 @@ import loaderCss from './Loader.css';
  * one time. The loader must be passed to the engine in order to
  * trigger the loading progress bar.
  *
- * The [[Loader]] itself implements [[ILoadable]] so you can load loaders.
+ * The [[Loader]] itself implements [[Loadable]] so you can load loaders.
  *
  * ## Example: Pre-loading resources for a game
  *

--- a/src/engine/Resources/Gif.ts
+++ b/src/engine/Resources/Gif.ts
@@ -8,7 +8,7 @@ import { Animation } from '../Drawing/Animation';
 import { Engine } from '../Engine';
 /**
  * The [[Texture]] object allows games built in Excalibur to load image resources.
- * [[Texture]] is an [[ILoadable]] which means it can be passed to a [[Loader]]
+ * [[Texture]] is an [[Loadable]] which means it can be passed to a [[Loader]]
  * to pre-load before starting a level or game.
  *
  * [[include:Textures.md]]

--- a/src/engine/Resources/Sound/Sound.ts
+++ b/src/engine/Resources/Sound/Sound.ts
@@ -10,7 +10,7 @@ import { canPlayFile } from '../../Util/Sound';
 
 /**
  * The [[Sound]] object allows games built in Excalibur to load audio
- * components, from soundtracks to sound effects. [[Sound]] is an [[ILoadable]]
+ * components, from soundtracks to sound effects. [[Sound]] is an [[Loadable]]
  * which means it can be passed to a [[Loader]] to pre-load before a game or level.
  *
  * [[include:Sounds.md]]
@@ -74,10 +74,10 @@ export class Sound extends Resource<Blob | ArrayBuffer> implements Audio {
 
     this._detectResponseType();
     /* Chrome : MP3, WAV, Ogg
-         * Firefox : WAV, Ogg,
-         * IE : MP3, WAV coming soon
-         * Safari MP3, WAV, Ogg
-         */
+     * Firefox : WAV, Ogg,
+     * IE : MP3, WAV coming soon
+     * Safari MP3, WAV, Ogg
+     */
     for (const path of paths) {
       if (canPlayFile(path)) {
         this.path = path;

--- a/src/engine/Resources/Texture.ts
+++ b/src/engine/Resources/Texture.ts
@@ -3,7 +3,7 @@ import { Promise } from '../Promises';
 import { Sprite } from '../Drawing/Sprite';
 /**
  * The [[Texture]] object allows games built in Excalibur to load image resources.
- * [[Texture]] is an [[ILoadable]] which means it can be passed to a [[Loader]]
+ * [[Texture]] is an [[Loadable]] which means it can be passed to a [[Loader]]
  * to pre-load before starting a level or game.
  *
  * [[include:Textures.md]]

--- a/src/engine/Util/Log.ts
+++ b/src/engine/Util/Log.ts
@@ -13,7 +13,7 @@ export enum LogLevel {
 /**
  * Static singleton that represents the logging facility for Excalibur.
  * Excalibur comes built-in with a [[ConsoleAppender]] and [[ScreenAppender]].
- * Derive from [[IAppender]] to create your own logging appenders.
+ * Derive from [[Appender]] to create your own logging appenders.
  *
  * [[include:Logger.md]]
  */
@@ -48,7 +48,7 @@ export class Logger {
   }
 
   /**
-   * Adds a new [[IAppender]] to the list of appenders to write to
+   * Adds a new [[Appender]] to the list of appenders to write to
    */
   public addAppender(appender: Appender): void {
     this._appenders.push(appender);


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Fixes broken TypeDoc type references