### PR TITLE
feat(KeyEvent): add key value and expose raw event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `SpriteSheet.spacing` now accepts a structure `{ top: number, left: number, margin: number }` for custom spacing dimensions ([#1788](https://github.com/excaliburjs/Excalibur/issues/1778))
 - `SpriteSheet.ctor` now has an overload that accepts `spacing` for consistency although the object constructor is recommended ([#1788](https://github.com/excaliburjs/Excalibur/issues/1778))
 - Add `SpriteSheet.getSpacingDimensions()` method to retrieve calculated spacing dimensions ([#1788](https://github.com/excaliburjs/Excalibur/issues/1778))
+- Add `KeyEvent.value?: string` which is the key value (or "typed" value) that the browser detected. For example, holding Shift and pressing 9 will have a value of `(` which is the typed character.
+- Add `KeyEvent.originalEvent?: KeyboardEvent` which exposes the raw keyboard event handled from the browser.
 
 ### Changed
 

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -3,7 +3,7 @@ import { Class } from '../Class';
 import * as Events from '../Events';
 
 /**
- * Enum representing input key codes
+ * Enum representing physical input key codes
  */
 export enum Keys {
   // NUMPAD
@@ -158,8 +158,10 @@ export enum Keys {
 export class KeyEvent extends Events.GameEvent<any> {
   /**
    * @param key  The key responsible for throwing the event
+   * @param character The typed character the browser detected
+   * @param keyboardEvent The original keyboard event that Excalibur handled
    */
-  constructor(public key: Keys) {
+  constructor(public key: Keys, public character?: string, public keyboardEvent?: KeyboardEvent) {
     super();
   }
 }
@@ -225,7 +227,7 @@ export class Keyboard extends Class {
       const key = this._keys.indexOf(code);
       this._keys.splice(key, 1);
       this._keysUp.push(code);
-      const keyEvent = new KeyEvent(code);
+      const keyEvent = new KeyEvent(code, ev.key, ev);
 
       // alias the old api, we may want to deprecate this in the future
       this.eventDispatcher.emit('up', keyEvent);
@@ -238,7 +240,7 @@ export class Keyboard extends Class {
       if (this._keys.indexOf(code) === -1) {
         this._keys.push(code);
         this._keysDown.push(code);
-        const keyEvent = new KeyEvent(code);
+        const keyEvent = new KeyEvent(code, ev.key, ev);
         this.eventDispatcher.emit('down', keyEvent);
         this.eventDispatcher.emit('press', keyEvent);
       }

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -158,10 +158,10 @@ export enum Keys {
 export class KeyEvent extends Events.GameEvent<any> {
   /**
    * @param key  The key responsible for throwing the event
-   * @param character The typed character the browser detected
-   * @param keyboardEvent The original keyboard event that Excalibur handled
+   * @param value The key's typed value the browser detected
+   * @param originalEvent The original keyboard event that Excalibur handled
    */
-  constructor(public key: Keys, public character?: string, public keyboardEvent?: KeyboardEvent) {
+  constructor(public key: Keys, public value?: string, public originalEvent?: KeyboardEvent) {
     super();
   }
 }

--- a/src/spec/KeyInputSpec.ts
+++ b/src/spec/KeyInputSpec.ts
@@ -21,12 +21,27 @@ describe('A keyboard', () => {
     let eventFired = false;
 
     keyboard.on('down', function (ev: ex.Input.KeyEvent) {
-      if (ev.key === ex.Input.Keys.Up) {
+      if (ev.key === ex.Input.Keys.Up && ev.value === ex.Input.Keys.Up) {
         eventFired = true;
       }
     });
 
-    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
+
+    expect(eventFired).toBeTruthy();
+  });
+
+  it('should fire keypress events', () => {
+    let eventFired = false;
+
+    keyboard.on('press', function (ev: ex.Input.KeyEvent) {
+      if (ev.key === ex.Input.Keys.Up && ev.value === ex.Input.Keys.Up) {
+        eventFired = true;
+      }
+    });
+
+    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
 
     expect(eventFired).toBeTruthy();
   });
@@ -35,26 +50,40 @@ describe('A keyboard', () => {
     let eventFired = false;
 
     keyboard.on('up', function (ev: ex.Input.KeyEvent) {
-      if (ev.key === ex.Input.Keys.Up) {
+      if (ev.key === ex.Input.Keys.Up && ev.value === ex.Input.Keys.Up) {
         eventFired = true;
       }
     });
 
-    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
+
+    expect(eventFired).toBeTruthy();
+  });
+
+  it('should fire keyboard event with actual value and physical key', () => {
+    let eventFired = false;
+
+    keyboard.on('up', function (ev: ex.Input.KeyEvent) {
+      if (ev.key === ex.Input.Keys.Digit9 && ev.value === '(') {
+        eventFired = true;
+      }
+    });
+
+    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Digit9, key: '(' });
 
     expect(eventFired).toBeTruthy();
   });
 
   it('should know if keys are pressed', () => {
     // push key down
-    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
 
     expect(keyboard.isHeld(ex.Input.Keys.Up)).toBeTruthy();
     expect(keyboard.wasReleased(ex.Input.Keys.Up)).toBeFalsy();
     expect(keyboard.wasPressed(ex.Input.Keys.Up)).toBeTruthy();
 
     // release key
-    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
 
     expect(keyboard.getKeys().length).toBe(0);
     expect(keyboard.isHeld(ex.Input.Keys.Up)).toBeFalsy();
@@ -63,13 +92,13 @@ describe('A keyboard', () => {
 
   it('should have keys stay held until released', () => {
     // push key down
-    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Up });
-    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Down });
+    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Down, key: ex.Input.Keys.Down });
 
     keyboard.update();
 
     // release key
-    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
 
     expect(keyboard.wasReleased(ex.Input.Keys.Down)).toBeFalsy();
     expect(keyboard.isHeld(ex.Input.Keys.Up)).toBeFalsy();
@@ -77,7 +106,7 @@ describe('A keyboard', () => {
     keyboard.update();
 
     // release key
-    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Down });
+    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Down, key: ex.Input.Keys.Down });
 
     expect(keyboard.wasReleased(ex.Input.Keys.Down)).toBeTruthy();
   });


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #

Allows getting at the typed character (or "key") from the keyboard event, as well as the originally handled event for advanced scenarios.

## Changes:

- Add `value` which is the [`key` value](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) from the original event
- Add `originalEvent` to allow accessing the original `KeyboardEvent`
