### PR TITLE
fix(Keyboard): Fix accessing cross-origin frame exception

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,7 @@
+import { addons } from '@storybook/addons';
+
+addons.setConfig({
+
+  // Excalibur will be listening for all key events
+  enableShortcuts: false
+})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed Excalibur crashing when embedded within a cross-origin IFrame ([#1151](https://github.com/excaliburjs/Excalibur/issues/1151))
+
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -1,7 +1,6 @@
-import { Class } from './../Class';
-import { GameEvent } from '../Events';
-import * as Events from '../Events';
 import { Logger } from '../Util/Log';
+import { Class } from '../Class';
+import * as Events from '../Events';
 
 /**
  * Enum representing input key codes
@@ -62,7 +61,7 @@ export enum Keys {
 /**
  * Event thrown on a game object for a key event
  */
-export class KeyEvent extends GameEvent<any> {
+export class KeyEvent extends Events.GameEvent<any> {
   /**
    * @param key  The key responsible for throwing the event
    */
@@ -88,7 +87,7 @@ export class Keyboard extends Class {
   public on(eventName: Events.press, handler: (event: KeyEvent) => void): void;
   public on(eventName: Events.release, handler: (event: KeyEvent) => void): void;
   public on(eventName: Events.hold, handler: (event: KeyEvent) => void): void;
-  public on(eventName: string, handler: (event: GameEvent<any>) => void): void;
+  public on(eventName: string, handler: (event: Events.GameEvent<any>) => void): void;
   public on(eventName: string, handler: (event: any) => void): void {
     super.on(eventName, handler);
   }

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -1,6 +1,7 @@
 import { Class } from './../Class';
 import { GameEvent } from '../Events';
 import * as Events from '../Events';
+import { Logger } from '../Util/Log';
 
 /**
  * Enum representing input key codes
@@ -96,9 +97,22 @@ export class Keyboard extends Class {
    * Initialize Keyboard event listeners
    */
   init(global?: GlobalEventHandlers): void {
-    // See https://github.com/excaliburjs/Excalibur/issues/1294
-    // window.top is for the iframe case
-    global = global || window.top || window;
+
+    // use passed in target or current window
+    global = global || window;
+
+    try {
+      // Try and listen to events on top window frame if within an iframe.
+      //
+      // See https://github.com/excaliburjs/Excalibur/issues/1294
+      global = window.top;
+    } catch {
+      Logger.getInstance().warn(
+        'Failed to bind to keyboard events from top-most window. ' +
+          'If you are trying to embed Excalibur in a cross-origin iframe, some features may not work until the game receives focus.'
+      );
+    }
+
     global.addEventListener('blur', () => {
       this._keys.length = 0; // empties array efficiently
     });

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -118,8 +118,8 @@ export class Keyboard extends Class {
         global = window;
 
         Logger.getInstance().warn(
-          'Failed to bind to keyboard events from top-most window. ' +
-            'If you are trying to embed Excalibur in a cross-origin iframe, some features may not work until the game receives focus.'
+          'Failed to bind to keyboard events to top frame. ' +
+            'If you are trying to embed Excalibur in a cross-origin iframe, keyboard events will not fire.'
         );
       }
     }

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -97,20 +97,31 @@ export class Keyboard extends Class {
    * Initialize Keyboard event listeners
    */
   init(global?: GlobalEventHandlers): void {
+    if (!global) {
+      try {
+        // Try and listen to events on top window frame if within an iframe.
+        //
+        // See https://github.com/excaliburjs/Excalibur/issues/1294
+        //
+        // Attempt to add an event listener, which triggers a DOMException on
+        // cross-origin iframes
+        const noop = () => {
+          return;
+        };
+        window.top.addEventListener('blur', noop);
+        window.top.removeEventListener('blur', noop);
 
-    // use passed in target or current window
-    global = global || window;
+        // this will be the same as window if not embedded within an iframe
+        global = window.top;
+      } catch {
+        // fallback to current frame
+        global = window;
 
-    try {
-      // Try and listen to events on top window frame if within an iframe.
-      //
-      // See https://github.com/excaliburjs/Excalibur/issues/1294
-      global = window.top;
-    } catch {
-      Logger.getInstance().warn(
-        'Failed to bind to keyboard events from top-most window. ' +
-          'If you are trying to embed Excalibur in a cross-origin iframe, some features may not work until the game receives focus.'
-      );
+        Logger.getInstance().warn(
+          'Failed to bind to keyboard events from top-most window. ' +
+            'If you are trying to embed Excalibur in a cross-origin iframe, some features may not work until the game receives focus.'
+        );
+      }
     }
 
     global.addEventListener('blur', () => {

--- a/src/stories/Actions.stories.ts
+++ b/src/stories/Actions.stories.ts
@@ -5,7 +5,7 @@ import { withEngine } from './utils';
 import heartTexture from './assets/heart.png';
 
 export default {
-  title: 'Actions',
+  title: 'Actors/Actions',
   decorators: [withKnobs]
 };
 

--- a/src/stories/Anchors.stories.ts
+++ b/src/stories/Anchors.stories.ts
@@ -4,7 +4,7 @@ import { withEngine } from './utils';
 import heartBitmap from './assets/heart.png';
 
 export default {
-  title: 'Transforms/Anchors'
+  title: 'Actors/Anchors'
 };
 
 class Cross extends Actor {

--- a/src/stories/Keyboard.stories.ts
+++ b/src/stories/Keyboard.stories.ts
@@ -1,0 +1,49 @@
+import { Label, Color, Input } from '../engine';
+import { withEngine } from './utils';
+
+export default {
+  title: 'Keyboard Input'
+};
+
+export const keyEvents = withEngine(async (game) => {
+  let lastKeysPressed: string;
+  const keyLabel = new Label({
+    x: game.halfCanvasWidth,
+    y: game.halfCanvasHeight,
+    color: Color.White,
+    fontSize: 72
+  });
+
+  const lastKey = new Label({
+    x: game.halfCanvasWidth,
+    y: game.halfCanvasHeight + 72,
+    color: Color.Cyan,
+    fontSize: 18
+  });
+
+  keyLabel.on('preupdate', () => {
+    const keys = game.input.keyboard.getKeys();
+
+    if (keys.length === 0) {
+      keyLabel.text = 'Press some keys';
+    } else {
+      lastKeysPressed = keys.map((key) => Input.Keys[key]).join('');
+      keyLabel.text = lastKeysPressed;
+    }
+  });
+
+  keyLabel.on('postupdate', () => {
+    lastKey.text = 'Last Pressed: ' + (lastKeysPressed || 'none');
+  });
+
+  keyLabel.on('predraw', (e) => {
+    // center text, which can be measured after we've drawn for the next frame
+    keyLabel.pos.setTo(game.halfCanvasWidth - keyLabel.getTextWidth(e.ctx) / 2, keyLabel.pos.y);
+    lastKey.pos.setTo(game.halfCanvasWidth - lastKey.getTextWidth(e.ctx) / 2, lastKey.pos.y);
+  });
+
+  game.add(keyLabel);
+  game.add(lastKey);
+
+  await game.start();
+});

--- a/src/stories/Pointers.stories.ts
+++ b/src/stories/Pointers.stories.ts
@@ -1,4 +1,3 @@
-import { action } from '@storybook/addon-actions';
 import * as ex from '../engine';
 import { withEngine } from './utils';
 
@@ -20,23 +19,18 @@ export const subscribingToEvents: Story = withEngine(async (game) => {
     onInitialize() {
       this.on(ex.EventTypes.PointerUp, (e) => {
         this.color = ex.Color.Black;
-        action('pointerup')(e);
       });
       this.on(ex.EventTypes.PointerDown, (e) => {
         this.color = ex.Color.Green;
-        action('pointerdown')(e);
       });
       this.on(ex.EventTypes.PointerEnter, (e) => {
         this.color = ex.Color.Yellow;
-        action('pointerenter')(e);
       });
       this.on(ex.EventTypes.PointerLeave, (e) => {
         this.color = ex.Color.Red;
-        action('pointerleave')(e);
       });
       this.on(ex.EventTypes.PointerMove, (e) => {
         this.color = ex.Color.Blue;
-        action('pointermove')(e);
       });
     }
   }
@@ -47,13 +41,13 @@ export const subscribingToEvents: Story = withEngine(async (game) => {
 
   await game.start(new ex.Loader());
 
-  game.input.pointers.primary.on('up', (e) => {
-    action('engine.pointerup')(e);
-  });
+  // game.input.pointers.primary.on('up', (e) => {
+  //   action('engine.pointerup')(e);
+  // });
 
-  game.input.pointers.primary.on('down', (e) => {
-    action('engine.pointerdown')(e);
-  });
+  // game.input.pointers.primary.on('down', (e) => {
+  //   action('engine.pointerdown')(e);
+  // });
 });
 
 subscribingToEvents.story = {
@@ -76,20 +70,16 @@ export const dragEvents: Story = withEngine(async (game) => {
     onInitialize() {
       this.on(ex.EventTypes.PointerDragStart, (e) => {
         this.color = ex.Color.Black;
-        action('pointerdragstart')(e);
       });
       this.on(ex.EventTypes.PointerDragEnd, (e) => {
         this.color = ex.Color.Green;
-        action('pointerdragend')(e);
       });
       this.on(ex.EventTypes.PointerDragMove, (e) => {
         this.color = ex.Color.Yellow;
         this.pos.setTo(e.pos.x, e.pos.y);
-        action('pointerdragmove')(e);
       });
       this.on(ex.EventTypes.PointerLeave, (e) => {
         this.color = ex.Color.Red;
-        action('pointerleave')(e);
       });
     }
   }

--- a/src/stories/utils.ts
+++ b/src/stories/utils.ts
@@ -1,4 +1,4 @@
-import { DisplayMode, Engine, Input } from '../engine';
+import { DisplayMode, Engine, Input, Logger } from '../engine';
 
 interface HTMLCanvasElement {
   gameRef?: Engine;
@@ -13,7 +13,7 @@ let observer: MutationObserver;
 /**
  * When Storybook unmounts story, make sure we cleanup the running game
  * to avoid weird state issues, or at least not to balloon memory.
- * 
+ *
  * @param records Change records
  */
 const onDomMutated: MutationCallback = (records) => {
@@ -41,6 +41,8 @@ export const withEngine = (storyFn: (game: Engine) => void) => {
   return () => {
     const canvas = document.createElement('canvas');
     const game = new Engine({ canvasElement: canvas, displayMode: DisplayMode.FullScreen, suppressPlayButton: true });
+
+    Logger.getInstance().info("Press 'd' for debug mode");
 
     game.input.keyboard.on('down', (keyDown?: Input.KeyEvent) => {
       if (keyDown.key === Input.Keys.D) {

--- a/src/stories/utils.ts
+++ b/src/stories/utils.ts
@@ -40,7 +40,12 @@ export const withEngine = (storyFn: (game: Engine) => void) => {
 
   return () => {
     const canvas = document.createElement('canvas');
-    const game = new Engine({ canvasElement: canvas, displayMode: DisplayMode.FullScreen, suppressPlayButton: true });
+    const game = new Engine({
+      canvasElement: canvas,
+      displayMode: DisplayMode.FullScreen,
+      suppressPlayButton: true,
+      pointerScope: Input.PointerScope.Canvas
+    });
 
     Logger.getInstance().info("Press 'd' for debug mode");
 


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #1510

## Changes:

- Fix `Keyboard.init` throwing error when embedded in cross-origin iframe
- Add Keyboard story
- Fix Anchors stories so they show up again
- Fix Pointer stories and use `PointerScope.Canvas` in Storybook
- Disable Storybook shortcuts so they don't conflict with keyboard-enabled stories

Example of it working in iframe:

![image](https://user-images.githubusercontent.com/563819/80446222-e6d2a000-88db-11ea-8b9f-8ee3cbbd2250.png)
