### PR TITLE
fix: [#1638] Re-tool easeTo actions to use velocity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed Animation flicker bug when switching to an animation ([#1636](https://github.com/excaliburjs/Excalibur/issues/1636))
+- Fixed `ex.Actor.easeTo` actions, they now use velocity to move Actors ([#1638](https://github.com/excaliburjs/Excalibur/issues/1638))
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->

--- a/src/engine/Actions/Action.ts
+++ b/src/engine/Actions/Action.ts
@@ -46,6 +46,8 @@ export class EaseTo implements Action {
       this._initialized = true;
     }
 
+    // Need to update lerp time first, otherwise the first update will always be zero
+    this._currentLerpTime += delta;
     let newX = this.actor.pos.x;
     let newY = this.actor.pos.y;
     if (this._currentLerpTime < this._lerpDuration) {
@@ -64,10 +66,9 @@ export class EaseTo implements Action {
       } else {
         newY = this.easingFcn(this._currentLerpTime, this._lerpStart.y, this._lerpEnd.y, this._lerpDuration);
       }
-      this.actor.vel.x = (newX - this.actor.pos.x) * delta;
-      this.actor.vel.y = (newY - this.actor.pos.y) * delta;
-
-      this._currentLerpTime += delta;
+      // Given the lerp position figure out the velocity in pixels per second
+      this.actor.vel.x = (newX - this.actor.pos.x) / (delta / 1000);
+      this.actor.vel.y = (newY - this.actor.pos.y) / (delta / 1000);
     } else {
       this.actor.pos.x = this._lerpEnd.x;
       this.actor.pos.y = this._lerpEnd.y;
@@ -85,6 +86,8 @@ export class EaseTo implements Action {
     this._initialized = false;
   }
   public stop(): void {
+    this.actor.vel.y = 0;
+    this.actor.vel.x = 0;
     this._stopped = true;
   }
 }

--- a/src/engine/Actions/Action.ts
+++ b/src/engine/Actions/Action.ts
@@ -64,13 +64,14 @@ export class EaseTo implements Action {
       } else {
         newY = this.easingFcn(this._currentLerpTime, this._lerpStart.y, this._lerpEnd.y, this._lerpDuration);
       }
-      this.actor.pos.x = newX;
-      this.actor.pos.y = newY;
+      this.actor.vel.x = (newX - this.actor.pos.x) * delta;
+      this.actor.vel.y = (newY - this.actor.pos.y) * delta;
 
       this._currentLerpTime += delta;
     } else {
       this.actor.pos.x = this._lerpEnd.x;
       this.actor.pos.y = this._lerpEnd.y;
+      this.actor.vel = Vector.Zero;
       //this._lerpStart = null;
       //this._lerpEnd = null;
       //this._currentLerpTime = 0;

--- a/src/spec/ActionSpec.ts
+++ b/src/spec/ActionSpec.ts
@@ -1,5 +1,6 @@
 import * as ex from '@excalibur';
 import { TestUtils } from './util/TestUtils';
+import { ExcaliburMatchers } from 'excalibur-jasmine';
 
 describe('Action', () => {
   let actor: ex.Actor;
@@ -8,6 +9,7 @@ describe('Action', () => {
   let scene: ex.Scene;
 
   beforeEach(() => {
+    jasmine.addMatchers(ExcaliburMatchers);
     engine = TestUtils.engine({ width: 100, height: 100 });
 
     actor = new ex.Actor();
@@ -197,6 +199,43 @@ describe('Action', () => {
       actor.update(engine, 500);
       expect(actor.pos.x).toBe(5);
       expect(actor.pos.y).toBe(0);
+    });
+  });
+
+  describe('easeTo', () => {
+    it('can be eased to a location given an easing function', () => {
+      expect(actor.pos).toBeVector(ex.vec(0, 0));
+
+      actor.actions.easeTo(100, 0, 1000, ex.EasingFunctions.EaseInOutCubic);
+
+      actor.update(engine, 500);
+      expect(actor.pos).toBeVector(ex.vec(50, 0));
+      expect(actor.vel).toBeVector(ex.vec(100, 0));
+
+      actor.update(engine, 500);
+      expect(actor.pos).toBeVector(ex.vec(100, 0));
+      expect(actor.vel).toBeVector(ex.vec(0, 0));
+
+      actor.update(engine, 500);
+      expect(actor.pos).toBeVector(ex.vec(100, 0));
+      expect(actor.vel).toBeVector(ex.vec(0, 0));
+    });
+
+    it('can be stopped', () => {
+      expect(actor.pos).toBeVector(ex.vec(0, 0));
+
+      actor.actions.easeTo(100, 0, 1000, ex.EasingFunctions.EaseInOutCubic);
+
+      actor.update(engine, 500);
+      expect(actor.pos).toBeVector(ex.vec(50, 0));
+      expect(actor.vel).toBeVector(ex.vec(100, 0));
+
+      actor.actions.clearActions();
+
+      // actor should not move and should have zero velocity after stopping
+      actor.update(engine, 500);
+      expect(actor.pos).toBeVector(ex.vec(50, 0));
+      expect(actor.vel).toBeVector(ex.vec(0, 0));
     });
   });
 


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #1638 

## Changes:

- Calculate the equivalent velocity needed to lerp instead of directly setting position
- Added tests
