### PR TITLE
fix: [#1636 ] First frame flicker when switching to an animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Fixed Animation flicker bug when switching to an animation ([#1636](https://github.com/excaliburjs/Excalibur/issues/1636))
+
+<!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
+<!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
+<!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
+
+## [[0.24.5] - 2020-09-07
+
+### Breaking Changes
+
 - [#1361] Makes use of proxies, Excalibur longer supports IE11 :boom: ([#1361]https://github.com/excaliburjs/Excalibur/issues/1361)
 
 ### Added
@@ -27,10 +47,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed Animation flicker bug on the first frame when using animations with scale, anchors, or rotation. ([#1636](https://github.com/excaliburjs/Excalibur/issues/1636))
-
-<!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
-<!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
-<!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 
 ## [0.24.4] - 2020-09-02
 

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -915,6 +915,9 @@ export class ActorImpl extends Entity implements Actionable, Eventable, PointerE
         Logger.getInstance().error(`the specified drawing key ${key} does not exist`);
       }
     }
+    if (this.currentDrawing && this.currentDrawing instanceof Animation) {
+      this.currentDrawing.tick(0);
+    }
   }
 
   /**

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -560,6 +560,95 @@ describe('A game actor', () => {
     });
   });
 
+  it('will tick animations when drawing switched', (done) => {
+    const texture = new ex.Texture('base/src/spec/images/SpriteSpec/icon.png', true);
+    texture.load().then(() => {
+      const sprite = new ex.Sprite({
+        image: texture,
+        x: 0,
+        y: 0,
+        width: 62,
+        height: 64,
+        rotation: 0,
+        anchor: new ex.Vector(0.0, 0.0),
+        scale: new ex.Vector(1, 1),
+        flipVertical: false,
+        flipHorizontal: false
+      });
+      const animation = new ex.Animation({
+        engine: engine,
+        sprites: [sprite, sprite],
+        speed: 200,
+        loop: false,
+        anchor: new ex.Vector(1, 1),
+        rotation: Math.PI,
+        scale: new ex.Vector(2, 2),
+        flipVertical: true,
+        flipHorizontal: true,
+        width: 100,
+        height: 200
+      });
+
+      spyOn(animation, 'tick').and.callThrough();
+
+      const actor = new ex.Actor({
+        pos: new ex.Vector(engine.halfCanvasWidth, engine.halfCanvasHeight),
+        width: 10,
+        height: 10
+      });
+
+      actor.addDrawing('default', animation);
+      actor.setDrawing('default');
+      expect(animation.tick).toHaveBeenCalledWith(0);
+      done();
+    });
+  });
+
+  it('will tick animations on update', (done) => {
+    const texture = new ex.Texture('base/src/spec/images/SpriteSpec/icon.png', true);
+    texture.load().then(() => {
+      const sprite = new ex.Sprite({
+        image: texture,
+        x: 0,
+        y: 0,
+        width: 62,
+        height: 64,
+        rotation: 0,
+        anchor: new ex.Vector(0.0, 0.0),
+        scale: new ex.Vector(1, 1),
+        flipVertical: false,
+        flipHorizontal: false
+      });
+      const animation = new ex.Animation({
+        engine: engine,
+        sprites: [sprite, sprite],
+        speed: 200,
+        loop: false,
+        anchor: new ex.Vector(1, 1),
+        rotation: Math.PI,
+        scale: new ex.Vector(2, 2),
+        flipVertical: true,
+        flipHorizontal: true,
+        width: 100,
+        height: 200
+      });
+
+      spyOn(animation, 'tick').and.callThrough();
+
+      const actor = new ex.Actor({
+        pos: new ex.Vector(engine.halfCanvasWidth, engine.halfCanvasHeight),
+        width: 10,
+        height: 10
+      });
+
+      actor.addDrawing('anim', animation);
+      actor.setDrawing('anim');
+      actor.update(engine, 100);
+      expect(animation.tick).toHaveBeenCalledWith(100, engine.stats.currFrame.id);
+      done();
+    });
+  });
+
   it('can detect containment off of child actors', () => {
     const parent = new ex.Actor(600, 100, 100, 100);
     const child = new ex.Actor(0, 0, 100, 100);


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Fixes additional issue with #1636 the problem is that if an animation switches inside of an action or another process in the main before animations have a time to be processed the same flicker will happen again.

## Changes:

- Calls an empty tick when switching to a new animation to ensure animation is ready
- Adds tests
