### PR TITLE
fix: [#1535] Actor without a drawing doesn't set anchor properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Fix for the anchor properly of single shape Actor [#1535](https://github.com/excaliburjs/Excalibur/issues/1535)
 - Color now can parse RGB/A string using Color.fromRGBString('rgb(255, 255, 255)') or Color.fromRGBString('rgb(255, 255, 255, 1)')
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Fix for the anchor properly of single shape Actor [#1535](https://github.com/excaliburjs/Excalibur/issues/1535)
 - Color now can parse RGB/A string using Color.fromRGBString('rgb(255, 255, 255)') or Color.fromRGBString('rgb(255, 255, 255, 1)')
 
 ### Changed
@@ -26,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed Animation flicker bug when switching to an animation ([#1636](https://github.com/excaliburjs/Excalibur/issues/1636))
 - Fixed `ex.Actor.easeTo` actions, they now use velocity to move Actors ([#1638](https://github.com/excaliburjs/Excalibur/issues/1638))
 - Fixed `Scene` constructor signature to make the `Engine` argument optional ([#1363](https://github.com/excaliburjs/Excalibur/issues/1363))
+- Fixed `anchor` properly of single shape `Actor` [#1535](https://github.com/excaliburjs/Excalibur/issues/1535)
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -1233,7 +1233,7 @@ export class ActorImpl extends Entity implements Actionable, Eventable, PointerE
       this.currentDrawing.draw({ ctx, x: offsetX, y: offsetY, opacity: this.opacity });
     } else {
       if (this.color && this.body && this.body.collider && this.body.collider.shape) {
-        this.body.collider.shape.draw(ctx, this.color, new Vector(this.width * this.anchor.x, this.height * this.anchor.y));
+        this.body.collider.shape.draw(ctx, this.color, new Vector(0, 0));
       }
     }
     ctx.restore();

--- a/src/engine/Collision/ConvexPolygon.ts
+++ b/src/engine/Collision/ConvexPolygon.ts
@@ -100,10 +100,7 @@ export class ConvexPolygon implements CollisionShape {
     const len = this.points.length;
     this._transformedPoints.length = 0; // clear out old transform
     for (let i = 0; i < len; i++) {
-      this._transformedPoints[i] = this.points[i]
-        .scale(scale)
-        .rotate(angle)
-        .add(pos);
+      this._transformedPoints[i] = this.points[i].scale(scale).rotate(angle).add(pos);
     }
   }
 
@@ -158,7 +155,7 @@ export class ConvexPolygon implements CollisionShape {
     // Always cast to the right, as long as we cast in a consistent fixed direction we
     // will be fine
     const testRay = new Ray(point, new Vector(1, 0));
-    const intersectCount = this.getSides().reduce(function(accum, side) {
+    const intersectCount = this.getSides().reduce(function (accum, side) {
       if (testRay.intersect(side) >= 0) {
         return accum + 1;
       }
@@ -378,18 +375,17 @@ export class ConvexPolygon implements CollisionShape {
   }
 
   public draw(ctx: CanvasRenderingContext2D, color: Color = Color.Green, pos: Vector = Vector.Zero) {
+    const basePos = pos.add(this.offset);
     ctx.beginPath();
     ctx.fillStyle = color.toString();
-    const newPos = pos.add(this.offset);
-    // Iterate through the supplied points and construct a 'polygon'
-    const firstPoint = this.points[0].add(newPos);
-    ctx.moveTo(firstPoint.x, firstPoint.y);
+    ctx.moveTo(basePos.x, basePos.y);
+    const diffToBase = this.points[0].sub(basePos);
     this.points
-      .map((p) => p.add(newPos))
-      .forEach(function(point) {
+      .map((p) => p.sub(diffToBase))
+      .forEach(function (point) {
         ctx.lineTo(point.x, point.y);
       });
-    ctx.lineTo(firstPoint.x, firstPoint.y);
+    ctx.lineTo(basePos.x, basePos.y);
     ctx.closePath();
     ctx.fill();
   }
@@ -401,7 +397,7 @@ export class ConvexPolygon implements CollisionShape {
     // Iterate through the supplied points and construct a 'polygon'
     const firstPoint = this.getTransformedPoints()[0];
     ctx.moveTo(firstPoint.x, firstPoint.y);
-    this.getTransformedPoints().forEach(function(point) {
+    this.getTransformedPoints().forEach(function (point) {
       ctx.lineTo(point.x, point.y);
     });
     ctx.lineTo(firstPoint.x, firstPoint.y);

--- a/src/spec/CollisionShapeSpec.ts
+++ b/src/spec/CollisionShapeSpec.ts
@@ -683,7 +683,7 @@ describe('Collision Shape', () => {
 
     it('can be drawn', (done) => {
       const polygon = new ex.ConvexPolygon({
-        offset: new ex.Vector(100, 100),
+        offset: new ex.Vector(100, 0),
         points: [new ex.Vector(0, -100), new ex.Vector(-100, 50), new ex.Vector(100, 50)]
       });
 
@@ -697,7 +697,7 @@ describe('Collision Shape', () => {
 
     it('can be drawn with actor', (done) => {
       const polygonActor = new ex.Actor({
-        pos: new ex.Vector(150, 100),
+        pos: new ex.Vector(150, 0),
         color: ex.Color.Blue,
         body: new ex.Body({
           collider: new ex.Collider({


### PR DESCRIPTION
Fix CollisionShapeSpec Draw to render relative position from the base of the position arg, because the Actor drawing its translating the canvas context.

```typescript
const actor = new Actor(0, 0, 50, 50, Color.Red);
//actor.anchor.setTo(0, 0);
game.add(actor);
```
![image](https://user-images.githubusercontent.com/2272323/95163758-ee497f80-077e-11eb-9e90-5d143d9267f6.png)

```typescript
const actor = new Actor(0, 0, 50, 50, Color.Red);
actor.anchor.setTo(0, 0);
game.add(actor);
```
![image](https://user-images.githubusercontent.com/2272323/95163820-13d68900-077f-11eb-8f14-cbee1c9eef3c.png)


```typescript
const actor = new Actor(0, 0, 50, 50, Color.Red);
actor.anchor.setTo(0.75, 0.75);
game.add(actor);
```
![image](https://user-images.githubusercontent.com/2272323/95163914-47191800-077f-11eb-81ae-bf79fb52d475.png)



===:clipboard: PR Checklist :clipboard:===

- [X] :pushpin: issue exists in github for these changes
- [X] :microscope: existing tests still pass
- [X] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [X] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [X] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1535