### PR TITLE
feat: [#1733][#1734] New FullScreen and Dynamic DisplayModes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Directly changing debug drawing by `engine.isDebug = value` has been replaced by `engine.showDebug(value)` and `engine.toggleDebug()` ([#1655](https://github.com/excaliburjs/Excalibur/issues/1655))
 - `UIActor` Class instances need to be replaced to `ScreenElement` (This Class it's marked as Obsolete) ([#1656](https://github.com/excaliburjs/Excalibur/issues/1656))
 - Switch to browser based promise, the Excalibur implementation `ex.Promise` is marked deprecated ([#994](https://github.com/excaliburjs/Excalibur/issues/994))
+- `DisplayMode.FullScreen` will now scale the game to fit the available space, preserving the `aspectRatio`. This matches the browser "FullScreen" api behavior ([#1733](https://github.com/excaliburjs/Excalibur/issues/1733))
 
 ### Added
 
 - Add Excalibur Feature Flag implementation for releasing experimental or preview features ([#1673](https://github.com/excaliburjs/Excalibur/issues/1673))
 - Color now can parse RGB/A string using Color.fromRGBString('rgb(255, 255, 255)') or Color.fromRGBString('rgb(255, 255, 255, 1)')
+- `DisplayMode.Dynamic` now does what `DisplayMode.FullScreen` used to do, the resolution and viewport dynamically adjust to fit the available space, DOES NOT preserve `aspectRatio` ([#1733](https://github.com/excaliburjs/Excalibur/issues/1733))
 
 ### Changed
 
@@ -28,11 +30,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Removed UIActor Stub in favor of ScreenElement ([#1656](https://github.com/excaliburjs/Excalibur/issues/1656))
 - `ex.SortedList` as deprecated 
 - `ex.Promise` is marked deprecated ([#994](https://github.com/excaliburjs/Excalibur/issues/994))
+- `DisplayMode.Position` CSS can accomplish this task better than Excalibur ([#1733](https://github.com/excaliburjs/Excalibur/issues/1733))
 
 ### Removed
 
 ### Fixed
 
+- Fixed in the browser "FullScreen" api, coordinates are now correctly mapped from page space to world space ([#1734](https://github.com/excaliburjs/Excalibur/issues/1734))
 - Fix audio decoding bug introduced in https://github.com/excaliburjs/Excalibur/pull/1707
 - Fixed issue with promise resolve on double resource load ([#1434](https://github.com/excaliburjs/Excalibur/issues/1434))
 - Fixed Firefox bug where scaled graphics with anti-aliasing turned off are not pixelated ([#1676](https://github.com/excaliburjs/Excalibur/issues/1676))

--- a/sandbox/html/index.html
+++ b/sandbox/html/index.html
@@ -10,11 +10,32 @@
             margin: auto;
             display: block;
         }
+
+        #fullscreen {
+          position: fixed;
+          right: 20px;
+          top: 20px;
+          color: white;
+          background-color: green;
+          padding: 10px;
+          border: none;
+          border-radius: 2px;
+          z-index: 2;
+        }
+
+        #page {
+          position: fixed;
+          width: 5px;
+          height: 5px;
+          background-color: green;
+        }
     </style>
 
     <link rel="icon" type="image/x-icon" href="../images/favicon.png" />
 </head>
 <body>
+    <button id="fullscreen">Go Fullscreen</button>
+    <div id="page"></div>
     <div id="container" class="container">
         <canvas id="game"></canvas>
     </div>

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -36,14 +36,25 @@
 var logger = ex.Logger.getInstance();
 logger.defaultLevel = ex.LogLevel.Debug;
 
+var fullscreenButton = document.getElementById('fullscreen') as HTMLButtonElement;
+
 // Create an the game container
 var game = new ex.Engine({
   width: 800,
   height: 600,
+  displayMode: ex.DisplayMode.FullScreen,
   antialiasing: false,
   canvasElementId: 'game',
   suppressHiDPIScaling: false,
   suppressPlayButton: true
+});
+
+fullscreenButton.addEventListener('click', () => {
+  if (game.screen.isFullScreen) {
+    game.screen.exitFullScreen();
+  } else {
+    game.screen.goFullScreen();
+  }
 });
 game.showDebug(true);
 
@@ -79,6 +90,34 @@ heartSprite.scale.setTo(2, 2);
 heart.addDrawing(heartSprite);
 game.add(heart);
 
+
+var pointer = new ex.Actor({
+  width: 25,
+  height: 25,
+  color: ex.Color.Red
+});
+game.add(pointer);
+var otherPointer = new ex.ScreenElement({
+  width: 15,
+  height: 15,
+  color: ex.Color.Blue
+});
+var pagePointer = document.getElementById('page') as HTMLDivElement;
+otherPointer.anchor.setTo(.5, .5);
+game.add(otherPointer);
+game.input.pointers.primary.on('move', (ev) => {
+   pointer.pos = ev.worldPos;
+   otherPointer.pos = game.screen.worldToScreenCoordinates(ev.worldPos);
+   let pagePos = game.screen.screenToPageCoordinates(otherPointer.pos);
+   pagePointer.style.left = pagePos.x + 'px';
+   pagePointer.style.top = pagePos.y + 'px';
+});
+
+game.input.pointers.primary.on('wheel', (ev) => {
+  pointer.pos.setTo(ev.x, ev.y);
+  game.currentScene.camera.z += (ev.deltaY / 1000);
+  game.currentScene.camera.z = ex.Util.clamp(game.currentScene.camera.z, .05, 100);
+})
 // Turn on debug diagnostics
 game.showDebug(false);
 //var blockSprite = new ex.Sprite(imageBlocks, 0, 0, 65, 49);

--- a/src/engine/Algebra.ts
+++ b/src/engine/Algebra.ts
@@ -1,5 +1,4 @@
 import { Engine } from './Engine';
-import * as Util from './Util/Util';
 import { Clonable } from './Interfaces/Clonable';
 import { obsolete } from './Util/Decorators';
 
@@ -585,10 +584,8 @@ export class GlobalCoordinates {
       engine = <Engine>yOrEngine;
     }
 
-    const screenX: number = pageX - Util.getPosition(engine.canvas).x;
-    const screenY: number = pageY - Util.getPosition(engine.canvas).y;
-    const screenPos = new Vector(screenX, screenY);
-    const worldPos = engine.screenToWorldCoordinates(screenPos);
+    const screenPos = engine.screen.pageToScreenCoordinates(pagePos);
+    const worldPos = engine.screen.screenToWorldCoordinates(screenPos);
 
     return new GlobalCoordinates(worldPos, pagePos, screenPos);
   }

--- a/src/engine/Input/Pointers.ts
+++ b/src/engine/Input/Pointers.ts
@@ -15,7 +15,7 @@ import { GameEvent } from '../Events';
 
 import * as Events from '../Events';
 import * as Util from '../Util/Util';
-import { GlobalCoordinates, Vector } from '../Algebra';
+import { GlobalCoordinates, vec, Vector } from '../Algebra';
 import { CapturePointer } from '../Traits/CapturePointer';
 import { Actor } from '../Actor';
 
@@ -459,10 +459,8 @@ export class Pointers extends Class {
       ) {
         e.preventDefault();
       }
-
-      const x: number = e.pageX - Util.getPosition(this._engine.canvas).x;
-      const y: number = e.pageY - Util.getPosition(this._engine.canvas).y;
-      const transformedPoint = this._engine.screenToWorldCoordinates(new Vector(x, y));
+      const screen = this._engine.screen.pageToScreenCoordinates(vec(e.pageX, e.pageY));
+      const world = this._engine.screen.screenToWorldCoordinates(screen);
 
       // deltaX, deltaY, and deltaZ are the standard modern properties
       // wheelDeltaX, wheelDeltaY, are legacy properties in webkit browsers and older IE
@@ -482,7 +480,7 @@ export class Pointers extends Class {
         }
       }
 
-      const we = new WheelEvent(transformedPoint.x, transformedPoint.y, e.pageX, e.pageY, x, y, 0, deltaX, deltaY, deltaZ, deltaMode, e);
+      const we = new WheelEvent(world.x, world.y, e.pageX, e.pageY, screen.x, screen.y, 0, deltaX, deltaY, deltaZ, deltaMode, e);
 
       eventArr.push(we);
       this.at(0).eventDispatcher.emit(eventName, we);

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -3,30 +3,61 @@ import { Logger } from './Util/Log';
 import { Camera } from './Camera';
 import { BrowserEvents } from './Util/Browser';
 import { BoundingBox } from './Collision/Index';
+import { getPosition } from './Util/Util';
 
 /**
  * Enum representing the different display modes available to Excalibur.
  */
 export enum DisplayMode {
   /**
-   * Use the entire screen's css width/height for the game resolution dynamically. This is not the same as [[Screen.goFullScreen]]
+   * Use as much space as possible that still fits in the screen while maintaining aspect ratio and resolution.
+   * This is not the same as [[Screen.goFullScreen]]
+   * 
+   * You may want to center your game here is an example
+   * ```html
+   * <!-- html -->
+   * <body>
+   * <main>
+   *   <canvas id="game"></canvas>
+   * </main>
+   * </body>
+   * ```
+   * 
+   * ```css
+   * // css
+   * main {
+   *   display: flex;
+   *   align-items: center;
+   *   justify-content: center;
+   *   height: 100%;
+   *   width: 100%;
+   * }
+   * ```
+   * 
    */
   FullScreen = 'FullScreen',
+
+  /**
+   * Use the entire screen's css width/height for the game resolution dynamically. This means the resolution of the game will
+   * change dynamically as the window is resized This is not the same as [[Screen.goFullScreen]]
+   */
+  Dynamic = 'Dynamic',
+  
+  /**
+   * Default, use a specified resolution for the game. Like 800x600 pixels for example.
+   */
+  Fixed = 'Fixed',
+  
+  /**
+   * Allow the game to be positioned with the [[EngineOptions.position]] option
+   * @deprecated Use CSS to position the game
+   */
+  Position = 'Position',
 
   /**
    * Use the parent DOM container's css width/height for the game resolution dynamically
    */
   Container = 'Container',
-
-  /**
-   * Default, use a specified resolution for the game
-   */
-  Fixed = 'Fixed',
-
-  /**
-   * Allow the game to be positioned with the [[EngineOptions.position]] option
-   */
-  Position = 'Position'
 }
 
 /**
@@ -183,6 +214,8 @@ export class Screen {
 
     this._mediaQueryList = this._browser.window.nativeComponent.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
     this._mediaQueryList.addEventListener('change', this._pixelRatioChangeHandler);
+
+    this._canvas.addEventListener('fullscreenchange', this._fullscreenChangeHandler);
   }
 
   public dispose(): void {
@@ -191,7 +224,13 @@ export class Screen {
       this._isDisposed = true;
       this._browser.window.off('resize', this._windowResizeHandler);
       this._mediaQueryList.removeEventListener('change', this._pixelRatioChangeHandler);
+      this._canvas.removeEventListener('fullscreenchange', this._fullscreenChangeHandler);
     }
+  }
+
+  private _fullscreenChangeHandler = () => {
+    this._isFullScreen = !this._isFullScreen;
+    this._logger.debug('Fullscreen Change', this._isFullScreen);
   }
 
   private _pixelRatioChangeHandler = () => {
@@ -202,8 +241,7 @@ export class Screen {
   private _windowResizeHandler = () => {
     const parent = <any>(this.displayMode === DisplayMode.Container ? <any>(this.canvas.parentElement || document.body) : <any>window);
     this._logger.debug('View port resized');
-    this._setHeightByDisplayMode(parent);
-    this._logger.info('parent.clientHeight ' + parent.clientHeight);
+    this._setResolutionAndViewportByDisplayMode(parent);
     this.applyResolutionAndViewport();
   };
 
@@ -250,6 +288,10 @@ export class Screen {
 
   public set viewport(viewport: ScreenDimension) {
     this._viewport = viewport;
+  }
+
+  public get aspectRatio() {
+    return this._resolution.width / this._resolution.height;
   }
 
   public get scaledWidth() {
@@ -320,22 +362,82 @@ export class Screen {
    * Requests to go fullscreen using the browser fullscreen api
    */
   public goFullScreen(): Promise<void> {
-    return this._canvas.requestFullscreen().then(() => {
-      this._isFullScreen = true;
-    });
+    return this._canvas.requestFullscreen();
   }
 
   /**
    * Requests to exit fullscreen using the browser fullscreen api
    */
   public exitFullScreen(): Promise<void> {
-    return document.exitFullscreen().then(() => {
-      this._isFullScreen = false;
-    });
+    return document.exitFullscreen();
   }
 
   /**
-   * Transforms the current x, y from screen coordinates to world coordinates
+   * Takes a coordinate in normal html page space, for example from a pointer move event, and translates it to 
+   * Excalibur screen space.
+   * 
+   * Excalibur screen space starts at the top left (0, 0) corner of the viewport, and extends to the
+   * bottom right corner (resolutionX, resolutionY)
+   * @param point 
+   */
+  public pageToScreenCoordinates(point: Vector): Vector {
+    let newX = point.x;
+    let newY = point.y;
+
+    newX -= getPosition(this._canvas).x;
+    newY -= getPosition(this._canvas).y;
+
+
+    // if fullscreen api on it centers with black bars
+    // we need to adjust the screen to world coordinates in this case
+    if (this._isFullScreen) {
+      if (window.innerWidth / this.aspectRatio < window.innerHeight) {
+        newY -= (window.innerHeight - this.viewport.height) / 2;
+      } else {
+        newX -= (window.innerWidth - this.viewport.width) / 2;
+      }
+    }
+
+    newX = (newX / this.viewport.width) * this.resolution.width;
+    newY = (newY / this.viewport.height) * this.resolution.height;
+
+    return new Vector(newX, newY);
+  }
+
+  /**
+   * Takes a coordinate in Excalibur screen space, and translates it to normal html page space. For example, 
+   * this is where html elements might live if you want to position them relative to Excalibur.
+   * 
+   * Excalibur screen space starts at the top left (0, 0) corner of the viewport, and extends to the
+   * bottom right corner (resolutionX, resolutionY)
+   * @param point 
+   */
+  public screenToPageCoordinates(point: Vector): Vector {
+    let newX = point.x;
+    let newY = point.y;
+
+    newX = (newX / this.resolution.width) * this.viewport.width;
+    newY = (newY / this.resolution.height) * this.viewport.height
+
+    if (this._isFullScreen) {
+      if (window.innerWidth / this.aspectRatio < window.innerHeight) {
+        newY += (window.innerHeight - this.viewport.height) / 2;
+      } else {
+        newX += (window.innerWidth - this.viewport.width) / 2;
+      }
+    }
+
+    newX += getPosition(this._canvas).x;
+    newY += getPosition(this._canvas).y;
+
+    return new Vector(newX, newY);
+  }
+
+  /**
+   * Takes a coordinate in Excalibur screen space, and translates it to Excalibur world space.
+   * 
+   * World space is where [[entities|Entity]] in Excalibur live by default [[CoordPlane.World]] 
+   * and extends infinitely out relative from the [[Camera]]. 
    * @param point  Screen coordinate to convert
    */
   public screenToWorldCoordinates(point: Vector): Vector {
@@ -343,29 +445,31 @@ export class Screen {
     let newY = point.y;
 
     // transform back to world space
-    newX = (newX / this.viewport.width) * this.drawWidth;
-    newY = (newY / this.viewport.height) * this.drawHeight;
+    newX = (newX / this.resolution.width) * this.drawWidth;
+    newY = (newY / this.resolution.height) * this.drawHeight;
 
     // transform based on zoom
     newX = newX - this.halfDrawWidth;
     newY = newY - this.halfDrawHeight;
 
-    // shift by focus
+    // shift by camera focus
     newX += this._camera?.x ?? 0;
     newY += this._camera?.y ?? 0;
 
-    return new Vector(Math.floor(newX), Math.floor(newY));
+    return new Vector(newX, newY);
   }
 
   /**
-   * Transforms a world coordinate, to a screen coordinate
+   * Takes a coordinate in Excalibur world space, and translates it to Excalibur screen space.
+   * 
+   * Screen space is where [[ScreenElements]] and [[entities|Entity]] with [[CoordPlane.Screen]] live.
    * @param point  World coordinate to convert
    */
   public worldToScreenCoordinates(point: Vector): Vector {
     let screenX = point.x;
     let screenY = point.y;
 
-    // shift by focus
+    // shift by camera focus
     screenX -= this._camera?.x ?? 0;
     screenY -= this._camera?.y ?? 0;
 
@@ -374,15 +478,27 @@ export class Screen {
     screenY = screenY + this.halfDrawHeight;
 
     // transform back to screen space
-    screenX = (screenX * this.viewport.width) / this.drawWidth;
-    screenY = (screenY * this.viewport.height) / this.drawHeight;
+    screenX = (screenX / this.drawWidth) * this.resolution.width;
+    screenY = (screenY / this.drawHeight) * this.resolution.height;
 
-    return new Vector(Math.floor(screenX), Math.floor(screenY));
+    return new Vector(screenX, screenY);
+  }
+
+  public pageToWorldCoordinates(point: Vector): Vector {
+    const screen = this.pageToScreenCoordinates(point);
+    return this.screenToWorldCoordinates(screen);
+  }
+
+  public worldToPageCoordinates(point: Vector): Vector {
+    const screen = this.worldToScreenCoordinates(point);
+    return this.screenToPageCoordinates(screen);
   }
 
   /**
    * Returns a BoundingBox of the top left corner of the screen
    * and the bottom right corner of the screen.
+   * 
+   * World bounds are in world coordinates, useful for culling objects offscreen
    */
   public getWorldBounds(): BoundingBox {
     const left = this.screenToWorldCoordinates(Vector.Zero).x;
@@ -457,11 +573,33 @@ export class Screen {
     return this.drawHeight / 2;
   }
 
+  private _computeFullScreen() {
+    document.body.style.margin = "0px";
+    document.body.style.overflow = "hidden";
+    const aspect = this.aspectRatio;
+    let adjustedWidth = 0;
+    let adjustedHeight = 0;
+    if (window.innerWidth / aspect < window.innerHeight) {
+      adjustedWidth = window.innerWidth;
+      adjustedHeight = window.innerWidth / aspect;
+    } else {
+      adjustedWidth = window.innerHeight * aspect;
+      adjustedHeight = window.innerHeight;
+    }
+
+    this.viewport = {
+      width: adjustedWidth,
+      height: adjustedHeight
+    };
+  }
+
   private _applyDisplayMode() {
-    if (this.displayMode === DisplayMode.FullScreen || this.displayMode === DisplayMode.Container) {
+    if (this.displayMode === DisplayMode.FullScreen ||
+        this.displayMode === DisplayMode.Dynamic ||
+        this.displayMode === DisplayMode.Container) {
       const parent = <any>(this.displayMode === DisplayMode.Container ? <any>(this.canvas.parentElement || document.body) : <any>window);
 
-      this._setHeightByDisplayMode(parent);
+      this._setResolutionAndViewportByDisplayMode(parent);
 
       this._browser.window.on('resize', this._windowResizeHandler);
     } else if (this.displayMode === DisplayMode.Position) {
@@ -470,9 +608,9 @@ export class Screen {
   }
 
   /**
-   * Sets the internal canvas height based on the selected display mode.
+   * Sets the resoultion and viewport based on the selected display mode.
    */
-  private _setHeightByDisplayMode(parent: HTMLElement | Window) {
+  private _setResolutionAndViewportByDisplayMode(parent: HTMLElement | Window) {
     if (this.displayMode === DisplayMode.Container) {
       this.resolution = {
         width: (<HTMLElement>parent).clientWidth,
@@ -482,7 +620,7 @@ export class Screen {
       this.viewport = this.resolution;
     }
 
-    if (this.displayMode === DisplayMode.FullScreen) {
+    if (this.displayMode === DisplayMode.Dynamic) {
       document.body.style.margin = '0px';
       document.body.style.overflow = 'hidden';
       this.resolution = {
@@ -491,6 +629,10 @@ export class Screen {
       };
 
       this.viewport = this.resolution;
+    }
+
+    if (this.displayMode === DisplayMode.FullScreen) {
+      this._computeFullScreen();
     }
   }
 

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -12,7 +12,7 @@ export enum DisplayMode {
   /**
    * Use as much space as possible that still fits in the screen while maintaining aspect ratio and resolution.
    * This is not the same as [[Screen.goFullScreen]]
-   * 
+   *
    * You may want to center your game here is an example
    * ```html
    * <!-- html -->
@@ -22,7 +22,7 @@ export enum DisplayMode {
    * </main>
    * </body>
    * ```
-   * 
+   *
    * ```css
    * // css
    * main {
@@ -33,7 +33,7 @@ export enum DisplayMode {
    *   width: 100%;
    * }
    * ```
-   * 
+   *
    */
   FullScreen = 'FullScreen',
 
@@ -42,15 +42,15 @@ export enum DisplayMode {
    * change dynamically as the window is resized This is not the same as [[Screen.goFullScreen]]
    */
   Dynamic = 'Dynamic',
-  
+
   /**
    * Default, use a specified resolution for the game. Like 800x600 pixels for example.
    */
   Fixed = 'Fixed',
-  
+
   /**
    * Allow the game to be positioned with the [[EngineOptions.position]] option
-   * @deprecated Use CSS to position the game
+   * @deprecated Use CSS to position the game canvas, will be removed in v0.26.0
    */
   Position = 'Position',
 
@@ -373,12 +373,12 @@ export class Screen {
   }
 
   /**
-   * Takes a coordinate in normal html page space, for example from a pointer move event, and translates it to 
+   * Takes a coordinate in normal html page space, for example from a pointer move event, and translates it to
    * Excalibur screen space.
-   * 
+   *
    * Excalibur screen space starts at the top left (0, 0) corner of the viewport, and extends to the
    * bottom right corner (resolutionX, resolutionY)
-   * @param point 
+   * @param point
    */
   public pageToScreenCoordinates(point: Vector): Vector {
     let newX = point.x;
@@ -405,19 +405,19 @@ export class Screen {
   }
 
   /**
-   * Takes a coordinate in Excalibur screen space, and translates it to normal html page space. For example, 
+   * Takes a coordinate in Excalibur screen space, and translates it to normal html page space. For example,
    * this is where html elements might live if you want to position them relative to Excalibur.
-   * 
+   *
    * Excalibur screen space starts at the top left (0, 0) corner of the viewport, and extends to the
    * bottom right corner (resolutionX, resolutionY)
-   * @param point 
+   * @param point
    */
   public screenToPageCoordinates(point: Vector): Vector {
     let newX = point.x;
     let newY = point.y;
 
     newX = (newX / this.resolution.width) * this.viewport.width;
-    newY = (newY / this.resolution.height) * this.viewport.height
+    newY = (newY / this.resolution.height) * this.viewport.height;
 
     if (this._isFullScreen) {
       if (window.innerWidth / this.aspectRatio < window.innerHeight) {
@@ -435,9 +435,9 @@ export class Screen {
 
   /**
    * Takes a coordinate in Excalibur screen space, and translates it to Excalibur world space.
-   * 
-   * World space is where [[entities|Entity]] in Excalibur live by default [[CoordPlane.World]] 
-   * and extends infinitely out relative from the [[Camera]]. 
+   *
+   * World space is where [[entities|Entity]] in Excalibur live by default [[CoordPlane.World]]
+   * and extends infinitely out relative from the [[Camera]].
    * @param point  Screen coordinate to convert
    */
   public screenToWorldCoordinates(point: Vector): Vector {
@@ -461,7 +461,7 @@ export class Screen {
 
   /**
    * Takes a coordinate in Excalibur world space, and translates it to Excalibur screen space.
-   * 
+   *
    * Screen space is where [[ScreenElements]] and [[entities|Entity]] with [[CoordPlane.Screen]] live.
    * @param point  World coordinate to convert
    */
@@ -497,7 +497,7 @@ export class Screen {
   /**
    * Returns a BoundingBox of the top left corner of the screen
    * and the bottom right corner of the screen.
-   * 
+   *
    * World bounds are in world coordinates, useful for culling objects offscreen
    */
   public getWorldBounds(): BoundingBox {
@@ -574,8 +574,8 @@ export class Screen {
   }
 
   private _computeFullScreen() {
-    document.body.style.margin = "0px";
-    document.body.style.overflow = "hidden";
+    document.body.style.margin = '0px';
+    document.body.style.overflow = 'hidden';
     const aspect = this.aspectRatio;
     let adjustedWidth = 0;
     let adjustedHeight = 0;

--- a/src/engine/TileMap.ts
+++ b/src/engine/TileMap.ts
@@ -181,8 +181,8 @@ export class TileMapImpl extends Entity<TransformComponent | CanvasDrawComponent
     this.emit('preupdate', new Events.PreUpdateEvent(engine, delta, this));
 
     const worldBounds = engine.getWorldBounds();
-    const worldCoordsUpperLeft = vec(worldBounds.left, worldBounds.top);// engine.screenToWorldCoordinates(new Vector(0, 0));
-    const worldCoordsLowerRight = vec(worldBounds.right, worldBounds.bottom);// engine.screenToWorldCoordinates(new Vector(engine.canvas.clientWidth, engine.canvas.clientHeight));
+    const worldCoordsUpperLeft = vec(worldBounds.left, worldBounds.top);
+    const worldCoordsLowerRight = vec(worldBounds.right, worldBounds.bottom);
 
     this._onScreenXStart = Math.max(Math.floor((worldCoordsUpperLeft.x - this.x) / this.cellWidth) - 2, 0);
     this._onScreenYStart = Math.max(Math.floor((worldCoordsUpperLeft.y - this.y) / this.cellHeight) - 2, 0);

--- a/src/engine/TileMap.ts
+++ b/src/engine/TileMap.ts
@@ -180,8 +180,9 @@ export class TileMapImpl extends Entity<TransformComponent | CanvasDrawComponent
     this.onPreUpdate(engine, delta);
     this.emit('preupdate', new Events.PreUpdateEvent(engine, delta, this));
 
-    const worldCoordsUpperLeft = engine.screenToWorldCoordinates(new Vector(0, 0));
-    const worldCoordsLowerRight = engine.screenToWorldCoordinates(new Vector(engine.canvas.clientWidth, engine.canvas.clientHeight));
+    const worldBounds = engine.getWorldBounds();
+    const worldCoordsUpperLeft = vec(worldBounds.left, worldBounds.top);// engine.screenToWorldCoordinates(new Vector(0, 0));
+    const worldCoordsLowerRight = vec(worldBounds.right, worldBounds.bottom);// engine.screenToWorldCoordinates(new Vector(engine.canvas.clientWidth, engine.canvas.clientHeight));
 
     this._onScreenXStart = Math.max(Math.floor((worldCoordsUpperLeft.x - this.x) / this.cellWidth) - 2, 0);
     this._onScreenYStart = Math.max(Math.floor((worldCoordsUpperLeft.y - this.y) / this.cellHeight) - 2, 0);

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -31,6 +31,150 @@ describe('A Screen', () => {
     expect(sut).toBeDefined();
   });
 
+  it('can calculate the aspect ratio', () => {
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      viewport: { width: 800, height: 600 }
+    });
+
+    expect(sut.aspectRatio).toBe(800/600);
+  });
+
+  it('can use fullscreen display mode, the viewport will adjust to it width', () => {
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      displayMode: ex.DisplayMode.FullScreen,
+      viewport: { width: 800, height: 600 }
+    });
+
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1000 });
+    Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 800 });
+
+    window.dispatchEvent(new Event('resize'));
+
+    expect(sut.resolution.width).toBe(800);
+    expect(sut.resolution.height).toBe(600);
+    expect(sut.viewport.width).toBe(1000);
+    expect(sut.viewport.height).toBe(1000 / sut.aspectRatio);
+  });
+
+  it('can use fullscreen display mode, the viewport will adjust to it height', () => {
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      displayMode: ex.DisplayMode.FullScreen,
+      viewport: { width: 800, height: 600 }
+    });
+
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1300 });
+    Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 800 });
+
+    window.dispatchEvent(new Event('resize'));
+
+    expect(sut.resolution.width).toBe(800);
+    expect(sut.resolution.height).toBe(600);
+    expect(sut.viewport.width).toBe(800 * sut.aspectRatio);
+    expect(sut.viewport.height).toBe(800);
+  });
+
+  it('can use dynamic display mode, the viewport and resolution adjust to match', () => {
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      displayMode: ex.DisplayMode.Dynamic,
+      viewport: { width: 800, height: 600 }
+    });
+
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1300 });
+    Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 800 });
+
+    window.dispatchEvent(new Event('resize'));
+
+    expect(sut.resolution.width).toBe(1300);
+    expect(sut.resolution.height).toBe(800);
+    expect(sut.viewport.width).toBe(1300);
+    expect(sut.viewport.height).toBe(800);
+  });
+
+  it('adjusts coordinates by height when using fullscreen api', () => {
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1000 });
+    Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 800 });
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      displayMode: ex.DisplayMode.FullScreen,
+      viewport: { width: 800, height: 600 }
+    });
+
+    expect(sut.isFullScreen).toBe(false);
+    const nonFullScreenScreenCoord = sut.pageToScreenCoordinates(ex.vec(100, 100));
+
+    canvas.dispatchEvent(new Event('fullscreenchange'));
+    expect(sut.isFullScreen).toBe(true);
+    
+    const fullScreenScreenCoord = sut.pageToScreenCoordinates(ex.vec(100, 100))
+    expect(nonFullScreenScreenCoord.sub(fullScreenScreenCoord)).toBeVector(ex.vec(0, 20));
+  });
+
+  it('adjusts coordinates by width when using fullscreen api', () => {
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1300 });
+    Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 800 });
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      displayMode: ex.DisplayMode.FullScreen,
+      viewport: { width: 800, height: 600 }
+    });
+
+    expect(sut.isFullScreen).toBe(false);
+    const nonFullScreenScreenCoord = sut.pageToScreenCoordinates(ex.vec(100, 100));
+
+    canvas.dispatchEvent(new Event('fullscreenchange'));
+    expect(sut.isFullScreen).toBe(true);
+    
+    const fullScreenScreenCoord = sut.pageToScreenCoordinates(ex.vec(100, 100))
+    expect(nonFullScreenScreenCoord.sub(fullScreenScreenCoord)).toBeVector(ex.vec(87.5, 0));
+  });
+
+  it('can round trip convert coordinates', () => {
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1300 });
+    Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 800 });
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      displayMode: ex.DisplayMode.FullScreen,
+      viewport: { width: 800, height: 600 }
+    });
+  
+    const page = new ex.Vector(100, 200);
+    const screen = sut.pageToScreenCoordinates(page);
+
+    const world = sut.screenToWorldCoordinates(screen);
+
+    const screen2 = sut.worldToScreenCoordinates(world);
+
+    const page2 = sut.screenToPageCoordinates(screen2);
+
+    const world2 = sut.pageToWorldCoordinates(page);
+
+    const page3 = sut.worldToPageCoordinates(world2);
+
+    expect(page).toBeVector(page2);
+    expect(page).toBeVector(page3);
+    expect(screen).toBeVector(screen2);
+    expect(world).toBeVector(world2)
+
+  });
+
   it('will use the current pixel ratio', () => {
     const sut = new ex.Screen({
       canvas,
@@ -129,6 +273,7 @@ describe('A Screen', () => {
       }
     );
     const canvasStub = { ...canvas, style: styleProxy } as HTMLCanvasElement;
+    canvasStub.addEventListener = () => {};
 
     const sut = new ex.Screen({
       canvas: canvasStub,

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -118,8 +118,8 @@ describe('A Screen', () => {
 
     canvas.dispatchEvent(new Event('fullscreenchange'));
     expect(sut.isFullScreen).toBe(true);
-    
-    const fullScreenScreenCoord = sut.pageToScreenCoordinates(ex.vec(100, 100))
+
+    const fullScreenScreenCoord = sut.pageToScreenCoordinates(ex.vec(100, 100));
     expect(nonFullScreenScreenCoord.sub(fullScreenScreenCoord)).toBeVector(ex.vec(0, 20));
   });
 
@@ -139,8 +139,8 @@ describe('A Screen', () => {
 
     canvas.dispatchEvent(new Event('fullscreenchange'));
     expect(sut.isFullScreen).toBe(true);
-    
-    const fullScreenScreenCoord = sut.pageToScreenCoordinates(ex.vec(100, 100))
+
+    const fullScreenScreenCoord = sut.pageToScreenCoordinates(ex.vec(100, 100));
     expect(nonFullScreenScreenCoord.sub(fullScreenScreenCoord)).toBeVector(ex.vec(87.5, 0));
   });
 
@@ -154,7 +154,7 @@ describe('A Screen', () => {
       displayMode: ex.DisplayMode.FullScreen,
       viewport: { width: 800, height: 600 }
     });
-  
+
     const page = new ex.Vector(100, 200);
     const screen = sut.pageToScreenCoordinates(page);
 
@@ -171,7 +171,7 @@ describe('A Screen', () => {
     expect(page).toBeVector(page2);
     expect(page).toBeVector(page3);
     expect(screen).toBeVector(screen2);
-    expect(world).toBeVector(world2)
+    expect(world).toBeVector(world2);
 
   });
 
@@ -273,7 +273,7 @@ describe('A Screen', () => {
       }
     );
     const canvasStub = { ...canvas, style: styleProxy } as HTMLCanvasElement;
-    canvasStub.addEventListener = () => {};
+    canvasStub.addEventListener = () => { /* nothing */ };
 
     const sut = new ex.Screen({
       canvas: canvasStub,


### PR DESCRIPTION
![fullscreen](https://user-images.githubusercontent.com/612071/102927569-d7045f00-445c-11eb-92d9-4126a301e937.gif)

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1733
Closes #1734

## Changes:

- Breaking change: `DisplayMode.FullScreen` will now scale the game to fit the available space, preserving the `aspectRatio`. This matches the browser "FullScreen" api behavior
- New: `DisplayMode.Dynamic` now does what `DisplayMode.FullScreen` used to do, the resolution and viewport dynamically adjust to fit the available space, DOES NOT preserve `aspectRatio`
- Fix: In the the browser "FullScreen" api, coordinates are now correctly mapped from page space to world space
- Added: Screen helpers for mapping between world, screen, and page space coordinates
- Deprecate: `DisplayMode.Position` CSS can accomplish this task better than Excalibur
- Tests!
