### PR TITLE
fix: Make engine parameter optional for scene constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed Animation flicker bug when switching to an animation ([#1636](https://github.com/excaliburjs/Excalibur/issues/1636))
 - Fixed `ex.Actor.easeTo` actions, they now use velocity to move Actors ([#1638](https://github.com/excaliburjs/Excalibur/issues/1638))
+- Fixed `Scene` constructor signature to make the `Engine` argument optional ([#1363](https://github.com/excaliburjs/Excalibur/issues/1363))
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -93,7 +93,7 @@ export class Scene extends Class implements CanInitialize, CanActivate, CanDeact
   private _cancelQueue: Timer[] = [];
   private _logger: Logger = Logger.getInstance();
 
-  constructor(_engine: Engine) {
+  constructor(_engine?: Engine) {
     super();
     this.camera = new Camera();
     this._engine = _engine;


### PR DESCRIPTION
Hello,

This minor change should address #1363.

As additional information, I noticed there aren't any usages within the codebase which invoke the parameter-less constructor for `Scene`. However, there are usages with the `Engine` argument supplied scattered throughout spec and test files. The usages of `new Scene()` appear to be confined to the documentation.

I also noticed there had been a change made in the past (#1068) which caused the `Engine` argument to be mandatory in the constructor signature to begin with. It's not clear to me exactly why that was done given the context available.

---
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================