### PR TITLE
fix: [#1676] Fallback support for Firefox when anti-aliasing turned off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed Firefox bug where scaled graphics with anti-aliasing turned off are not pixelated ([#1676](https://github.com/excaliburjs/Excalibur/issues/1676))
 - Fixed z-index regression where actors did not respect z-index ([#1678](https://github.com/excaliburjs/Excalibur/issues/1678))
 - Fixed Animation flicker bug when switching to an animation ([#1636](https://github.com/excaliburjs/Excalibur/issues/1636))
 - Fixed `ex.Actor.easeTo` actions, they now use velocity to move Actors ([#1638](https://github.com/excaliburjs/Excalibur/issues/1638))

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -275,7 +275,16 @@ export class Screen {
     this._canvas.width = this.scaledWidth;
     this._canvas.height = this.scaledHeight;
 
-    this._canvas.style.imageRendering = this._antialiasing ? 'auto' : 'pixelated';
+    if (this._antialiasing) {
+      this._canvas.style.imageRendering = 'auto';
+    } else {
+      this._canvas.style.imageRendering = 'pixelated';
+      // Fall back to 'crisp-edges' if 'pixelated' is not supported
+      // Currently for firefox https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering
+      if (this._canvas.style.imageRendering === '') {
+        this._canvas.style.imageRendering = 'crisp-edges';
+      }
+    }
     this._canvas.style.width = this.viewport.width + 'px';
     this._canvas.style.height = this.viewport.height + 'px';
 

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -95,7 +95,7 @@ describe('A Screen', () => {
     expect(sut.viewport.height).toBe(600);
   });
 
-  fit('can specify anti-aliasing off', () => {
+  it('can specify anti-aliasing off', () => {
     const sut = new ex.Screen({
       canvas,
       context,
@@ -109,6 +109,56 @@ describe('A Screen', () => {
 
     expect(context.imageSmoothingEnabled).toBeFalse();
     expect(canvas.style.imageRendering).toBe('pixelated');
+  });
+
+  it('can specify anti-aliasing off will fall back to crisp-edges if pixelated not supported', () => {
+    // Using some proxy trickery we can simulate the behavior of firefox not supporting pixelated
+    const styleProxy = new Proxy(
+      {},
+      {
+        set: function (object, property, value) {
+          if (property === 'imageRendering' && value === 'pixelated') {
+            object[property] = '';
+            return true;
+          }
+
+          object[property] = value;
+
+          return true;
+        }
+      }
+    );
+    const canvasStub = { ...canvas, style: styleProxy } as HTMLCanvasElement;
+
+    const sut = new ex.Screen({
+      canvas: canvasStub,
+      context,
+      browser,
+      viewport: { width: 800, height: 600 },
+      pixelRatio: 2,
+      antialiasing: false
+    });
+
+    sut.applyResolutionAndViewport();
+
+    expect(context.imageSmoothingEnabled).toBeFalse();
+    expect(canvasStub.style.imageRendering).toBe('crisp-edges');
+  });
+
+  it('can specify anti-aliasing on', () => {
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      viewport: { width: 800, height: 600 },
+      pixelRatio: 2,
+      antialiasing: true
+    });
+
+    sut.applyResolutionAndViewport();
+
+    expect(context.imageSmoothingEnabled).toBeTrue();
+    expect(canvas.style.imageRendering).toBe('auto');
   });
 
   it('can push and pop screen resolution', () => {
@@ -250,5 +300,4 @@ describe('A Screen', () => {
     expect(bounds.bottom).toBe(450);
     expect(bounds.top).toBe(150);
   });
-
 });

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -95,6 +95,22 @@ describe('A Screen', () => {
     expect(sut.viewport.height).toBe(600);
   });
 
+  fit('can specify anti-aliasing off', () => {
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      viewport: { width: 800, height: 600 },
+      pixelRatio: 2,
+      antialiasing: false
+    });
+
+    sut.applyResolutionAndViewport();
+
+    expect(context.imageSmoothingEnabled).toBeFalse();
+    expect(canvas.style.imageRendering).toBe('pixelated');
+  });
+
   it('can push and pop screen resolution', () => {
     const sut = new ex.Screen({
       canvas,
@@ -234,4 +250,5 @@ describe('A Screen', () => {
     expect(bounds.bottom).toBe(450);
     expect(bounds.top).toBe(150);
   });
+
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1676

## Changes:

- Falls back to "crisp-edges" if "pixelated" doesn't work see [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering)
- Adds tests for these property changes
