### PR TITLE
docs: Added ParticleEmitter Story on Storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Color now can parse RGB/A string using Color.fromRGBString('rgb(255, 255, 255)') or Color.fromRGBString('rgb(255, 255, 255, 1)')
+
 ### Changed
 
 ### Deprecated

--- a/src/engine/Drawing/Color.ts
+++ b/src/engine/Drawing/Color.ts
@@ -66,6 +66,28 @@ export class Color {
   }
 
   /**
+   * Creates a new instance of Color from a rgb string
+   *
+   * @param string  CSS color string of the form rgba(255, 255, 255, 1) or rgb(255, 255, 255)
+   */
+  public static fromRGBString(string: string): Color {
+    const rgbaRegEx: RegExp = /^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)/i;
+    let match = null;
+    if ((match = string.match(rgbaRegEx))) {
+      const r = parseInt(match[1], 10);
+      const g = parseInt(match[2], 10);
+      const b = parseInt(match[3], 10);
+      let a = 1;
+      if (match[4]) {
+        a = parseFloat(match[4]);
+      }
+      return new Color(r, g, b, a);
+    } else {
+      throw new Error('Invalid rgb/a string: ' + string);
+    }
+  }
+
+  /**
    * Creates a new instance of Color from a hex string
    *
    * @param hex  CSS color string of the form #ffffff, the alpha component is optional

--- a/src/spec/ColorSpec.ts
+++ b/src/spec/ColorSpec.ts
@@ -52,6 +52,22 @@ describe('A color', () => {
     expect(color.a).toBe(0);
   });
 
+  it('can be parsed from rgb string', () => {
+    color = ex.Color.fromRGBString('rgb(100, 120, 140)');
+    expect(color.r).toBe(100);
+    expect(color.g).toBe(120);
+    expect(color.b).toBe(140);
+    expect(color.a).toBe(1);
+  });
+
+  it('can be parsed from rgba string', () => {
+    color = ex.Color.fromRGBString('rgb(100, 120, 140, 0.5)');
+    expect(color.r).toBe(100);
+    expect(color.g).toBe(120);
+    expect(color.b).toBe(140);
+    expect(color.a).toBe(0.5);
+  });
+
   it('can be parsed from hsl', () => {
     color = ex.Color.fromHSL(0, 0, 1.0);
     expect(color.r).toBe(255);

--- a/src/stories/ParticleEmitter.stories.ts
+++ b/src/stories/ParticleEmitter.stories.ts
@@ -1,0 +1,63 @@
+import { withKnobs, number, select, boolean, color } from '@storybook/addon-knobs';
+import { ParticleEmitter, EmitterType, Color, Vector } from '../engine';
+import { withEngine, enumToKnobSelect } from './utils';
+
+export default {
+  title: 'ParticleEmitter',
+  decorators: [withKnobs]
+};
+
+export const main = withEngine(async (game) => {
+  // Knobs
+  const width = number('width', 1, { range: true, min: 0, max: 100, step: 1 });
+  const height = number('height', 1, { range: true, min: 0, max: 100, step: 1 });
+  const emitterType = select('emitterType', enumToKnobSelect(EmitterType), EmitterType.Rectangle);
+  const radius = number('radius', 5, { range: true, min: 0, max: 1000, step: 1 });
+  const minVel = number('minVel', 100, { range: true, min: 0, max: 1000, step: 1 });
+  const maxVel = number('maxVel', 200, { range: true, min: 0, max: 1000, step: 1 });
+  const minAngle = number('minAngle', 0, { range: true, min: 0, max: 6.2, step: 0.1 });
+  const maxAngle = number('maxAngle', 6.2, { range: true, min: 0, max: 6.2, step: 0.1 });
+  const isEmitting = boolean('isEmitting', true);
+  const emitRate = number('emitRate', 300, { range: true, min: 0, max: 1000, step: 1 });
+  const opacity = number('opacity', 0.5, { range: true, min: 0, max: 1, step: 0.01 });
+  const fadeFlag = boolean('fadeFlag', true);
+  const particleLife = number('particleLife (ms)', 1000, { range: true, min: 0, max: 5000, step: 10 });
+  const minSize = number('minSize', 1, { range: true, min: 0, max: 200, step: 1 });
+  const maxSize = number('maxSize', 10, { range: true, min: 0, max: 200, step: 1 });
+  const startSize = number('startSize', 5, { range: true, min: 0, max: 200, step: 1 });
+  const endSize = number('endSize', 10, { range: true, min: 0, max: 200, step: 1 });
+  const accelX = number('Accel X', 0, { range: true, min: -2000, max: 2000, step: 1 });
+  const accelY = number('Accel Y', 0, { range: true, min: -2000, max: 2000, step: 1 });
+  const beginColor = color('beginColor', Color.Rose.toRGBA());
+  const endColor = color('endColor', Color.Yellow.toRGBA());
+
+  // Default Scenario
+  game.backgroundColor = Color.Black;
+
+  // Particle Emitter
+  const emitter = new ParticleEmitter(game.currentScene.camera.x, game.currentScene.camera.y);
+  emitter.width = width;
+  emitter.height = height;
+  emitter.emitterType = emitterType;
+  emitter.radius = radius;
+  emitter.minVel = minVel;
+  emitter.maxVel = maxVel;
+  emitter.minAngle = minAngle;
+  emitter.maxAngle = maxAngle;
+  emitter.isEmitting = isEmitting;
+  emitter.emitRate = emitRate;
+  emitter.opacity = opacity;
+  emitter.fadeFlag = fadeFlag;
+  emitter.particleLife = particleLife;
+  emitter.minSize = minSize;
+  emitter.maxSize = maxSize;
+  emitter.startSize = startSize;
+  emitter.endSize = endSize;
+  emitter.acceleration = new Vector(accelX, accelY);
+  emitter.beginColor = Color.fromRGBString(beginColor);
+  emitter.endColor = Color.fromRGBString(endColor);
+  emitter.focusAccel = 800;
+  game.add(emitter);
+
+  await game.start();
+});

--- a/src/stories/utils.ts
+++ b/src/stories/utils.ts
@@ -4,6 +4,9 @@ interface HTMLCanvasElement {
   gameRef?: Engine;
 }
 
+/**
+ *
+ */
 function isCanvasElement(el: any): el is HTMLCanvasElement {
   return el && el.nodeName === 'CANVAS';
 }
@@ -47,7 +50,7 @@ export const withEngine = (storyFn: (game: Engine) => void) => {
       pointerScope: Input.PointerScope.Canvas
     });
 
-    Logger.getInstance().info("Press 'd' for debug mode");
+    Logger.getInstance().info('Press \'d\' for debug mode');
 
     game.input.keyboard.on('down', (keyDown?: Input.KeyEvent) => {
       if (keyDown.key === Input.Keys.D) {
@@ -62,4 +65,17 @@ export const withEngine = (storyFn: (game: Engine) => void) => {
 
     return canvas;
   };
+};
+
+/**
+ * Helper to generate Storybook Knob Select Options from a Enum Type
+ * @param e Enum
+ */
+export const enumToKnobSelect = (e: any): Record<string, any> => {
+  return Object.keys(e)
+    .filter((k) => typeof e[k as any] === 'number')
+    .reduce((o: Record<string, any>, el: string) => {
+      o[el] = e[el];
+      return o;
+    }, {});
 };


### PR DESCRIPTION
HI, As mentioned on the Issue #1536 (https://github.com/excaliburjs/Excalibur/issues/1536) I ported the [Particle Tester}(https://github.com/excaliburjs/particle-tester) into Storybook of the main repo.
Basically it's the same using the Knobs provided by the addon. The only problem that I haved it's to support the Color Selecto to be more Flexible on the options that we show, I included a new static function fromRGBString to create a Color from a rgb or rgba string used by the color knob.
If you want, I can change this and back to a Static list of colors or move this functionality outside of the Color class.

- Added the ParticleEmitter Story on Storybook
- Added a function to create and parse the RGB and RGBA from string on Color class. (This is for use directly the Knob color provided by storybook without any intermediate transformation)

![image](https://user-images.githubusercontent.com/2272323/95000723-969def00-0599-11eb-927c-f3df46e79b28.png)

===:clipboard: PR Checklist :clipboard:===

- [X] :pushpin: issue exists in github for these changes
- [X] :microscope: existing tests still pass
- [X] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [X] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [X] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1536
Resolves: #1536