### PR TITLE
[#1504] Fix typedoc generated links by reverting to older version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3754,7 +3754,6 @@
           "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
           "requires": {
             "@babel/generator": "^7.8.4",
-            "@babel/helpers": "^7.8.4",
             "@babel/parser": "^7.8.4",
             "@babel/template": "^7.8.3",
             "@babel/traverse": "^7.8.4",
@@ -6790,6 +6789,15 @@
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
+    },
+    "backbone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+      "dev": true,
+      "requires": {
+        "underscore": ">=1.8.3"
+      }
     },
     "backo2": {
       "version": "1.0.2",
@@ -15179,6 +15187,12 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==",
+      "dev": true
+    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -20273,7 +20287,6 @@
           "requires": {
             "@babel/code-frame": "^7.8.3",
             "@babel/generator": "^7.8.4",
-            "@babel/helpers": "^7.8.4",
             "@babel/parser": "^7.8.4",
             "@babel/template": "^7.8.3",
             "@babel/traverse": "^7.8.4",
@@ -23731,21 +23744,22 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.4.tgz",
-      "integrity": "sha512-4Lotef1l6lNU5Fulpux809WPlF9CkmcXfv5QFyanrjYlxMFxSdARRdsy8Jv1OU3z0vjR4JsvUQT0YpiPqztcOA==",
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.8.tgz",
+      "integrity": "sha512-a0zypcvfIFsS7Gqpf2MkC1+jNND3K1Om38pbDdy/gYWX01NuJZhC5+O0HkIp0oRIZOo7PWrA5+fC24zkANY28Q==",
       "dev": true,
       "requires": {
+        "@types/minimatch": "3.0.3",
         "fs-extra": "^8.1.0",
-        "handlebars": "^4.7.6",
-        "highlight.js": "^9.18.1",
+        "handlebars": "^4.7.0",
+        "highlight.js": "^9.17.1",
         "lodash": "^4.17.15",
-        "lunr": "^2.3.8",
-        "marked": "0.8.2",
+        "marked": "^0.8.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.3",
-        "typedoc-default-themes": "^0.10.0"
+        "typedoc-default-themes": "^0.6.3",
+        "typescript": "3.7.x"
       },
       "dependencies": {
         "fs-extra": {
@@ -23766,9 +23780,9 @@
           "dev": true
         },
         "shelljs": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-          "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+          "version": "0.8.4",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+          "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
           "dev": true,
           "requires": {
             "glob": "^7.0.0",
@@ -23776,20 +23790,24 @@
             "rechoir": "^0.6.2"
           }
         },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        "typescript": {
+          "version": "3.7.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+          "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+          "dev": true
         }
       }
     },
     "typedoc-default-themes": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.1.tgz",
-      "integrity": "sha512-SuqAQI0CkwhqSJ2kaVTgl37cWs733uy9UGUqwtcds8pkFK8oRF4rZmCq+FXTGIb9hIUOu40rf5Kojg0Ha6akeg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.3.tgz",
+      "integrity": "sha512-rouf0TcIA4M2nOQFfC7Zp4NEwoYiEX4vX/ZtudJWU9IHA29MPC+PPgSXYLPESkUo7FuB//GxigO3mk9Qe1xp3Q==",
       "dev": true,
       "requires": {
-        "lunr": "^2.3.8"
+        "backbone": "^1.4.0",
+        "jquery": "^3.4.1",
+        "lunr": "^2.3.8",
+        "underscore": "^1.9.1"
       }
     },
     "typescript": {
@@ -23861,6 +23879,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
       "dev": true
     },
     "underscore.string": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "travis-ci": "2.2.0",
     "ts-loader": "7.0.1",
     "tslint": "6.1.1",
-    "typedoc": "0.17.4",
+    "typedoc": "0.15.8",
     "typescript": "3.8.3",
     "url-loader": "4.1.0",
     "webpack": "4.42.1",


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [N/A] ~~:microscope: existing tests still pass~~ 
- [N/A] ~~:see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)~~
- [N/A] ~~:triangular_ruler: new tests written and passing / old tests updated with new scenario(s)~~
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1504

## Changes:

- Reverts typedoc to an older version, link generation changed a few months back will open an issue with typedoc to discuss a path forward
