### PR TITLE
fix: Offscreen Culling Events in new graphics system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `new Entity(components: Component[])` constructor overload to create entities with components quickly.
 - Added `Entity.get(type: ComponentType)` to get strongly typed components if they exist on the entity.
 - Added `Entity.has(type: ComponentType)` overload to check if an entity has a component of that type.
+  - Tag `offscreen` is now added to entities that are offscreen
 - Added `Entity.componentAdded$` and `Entity.componentRemoved$` for observing component changes on an entity.
 - For child/parent entities:
   - Added `Entity.add(entity: Entity)`, `Entity.remove(entity: Entity)`, `Entity.removeAll()` for managing child entities
@@ -56,6 +57,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Entity update lifecycle is now called correctly
+- Fixed GraphicsSystem `enterviewport` and `exitviewport` event
 - Fixed DOM element leak when restarting games, play button elements piled up in the DOM.
 - Fixed issues with `Sprite` not rotating/scaling correctly around the anchor (Related to TileMap plugin updates https://github.com/excaliburjs/excalibur-tiled/issues/4, https://github.com/excaliburjs/excalibur-tiled/issues/23, https://github.com/excaliburjs/excalibur-tiled/issues/108)
   - Optionally specify whether to draw around the anchor or not `drawAroundAnchor`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 
+- Camera.z has been renamed to property `zoom` which is the zoom factor
+- Camera.zoom(...) has been renamed to function `zoomOverTime()`
 - TileMap no longer needs registered SpriteSheets, `Sprite`'s can be added directly to `Cell`'s with `addSprite`
   - The confusing `TileSprite` type is removed (Related to TileMap plugin updates https://github.com/excaliburjs/excalibur-tiled/issues/4, https://github.com/excaliburjs/excalibur-tiled/issues/23, https://github.com/excaliburjs/excalibur-tiled/issues/108)
 - Directly changing debug drawing by `engine.isDebug = value` has been replaced by `engine.showDebug(value)` and `engine.toggleDebug()` ([#1655](https://github.com/excaliburjs/Excalibur/issues/1655))
@@ -17,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `SpriteSheet` now is immutable after creation to reduce chance of bugs if you modified a public field. The following properties are read-only: `columns`, `rows`, `spWidth`, `spHeight`, `image`, `sprites` and `spacing`.
 
 ### Added
+
 - `BoundingBox`'s can now by `transform`'d by a `Matrix`
 - Added `new Entity(components: Component[])` constructor overload to create entities with components quickly.
 - Added `Entity.get(type: ComponentType)` to get strongly typed components if they exist on the entity.
@@ -25,7 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `Entity.componentAdded$` and `Entity.componentRemoved$` for observing component changes on an entity.
 - For child/parent entities:
   - Added `Entity.add(entity: Entity)`, `Entity.remove(entity: Entity)`, `Entity.removeAll()` for managing child entities
-  - Added `Entity.parent` readonly accessor to the parent (if exists), and  `Entity.unparent()` to unparent an entity.
+  - Added `Entity.parent` readonly accessor to the parent (if exists), and `Entity.unparent()` to unparent an entity.
   - Added `Entity.getAncestors()` is a sorted list of parents starting with the topmost parent.
   - Added `Entity.children` readonly accessor to the list of children.
 - Add the ability to press enter to start the game after loaded

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Excalibur.js is a simple JavaScript game engine with TypeScript bindings for making 2D games in HTML5 Canvas. Our mission is to make web game development as simple as possible.",
   "author": "https://github.com/excaliburjs/Excalibur/graphs/contributors",
   "homepage": "https://github.com/excaliburjs/Excalibur",
-  "main": "build/dist/excalibur.js",
+  "main": "build/dist/excalibur.min.js",
   "typings": "build/dist/excalibur.d.ts",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "core": "npm run core:tsc && npm run core:copy && npm run core:bundle",
     "core:tsc": "tsc --project src/engine/tsconfig.json --incremental true --tsBuildInfoFile .tsbuildinfo",
     "core:copy": "copyfiles -u 2 ./src/engine/**/*.png ./src/engine/**/*.css ./src/engine/**/*.glsl ./build/dist/",
-    "core:bundle": "webpack --config webpack.config.js --progress --mode production",
+    "core:bundle": "webpack --config webpack.config.js --mode production",
     "core:watch": "npm run core:bundle -- --watch",
     "lint": "npm run eslint && npm run eslint:spec",
     "eslint": "eslint \"src/engine/**/*.ts\"",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Excalibur.js is a simple JavaScript game engine with TypeScript bindings for making 2D games in HTML5 Canvas. Our mission is to make web game development as simple as possible.",
   "author": "https://github.com/excaliburjs/Excalibur/graphs/contributors",
   "homepage": "https://github.com/excaliburjs/Excalibur",
-  "main": "build/dist/excalibur.min.js",
+  "main": "build/dist/excalibur.js",
   "typings": "build/dist/excalibur.d.ts",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "core": "npm run core:tsc && npm run core:copy && npm run core:bundle",
     "core:tsc": "tsc --project src/engine/tsconfig.json --incremental true --tsBuildInfoFile .tsbuildinfo",
     "core:copy": "copyfiles -u 2 ./src/engine/**/*.png ./src/engine/**/*.css ./src/engine/**/*.glsl ./build/dist/",
-    "core:bundle": "webpack --config webpack.config.js --mode production",
+    "core:bundle": "webpack --config webpack.config.js --progress --mode production",
     "core:watch": "npm run core:bundle -- --watch",
     "lint": "npm run eslint && npm run eslint:spec",
     "eslint": "eslint \"src/engine/**/*.ts\"",

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -285,8 +285,8 @@ game.input.pointers.primary.on('move', (ev) => {
 
 game.input.pointers.primary.on('wheel', (ev) => {
   pointer.pos.setTo(ev.x, ev.y);
-  game.currentScene.camera.z += (ev.deltaY / 1000);
-  game.currentScene.camera.z = ex.Util.clamp(game.currentScene.camera.z, .05, 100);
+  game.currentScene.camera.zoom += (ev.deltaY / 1000);
+  game.currentScene.camera.zoom = ex.Util.clamp(game.currentScene.camera.zoom, .05, 100);
 })
 // Turn on debug diagnostics
 game.showDebug(false);

--- a/sandbox/tests/camera/zoom.ts
+++ b/sandbox/tests/camera/zoom.ts
@@ -20,10 +20,10 @@ var zoomedIn = false;
 game.input.pointers.primary.on('down', (evt: ex.Input.PointerEvent) => {
   if (!zoomedIn) {
     zoomedIn = true;
-    game.currentScene.camera.zoom(5, 1000);
+    game.currentScene.camera.zoomOverTime(5, 1000);
   } else {
     zoomedIn = false;
-    game.currentScene.camera.zoom(0.2, 1000);
+    game.currentScene.camera.zoomOverTime(0.2, 1000);
   }
 });
 

--- a/sandbox/tests/culling/culling2.ts
+++ b/sandbox/tests/culling/culling2.ts
@@ -51,10 +51,10 @@ game.start();
 let zoomed = false;
 setInterval(() => {
   if (zoomed) {
-    game.currentScene.camera.zoom(1, 3500);
+    game.currentScene.camera.zoomOverTime(1, 3500);
     zoomed = false;
   } else {
-    game.currentScene.camera.zoom(2, 3500);
+    game.currentScene.camera.zoomOverTime(2, 3500);
     zoomed = true;
   }
 }, 4000);

--- a/sandbox/tests/physics/fastphysics.ts
+++ b/sandbox/tests/physics/fastphysics.ts
@@ -14,7 +14,7 @@ ex.Physics.showContacts = true;
 ex.Physics.showNormals = true;
 ex.Physics.acc.setTo(0, 300);
 //ex.Physics.dynamicTreeVelocityMultiplyer = 1;
-game.currentScene.camera.z = 0.5;
+game.currentScene.camera.zoom = 0.5;
 var rocketTex = new ex.Texture('missile.png');
 var loader = new ex.Loader([rocketTex]);
 

--- a/sandbox/tests/physics/physics2.ts
+++ b/sandbox/tests/physics/physics2.ts
@@ -12,7 +12,7 @@ ex.Physics.broadphaseDebug = true;
 
 game.currentScene.camera.x = 0;
 game.currentScene.camera.y = 0;
-game.currentScene.camera.zoom(3);
+game.currentScene.camera.zoomOverTime(3);
 
 function spawnCircle2(x: number, y: number, vx: number) {
   var width = 20;

--- a/sandbox/tests/tilemap/tilemap.ts
+++ b/sandbox/tests/tilemap/tilemap.ts
@@ -39,8 +39,8 @@ game.add(tm);
 game.start(loader).then(() => {
   game.currentScene.camera.move(ex.Vector.Zero.clone(), 2000, ex.EasingFunctions.EaseInOutCubic).then(() => {
     game.currentScene.camera.move(new ex.Vector(600, 600), 2000, ex.EasingFunctions.EaseInOutCubic).then(() => {
-      game.currentScene.camera.zoom(2, 1000).then(() => {
-        game.currentScene.camera.zoom(1, 1000);
+      game.currentScene.camera.zoomOverTime(2, 1000).then(() => {
+        game.currentScene.camera.zoomOverTime(1, 1000);
       });
     });
   });

--- a/sandbox/tests/zoom/zoom.ts
+++ b/sandbox/tests/zoom/zoom.ts
@@ -36,10 +36,10 @@ game.add(target);
 
 game.input.keyboard.on('down', (ev: ex.Input.KeyEvent) => {
   if (ev.key === ex.Input.Keys.NumAdd /* + */) {
-    game.currentScene.camera.zoom((currentZoom += 0.03));
+    game.currentScene.camera.zoomOverTime((currentZoom += 0.03));
   }
   if (ev.key === ex.Input.Keys.NumSubtract /* - */) {
-    game.currentScene.camera.zoom((currentZoom -= 0.03));
+    game.currentScene.camera.zoomOverTime((currentZoom -= 0.03));
   }
 
   var currentFocus = game.currentScene.camera.getFocus();

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -310,7 +310,9 @@ export class ActorImpl
   /**
    * Indicates whether the actor is physically in the viewport
    */
-  public isOffScreen: boolean = false;
+  public get isOffScreen(): boolean {
+    return this.hasTag('offscreen');
+  }
   /**
    * The visibility of an actor
    * @deprecated Use [[GraphicsComponent.visible|Actor.graphics.visible]]

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -246,7 +246,16 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
   /**
    * Get or set current zoom of the camera, defaults to 1
    */
-  public z: number = 1;
+  private _z = 1;
+  public get z(): number {
+    return this._z;
+  }
+
+  public set z(val: number) {
+    this._z = val;
+    this._halfWidth = this._engine.halfDrawWidth;
+    this._halfHeight = this._engine.halfDrawHeight;
+  }
   /**
    * Get or set rate of change in zoom, defaults to 0
    */

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -253,8 +253,10 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
 
   public set z(val: number) {
     this._z = val;
-    this._halfWidth = this._engine.halfDrawWidth;
-    this._halfHeight = this._engine.halfDrawHeight;
+    if (this._engine) {
+      this._halfWidth = this._engine.halfDrawWidth;
+      this._halfHeight = this._engine.halfDrawHeight;
+    }
   }
   /**
    * Get or set rate of change in zoom, defaults to 0

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -223,7 +223,6 @@ export class LimitCameraBoundsStrategy implements CameraStrategy<BoundingBox> {
       focusY = target.bottom - _eng.halfDrawHeight;
     }
 
-
     return vec(focusX, focusY);
   };
 }
@@ -247,11 +246,11 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
    * Get or set current zoom of the camera, defaults to 1
    */
   private _z = 1;
-  public get z(): number {
+  public get zoom(): number {
     return this._z;
   }
 
-  public set z(val: number) {
+  public set zoom(val: number) {
     this._z = val;
     if (this._engine) {
       this._halfWidth = this._engine.halfDrawWidth;
@@ -473,7 +472,7 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
    * @param scale    The scale of the zoom
    * @param duration The duration of the zoom in milliseconds
    */
-  public zoom(scale: number, duration: number = 0, easingFn: EasingFunction = EasingFunctions.EaseInOutCubic): Promise<boolean> {
+  public zoomOverTime(scale: number, duration: number = 0, easingFn: EasingFunction = EasingFunctions.EaseInOutCubic): Promise<boolean> {
     this._zoomPromise = new Promise<boolean>((resolve) => {
       this._zoomResolve = resolve;
     });
@@ -483,22 +482,15 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
       this._zoomEasing = easingFn;
       this._currentZoomTime = 0;
       this._zoomDuration = duration;
-      this._zoomStart = this.z;
+      this._zoomStart = this.zoom;
       this._zoomEnd = scale;
     } else {
       this._isZooming = false;
-      this.z = scale;
+      this.zoom = scale;
       return Promise.resolve(true);
     }
 
     return this._zoomPromise;
-  }
-
-  /**
-   * Gets the current zoom scale
-   */
-  public getZoom() {
-    return this.z;
   }
 
   private _viewport: BoundingBox = null;
@@ -631,7 +623,7 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
 
     // Update placements based on linear algebra
     this.pos = this.pos.add(this.vel.scale(delta / 1000));
-    this.z += (this.dz * delta) / 1000;
+    this.zoom += (this.dz * delta) / 1000;
 
     this.vel = this.vel.add(this.acc.scale(delta / 1000));
     this.dz += (this.az * delta) / 1000;
@@ -643,11 +635,11 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
         const zoomEasing = this._zoomEasing;
         const newZoom = zoomEasing(this._currentZoomTime, this._zoomStart, this._zoomEnd, this._zoomDuration);
 
-        this.z = newZoom;
+        this.zoom = newZoom;
         this._currentZoomTime += delta;
       } else {
         this._isZooming = false;
-        this.z = this._zoomEnd;
+        this.zoom = this._zoomEnd;
         this._currentZoomTime = 0;
         this._zoomResolve(true);
       }
@@ -721,7 +713,7 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
     }
     const focus = this.getFocus();
     const pixelRatio = this._engine ? this._engine.pixelRatio : 1;
-    const zoom = this.getZoom();
+    const zoom = this.zoom;
 
     const newCanvasWidth = canvasWidth / zoom / pixelRatio;
     const newCanvasHeight = canvasHeight / zoom / pixelRatio;

--- a/src/engine/EntityComponentSystem/Entity.ts
+++ b/src/engine/EntityComponentSystem/Entity.ts
@@ -122,7 +122,7 @@ export class Entity<KnownComponents extends Component = never> extends Class imp
   }
 
   /**
-   * Adds a tag to an entitie
+   * Adds a tag to an entity
    * @param tag
    * @returns Entity
    */
@@ -256,7 +256,7 @@ export class Entity<KnownComponents extends Component = never> extends Class imp
    * Removes all children from this entity
    */
   public removeAll(): Entity {
-    this.children.forEach(c => {
+    this.children.forEach((c) => {
       this.remove(c);
     });
     return this;
@@ -406,7 +406,7 @@ export class Entity<KnownComponents extends Component = never> extends Class imp
   /**
    * Get a component by type with typecheck
    *
-   * (Does not work on tag components use .hasTag("mytag"))
+   * (Does not work on tag components, use .hasTag("mytag") instead)
    * @param type
    */
   public get<T extends Component>(type: ComponentCtor<T>): T {

--- a/src/engine/EntityComponentSystem/Entity.ts
+++ b/src/engine/EntityComponentSystem/Entity.ts
@@ -123,11 +123,11 @@ export class Entity<KnownComponents extends Component = never> extends Class imp
 
   /**
    * Adds a tag to an entitie
-   * @param tag 
-   * @returns 
+   * @param tag
+   * @returns Entity
    */
   public addTag(tag: string) {
-    return this.addComponent(new TagComponent(tag))
+    return this.addComponent(new TagComponent(tag));
   }
 
   /**
@@ -405,7 +405,7 @@ export class Entity<KnownComponents extends Component = never> extends Class imp
 
   /**
    * Get a component by type with typecheck
-   * 
+   *
    * (Does not work on tag components use .hasTag("mytag"))
    * @param type
    */

--- a/src/engine/EntityComponentSystem/Entity.ts
+++ b/src/engine/EntityComponentSystem/Entity.ts
@@ -122,6 +122,15 @@ export class Entity<KnownComponents extends Component = never> extends Class imp
   }
 
   /**
+   * Adds a tag to an entitie
+   * @param tag 
+   * @returns 
+   */
+  public addTag(tag: string) {
+    return this.addComponent(new TagComponent(tag))
+  }
+
+  /**
    * The types of the components on the Entity
    */
   public get types(): string[] {
@@ -396,6 +405,8 @@ export class Entity<KnownComponents extends Component = never> extends Class imp
 
   /**
    * Get a component by type with typecheck
+   * 
+   * (Does not work on tag components use .hasTag("mytag"))
    * @param type
    */
   public get<T extends Component>(type: ComponentCtor<T>): T {

--- a/src/engine/EntityComponentSystem/Query.ts
+++ b/src/engine/EntityComponentSystem/Query.ts
@@ -82,8 +82,9 @@ export class Query<T extends Component = Component> extends Observable<AddedEnti
    * @param entity
    */
   public matches(entity: Entity): boolean;
+
   /**
-   * Returns whether the list of ComponentTypes match the query
+   * Returns whether the list of ComponentTypes have at least the same types as the query 
    * @param types
    */
   public matches(types: string[]): boolean;
@@ -103,5 +104,9 @@ export class Query<T extends Component = Component> extends Observable<AddedEnti
       }
     }
     return matches;
+  }
+
+  public contain(type: string) {
+    return this.types.indexOf(type) > -1;
   }
 }

--- a/src/engine/EntityComponentSystem/Query.ts
+++ b/src/engine/EntityComponentSystem/Query.ts
@@ -84,7 +84,7 @@ export class Query<T extends Component = Component> extends Observable<AddedEnti
   public matches(entity: Entity): boolean;
 
   /**
-   * Returns whether the list of ComponentTypes have at least the same types as the query 
+   * Returns whether the list of ComponentTypes have at least the same types as the query
    * @param types
    */
   public matches(types: string[]): boolean;

--- a/src/engine/EntityComponentSystem/QueryManager.ts
+++ b/src/engine/EntityComponentSystem/QueryManager.ts
@@ -53,7 +53,9 @@ export class QueryManager {
    */
   public removeComponent(entity: Entity, component: Component) {
     for (const queryType in this._queries) {
-      if (this._queries[queryType].matches(entity.types.concat([component.type]))) {
+      // If the component being removed from an entity is a part of a query,
+      // it is now disqualified from that query, remove it
+      if (this._queries[queryType].contain(component.type)) {
         this._queries[queryType].removeEntity(entity);
       }
     }

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -45,7 +45,6 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
       const entityOffscreen = this._isOffscreen(transform, graphics);
       if (entityOffscreen && !entity.hasTag('offscreen')) {
         entity.eventDispatcher.emit('exitviewport', new ExitViewPortEvent(entity));
-        // TODO tag component seems to cause ecs issues
         entity.addComponent(new TagComponent('offscreen'));
       }
 
@@ -126,11 +125,7 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
           const offsetX = -graphic.width * anchor.x + offset.x;
           const offsetY = -graphic.height * anchor.y + offset.y;
 
-          graphic?.draw(
-            this._graphicsContext,
-            offsetX + layer.offset.x,
-            offsetY + layer.offset.y
-          );
+          graphic?.draw(this._graphicsContext, offsetX + layer.offset.x, offsetY + layer.offset.y);
 
           if (this._engine?.isDebug) {
             /* istanbul ignore next */

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -48,7 +48,7 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
         // TODO tag component seems to cause ecs issues
         entity.addComponent(new TagComponent('offscreen'));
       }
-      
+
       if (!entityOffscreen && entity.hasTag('offscreen')) {
         entity.eventDispatcher.emit('enterviewport', new EnterViewPortEvent(entity));
         entity.removeComponent('offscreen');

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -7,9 +7,10 @@ import { Color } from '../Drawing/Color';
 import { CoordPlane, TransformComponent } from '../EntityComponentSystem/Components/TransformComponent';
 import { Entity } from '../EntityComponentSystem/Entity';
 import { Camera } from '../Camera';
-import { System, SystemType } from '../EntityComponentSystem';
+import { System, SystemType, TagComponent } from '../EntityComponentSystem';
 import { Engine } from '../Engine';
 import { GraphicsDiagnostics } from './GraphicsDiagnostics';
+import { EnterViewPortEvent, ExitViewPortEvent } from '../Events';
 
 export class GraphicsSystem extends System<TransformComponent | GraphicsComponent> {
   public readonly types = ['transform', 'graphics'] as const;
@@ -40,8 +41,20 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
       transform = entity.components.transform;
       graphics = entity.components.graphics;
 
+      // Figure out if entities are offscreen
+      const entityOffscreen = this._isOffscreen(transform, graphics);
+      if (entityOffscreen && !entity.hasTag('offscreen')) {
+        entity.eventDispatcher.emit('exitviewport', new ExitViewPortEvent(entity));
+        // TODO tag component seems to cause ecs issues
+        entity.addComponent(new TagComponent('offscreen'));
+      }
+      
+      if (!entityOffscreen && entity.hasTag('offscreen')) {
+        entity.eventDispatcher.emit('enterviewport', new EnterViewPortEvent(entity));
+        entity.removeComponent('offscreen');
+      }
       // Skip entities that have graphics offscreen
-      if (this._isOffscreen(transform, graphics)) {
+      if (entityOffscreen) {
         continue;
       }
 

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -562,7 +562,7 @@ export class Screen {
    */
   public get drawWidth(): number {
     if (this._camera) {
-      return this.scaledWidth / this._camera.z / this.pixelRatio;
+      return this.scaledWidth / this._camera.zoom / this.pixelRatio;
     }
     return this.scaledWidth / this.pixelRatio;
   }
@@ -579,7 +579,7 @@ export class Screen {
    */
   public get drawHeight(): number {
     if (this._camera) {
-      return this.scaledHeight / this._camera.z / this.pixelRatio;
+      return this.scaledHeight / this._camera.zoom / this.pixelRatio;
     }
     return this.scaledHeight / this.pixelRatio;
   }

--- a/src/engine/Traits/OffscreenCulling.ts
+++ b/src/engine/Traits/OffscreenCulling.ts
@@ -3,6 +3,7 @@ import { Trait } from '../Interfaces/Trait';
 import { Actor } from '../Actor';
 import { Engine } from '../Engine';
 import { ExitViewPortEvent, EnterViewPortEvent } from '../Events';
+import { TagComponent } from '../EntityComponentSystem';
 
 export class OffscreenCulling implements Trait {
   public cullingBox: CullingBox = new CullingBox();
@@ -23,12 +24,12 @@ export class OffscreenCulling implements Trait {
     if (!actor.isOffScreen) {
       if (actorBoundsOffscreen && isSpriteOffScreen) {
         events.emit('exitviewport', new ExitViewPortEvent(actor));
-        actor.isOffScreen = true;
+        actor.addComponent(new TagComponent('offscreen'));
       }
     } else {
       if (!actorBoundsOffscreen || !isSpriteOffScreen) {
         events.emit('enterviewport', new EnterViewPortEvent(actor));
-        actor.isOffScreen = false;
+        actor.removeComponent('offscreen');
       }
     }
   }

--- a/src/spec/CameraSpec.ts
+++ b/src/spec/CameraSpec.ts
@@ -167,7 +167,7 @@ describe('A camera', () => {
 
   it('can zoom', () => {
     engine.currentScene.camera = Camera;
-    Camera.zoom(2, 0.1);
+    Camera.zoomOverTime(2, 0.1);
 
     expect((Camera as any)._isZooming).toBe(true);
   });
@@ -304,7 +304,7 @@ describe('A camera', () => {
 
   xit('can zoom in over time', (done) => {
     engine.start().then(() => {
-      engine.currentScene.camera.zoom(5, 1000).then(() => {
+      engine.currentScene.camera.zoomOverTime(5, 1000).then(() => {
         ensureImagesLoaded(engine.canvas, 'src/spec/images/CameraSpec/zoomin.png').then(([canvas, image]) => {
           expect(canvas).toEqualImage(image, 0.995);
           done();
@@ -315,7 +315,7 @@ describe('A camera', () => {
 
   xit('can zoom out over time', (done) => {
     engine.start().then(() => {
-      engine.currentScene.camera.zoom(0.2, 1000).then(() => {
+      engine.currentScene.camera.zoomOverTime(0.2, 1000).then(() => {
         ensureImagesLoaded(engine.canvas, 'src/spec/images/CameraSpec/zoomout.png').then(([canvas, image]) => {
           expect(canvas).toEqualImage(image, 0.995);
           done();

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -185,7 +185,7 @@ describe('The engine', () => {
 
   it('should return correct screen dimensions if zoomed in', () => {
     engine.start();
-    engine.currentScene.camera.z = 2;
+    engine.currentScene.camera.zoom = 2;
 
     expect(engine.drawHeight).toBe(250);
     expect(engine.drawWidth).toBe(250);

--- a/src/spec/QueryManagerSpec.ts
+++ b/src/spec/QueryManagerSpec.ts
@@ -150,4 +150,28 @@ describe('A QueryManager', () => {
 
     expect(queryAB.getEntities()).toEqual([entity2]);
   });
+
+  it('removing components unrelated to the query doesnt remove the entity', () => {
+    const world = new ex.World(null);
+    const entity1 = new ex.Entity();
+    entity1.addComponent(new FakeComponent('A'));
+    entity1.addComponent(new FakeComponent('B'));
+    entity1.addComponent(new FakeComponent('C'));
+
+    const entity2 = new ex.Entity();
+    entity2.addComponent(new FakeComponent('A'));
+    entity2.addComponent(new FakeComponent('B'));
+
+    const queryAB = world.queryManager.createQuery(['A', 'B']);
+    world.queryManager.addEntity(entity1);
+    world.queryManager.addEntity(entity2);
+
+    expect(queryAB.getEntities()).toEqual([entity1, entity2]);
+
+    const removed = entity1.components.C;
+    entity1.removeComponent('C');
+    world.queryManager.removeComponent(entity1, removed);
+
+    expect(queryAB.getEntities()).toEqual([entity1, entity2]);
+  });
 });

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -400,7 +400,7 @@ describe('A Screen', () => {
     const camera = new Camera();
     camera.x = 400;
     camera.y = 300;
-    camera.z = 2;
+    camera.zoom = 2;
 
     sut.setCurrentCamera(camera);
 
@@ -426,7 +426,7 @@ describe('A Screen', () => {
     const camera = new Camera();
     camera.x = 400;
     camera.y = 300;
-    camera.z = 2;
+    camera.zoom = 2;
 
     sut.setCurrentCamera(camera);
 
@@ -452,7 +452,7 @@ describe('A Screen', () => {
     const camera = new Camera();
     camera.x = 400;
     camera.y = 300;
-    camera.z = 2;
+    camera.zoom = 2;
 
     sut.setCurrentCamera(camera);
     sut.applyResolutionAndViewport();

--- a/src/stories/Actions.stories.ts
+++ b/src/stories/Actions.stories.ts
@@ -22,7 +22,7 @@ export const usingActions: Story = withEngine(async (game) => {
   game.setAntialiasing(false);
 
   // Zoom in a bit
-  game.currentScene.camera.z = 4;
+  game.currentScene.camera.zoom = 4;
 
   // Center the actor on the camera coordinates
   const heart = new Actor({
@@ -52,7 +52,7 @@ export const fade: Story = withEngine(async (game) => {
   game.setAntialiasing(false);
 
   // Zoom in a bit
-  game.currentScene.camera.z = 4;
+  game.currentScene.camera.zoom = 4;
 
   // Center the actor on the camera coordinates
   const heart = new Actor({
@@ -89,7 +89,7 @@ export const rotateTo: Story = withEngine(async (game) => {
   game.setAntialiasing(false);
 
   // Zoom in a bit
-  game.currentScene.camera.z = 4;
+  game.currentScene.camera.zoom = 4;
 
   // Center the actor on the camera coordinates
   const heart = new Actor({
@@ -144,7 +144,7 @@ export const rotateBy: Story = withEngine(async (game) => {
   game.setAntialiasing(false);
 
   // Zoom in a bit
-  game.currentScene.camera.z = 4;
+  game.currentScene.camera.zoom = 4;
 
   // Center the actor on the camera coordinates
   const heart = new Actor({
@@ -199,7 +199,7 @@ export const move: Story = withEngine(async (game) => {
   game.setAntialiasing(false);
 
   // Zoom in a bit
-  game.currentScene.camera.z = 4;
+  game.currentScene.camera.zoom = 4;
 
   // Center the actor on the camera coordinates
   const heart = new Actor({
@@ -239,7 +239,7 @@ export const ease: Story = withEngine(async (game) => {
   game.setAntialiasing(false);
 
   // Zoom in a bit
-  game.currentScene.camera.z = 4;
+  game.currentScene.camera.zoom = 4;
 
   // Center the actor on the camera coordinates
   const heart = new Actor({
@@ -281,7 +281,7 @@ export const scale: Story = withEngine(async (game) => {
   game.setAntialiasing(false);
 
   // Zoom in a bit
-  game.currentScene.camera.z = 4;
+  game.currentScene.camera.zoom = 4;
 
   // Center the actor on the camera coordinates
   const heart = new Actor({


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Offscreen culling events were not firing in the new graphics system, this updates entities with an "offscreen" tag if they are offscreen

## Changes:

- "offscreen" tag
- enter and exit viewport events fire once more for the new graphics system
- Bug in ECS component removal :boom: where entities were being removed from queries they still qualified for
