### PR TITLE
chore: [#1656] Remove UIActor Stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking Changes
 
 - Directly changing debug drawing by `engine.isDebug = value` has been replaced by `engine.showDebug(value)` and `engine.toggleDebug()` ([#1655](https://github.com/excaliburjs/Excalibur/issues/1655))
+- `UIActor` Class instances need to be replaced to `ScreenElement` (This Class it's marked as Obsolete) ([#1656](https://github.com/excaliburjs/Excalibur/issues/1656))
 
 ### Added
 
@@ -16,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Deprecated
+
+- Removed UIActor Stub in favor of ScreenElement ([#1656](https://github.com/excaliburjs/Excalibur/issues/1656))
 
 ### Removed
 

--- a/src/engine/Docs/Constructors.md
+++ b/src/engine/Docs/Constructors.md
@@ -54,7 +54,6 @@ See:
 - [[Sprite]]
 - [[SpriteSheet]]
 - [[SpriteFont]]
-- [[UIActor]]
 - [[Particle]]
 - [[ParticleEmitter]]
 - [[TileMap]]

--- a/src/engine/Docs/Index.md
+++ b/src/engine/Docs/Index.md
@@ -21,7 +21,6 @@ familiar with.
 - [[Actor|Working with Actors]]
   - [[Label|Labels]]
   - [[Trigger|Triggers]]
-  - [[UIActor|UI Actors (HUD)]]
   - [[ActionContext|Action API]]
   - [[CollisionGroup|Collision Groups]]
 - [[Physics|Working with Physics]]

--- a/src/engine/ScreenElement.ts
+++ b/src/engine/ScreenElement.ts
@@ -4,7 +4,6 @@ import { Actor, ActorArgs } from './Actor';
 import * as Traits from './Traits/Index';
 import { CollisionType } from './Collision/CollisionType';
 import { Shape } from './Collision/Shape';
-import { obsolete } from './Util/Decorators';
 
 /**
  * Helper [[Actor]] primitive for drawing UI's, optimized for UI drawing. Does
@@ -50,10 +49,3 @@ export class ScreenElement extends Actor {
     return super.contains(coords.x, coords.y);
   }
 }
-
-/**
- * Legacy UIActor constructor
- * @obsolete UIActor constructor will be removed in v0.25.0 use [[ScreenElement]] instead
- */
-@obsolete({ message: 'Will be removed in v0.25.0', alternateMethod: 'ScreenElement' })
-export class UIActor extends ScreenElement {}


### PR DESCRIPTION
Hi, I removed the UIActor Class in favor to move the implementation to the ScreenElement (https://excaliburjs.com/docs/api/edge/classes/_screenelement_.screenelement.html).
I update the documentation and added the inform of this breaking change on the Changelog.md

===:clipboard: PR Checklist :clipboard:===

- [X] :pushpin: issue exists in github for these changes
- [X] :microscope: existing tests still pass
- [X] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [X] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [X] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1656

## Changes:

- Fix #1656 
