### PR TITLE
fix: [#1553] Scene `onInitialize` order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed Excalibur crashing when embedded within a cross-origin IFrame ([#1151](https://github.com/excaliburjs/Excalibur/issues/1151))
 - Fixed issue when loading images from a base64 strings that would crash the loader ([#1543](https://github.com/excaliburjs/Excalibur/issues/1543))
+- Fixed Scene initialization order when using the lifecycle overrides ([#1553](https://github.com/excaliburjs/Excalibur/issues/1553))
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -228,12 +228,13 @@ export class Scene extends Class implements CanInitialize, CanActivate, CanDeact
         this.camera.y = engine.halfDrawHeight;
       }
 
+      // This order is important! we want to be sure any custom init that add actors
+      // fire before the actor init
+      this.onInitialize.call(this, engine);
       this._initializeChildren();
 
       this._logger.debug('Scene.onInitialize', this, engine);
-
       this.eventDispatcher.emit('initialize', new InitializeEvent(engine, this));
-      this.onInitialize.call(this, engine);
       this._isInitialized = true;
     }
   }

--- a/src/spec/SceneSpec.ts
+++ b/src/spec/SceneSpec.ts
@@ -285,6 +285,21 @@ describe('A scene', () => {
     expect(initializeCount).toBe(1, 'Scenes can only be initialized once');
   });
 
+  it('should initialize before actors in the scene', () => {
+    const actor = new ex.Actor();
+    scene.add(actor);
+    let sceneInit = false;
+    scene.onInitialize = () => {
+      sceneInit = true;
+    };
+    actor.onInitialize = () => {
+      expect(sceneInit).toBe(true, 'Scene should be initialized first before any actors');
+    };
+
+    engine.goToScene('root');
+    scene.update(engine, 100);
+  });
+
   it('should allow adding and removing an Actor in same frame', () => {
     let removed = false;
     scene.add(actor);


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1553

## Changes:

- Update the Scene `onInitialize` order
- Add test to confirm order works
