### PR TITLE
fix: Loader DOM element leak, press enter to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add the ability to press enter to start the game after loaded
 - Add Excalibur Feature Flag implementation for releasing experimental or preview features ([#1673](https://github.com/excaliburjs/Excalibur/issues/1673))
 - Color now can parse RGB/A string using Color.fromRGBString('rgb(255, 255, 255)') or Color.fromRGBString('rgb(255, 255, 255, 1)')
 - `DisplayMode.Fit` will now scale the game to fit the available space, preserving the `aspectRatio`. ([#1733](https://github.com/excaliburjs/Excalibur/issues/1733))
@@ -43,6 +44,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed DOM element leak when restarting games, play button elements piled up in the DOM.
 - Fixed issues with `Sprite` not rotating/scaling correctly around the anchor (Related to TileMap plugin updates https://github.com/excaliburjs/excalibur-tiled/issues/4, https://github.com/excaliburjs/excalibur-tiled/issues/23, https://github.com/excaliburjs/excalibur-tiled/issues/108)
   - Optionally specify whether to draw around the anchor or not `drawAroundAnchor`
 - Fixed in the browser "FullScreen" api, coordinates are now correctly mapped from page space to world space ([#1734](https://github.com/excaliburjs/Excalibur/issues/1734))

--- a/src/engine/Loader.ts
+++ b/src/engine/Loader.ts
@@ -141,6 +141,10 @@ export class Loader extends Class implements Loadable<Loadable<any>[]> {
   /** Loads the css from Loader.css */
   protected _playButtonStyles: string = loaderCss.toString();
   protected get _playButton() {
+    const existingRoot = document.getElementById('excalibur-play-root');
+    if (existingRoot) {
+      this._playButtonRootElement = existingRoot;
+    }
     if (!this._playButtonRootElement) {
       this._playButtonRootElement = document.createElement('div');
       this._playButtonRootElement.id = 'excalibur-play-root';
@@ -168,7 +172,11 @@ export class Loader extends Class implements Loadable<Loadable<any>[]> {
    * Return a html button element for excalibur to use as a play button
    */
   public startButtonFactory = () => {
-    const buttonElement = document.createElement('button');
+    let buttonElement: HTMLButtonElement = document.getElementById('excalibur-play') as HTMLButtonElement;
+    if (!buttonElement) {
+      buttonElement = document.createElement('button');
+    }
+
     buttonElement.id = 'excalibur-play';
     buttonElement.textContent = this.playButtonText;
     buttonElement.style.display = 'none';
@@ -231,6 +239,11 @@ export class Loader extends Class implements Loadable<Loadable<any>[]> {
     } else {
       this._playButtonShown = true;
       this._playButton.style.display = 'block';
+      document.body.addEventListener('keyup', (evt: KeyboardEvent) => {
+        if (evt.key === 'Enter') {
+          this._playButton.click();
+        }
+      });
       const promise = new Promise((resolve) => {
         this._playButton.addEventListener('click', () => resolve());
         this._playButton.addEventListener('touchend', () => resolve());

--- a/src/spec/LoaderSpec.ts
+++ b/src/spec/LoaderSpec.ts
@@ -1,4 +1,5 @@
 import * as ex from '@excalibur';
+import { Loader } from '@excalibur';
 import { ExcaliburMatchers, ensureImagesLoaded } from 'excalibur-jasmine';
 import { TestUtils } from './util/TestUtils';
 
@@ -171,5 +172,31 @@ describe('A loader', () => {
     loader.showPlayButton();
     loader.dispose();
     expect(loader.playButtonRootElement).toBeFalsy();
+  });
+
+  it('can have the enter key pressed to start', (done) => {
+    const loader = new ex.Loader([, , , ,]);
+    loader.loadingBarPosition = ex.vec(0, 0);
+    loader.loadingBarColor = ex.Color.Red;
+    loader.markResourceComplete();
+    loader.markResourceComplete();
+    loader.markResourceComplete();
+    loader.markResourceComplete();
+    loader.showPlayButton().then(() => {
+      done();
+      loader.dispose();
+    });
+    document.body.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter'}));
+  });
+
+  it('can reload without building root elements', () => {
+    const loader = new ex.Loader([,,,]);
+    loader.showPlayButton();
+    loader.showPlayButton();
+    loader.showPlayButton();
+    const roots = document.querySelectorAll('#excalibur-play-root');
+    const buttons = document.querySelectorAll('#excalibur-play');
+    expect(roots.length).toBe(1);
+    expect(buttons.length).toBe(1);
   });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Fixes issue where loader dom elements leak and pile up in the DOM if restarting the game

![image](https://user-images.githubusercontent.com/612071/107138243-ef2f2100-68d8-11eb-8641-fb5ee9bb1def.png)

