### PR TITLE
docs: Update documented usage for label constructor

### DIFF
--- a/src/engine/Docs/Labels.md
+++ b/src/engine/Docs/Labels.md
@@ -8,7 +8,7 @@ to be drawn and updated on-screen.
 ```js
 var game = new ex.Engine();
 // constructor
-var label = new ex.Label('Hello World', 50, 50, '10px Arial');
+var label = new ex.Label('Hello World', 50, 50, 'Arial');
 // properties
 var label = new ex.Label();
 label.pos.x = 50;
@@ -43,16 +43,16 @@ or set [[Label.fontFamily]].
 **index.html**
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html>
-<head>
-  <!-- Include the web font per usual -->
-  <script src="//google.com/fonts/foobar"></script>
-</head>
-<body>
-  <canvas id="game"></canvas>
-  <script src="game.js"></script>
-</body>
+  <head>
+    <!-- Include the web font per usual -->
+    <script src="//google.com/fonts/foobar"></script>
+  </head>
+  <body>
+    <canvas id="game"></canvas>
+    <script src="game.js"></script>
+  </body>
 </html>
 ```
 

--- a/src/engine/Label.ts
+++ b/src/engine/Label.ts
@@ -196,7 +196,7 @@ export class LabelImpl extends Actor {
    * @param textOrConfig    The text of the label, or label option bag
    * @param x           The x position of the label
    * @param y           The y position of the label
-   * @param fontFamily  Use any valid CSS font string for the label's font. Web fonts are supported. Default is `10px sans-serif`.
+   * @param fontFamily  Use a value that is valid for the CSS `font-family` property. The default is `sans-serif`.
    * @param spriteFont  Use an Excalibur sprite font for the label's font, if a SpriteFont is provided it will take precedence
    * over a css font.
    */


### PR DESCRIPTION
Hello,

I took a look at #1364 and I'd suggest the least destructive approach is to amend the documented usage for that particular constructor overload for `Label`.

Before arriving at this conclusion, I toyed with the idea of accepting a valid value to the CSS `font` shorthand property. However, trying to get a simple regular expression to parse all cases seemed a bit overkill for what it's worth (e.g. `oblique 10deg small "Comic Sans"` is technically a valid value). The fact `Label` fragments the various font properties up into separate properties (i.e. `fontSize`, `fontStyle`, etc.) is the complication that makes parsing necessary I think.

I also noticed `LabelSpec.ts` has been suppressed entirely. I enabled it and ran the tests out of curiosity, noticed a failing one, and didn't go any further because it looks like some custom screenshot diff mechanism is being used.

And one last observation: I noticed some test-like files in the sandbox try to make use of this constructor with a `font`-like value. I haven't updated all usages of those. I guess if necessary, I can do that too.

(Note the additional whitespace diffs were forced by the pre-commit hook, I didn't make them explicitly.)

---

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================
