### PR TITLE
fix: [#874] Improve confusing behaviour of Actor.opacity

### DIFF
--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -327,7 +327,13 @@ export class ActorImpl extends Entity implements Actionable, Eventable, PointerE
   /**
    * The opacity of an actor. Passing in a color in the [[constructor]] will use the
    * color's opacity.
+   *
+   * @obsolete Actor.opacity will be removed in v0.26.0, use [[GraphicsComponent.opacity|Actor.graphics.opacity]].
    */
+  @obsolete({
+    message: 'Actor.opacity will be removed in v0.26.0',
+    alternateMethod: 'Use Actor.graphics.opacity'
+  })
   public opacity: number = 1;
 
   /**

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -1114,10 +1114,6 @@ export class ActorImpl extends Entity implements Actionable, Eventable, PointerE
       this.color.a = this.opacity;
     }
 
-    if (this.opacity === 0) {
-      this.visible = false;
-    }
-
     // capture old transform
     this.body.captureOldTransform();
 

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -85,9 +85,7 @@ export interface ActorDefaults {
  * @hidden
  */
 
-export class ActorImpl
-  extends Entity
-  implements Actionable, Eventable, PointerEvents, CanInitialize, CanUpdate, CanDraw, CanBeKilled {
+export class ActorImpl extends Entity implements Actionable, Eventable, PointerEvents, CanInitialize, CanUpdate, CanDraw, CanBeKilled {
   // #region Properties
 
   /**
@@ -331,7 +329,6 @@ export class ActorImpl
    * color's opacity.
    */
   public opacity: number = 1;
-  public previousOpacity: number = 1;
 
   /**
    * Direct access to the actor's [[ActionQueue]]. Useful if you are building custom actions.
@@ -460,11 +457,7 @@ export class ActorImpl
    * initial [[opacity]].
    */
   constructor(xOrConfig?: number | ActorArgs, y?: number, width?: number, height?: number, color?: Color) {
-    super([
-      new TransformComponent(),
-      new GraphicsComponent(),
-      new CanvasDrawComponent((ctx, delta) => this.draw(ctx, delta))
-    ]);
+    super([new TransformComponent(), new GraphicsComponent(), new CanvasDrawComponent((ctx, delta) => this.draw(ctx, delta))]);
 
     this.transform = this.get(TransformComponent);
     this.graphics = this.get(GraphicsComponent);

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -325,8 +325,7 @@ export class ActorImpl extends Entity implements Actionable, Eventable, PointerE
   }
 
   /**
-   * The opacity of an actor. Passing in a color in the [[constructor]] will use the
-   * color's opacity.
+   * The opacity of an actor.
    *
    * @obsolete Actor.opacity will be removed in v0.26.0, use [[GraphicsComponent.opacity|Actor.graphics.opacity]].
    */
@@ -334,7 +333,15 @@ export class ActorImpl extends Entity implements Actionable, Eventable, PointerE
     message: 'Actor.opacity will be removed in v0.26.0',
     alternateMethod: 'Use Actor.graphics.opacity'
   })
-  public opacity: number = 1;
+  public get opacity(): number {
+    return this._opacity;
+  }
+
+  public set opacity(opacity: number) {
+    this._opacity = opacity;
+  }
+
+  private _opacity: number = 1;
 
   /**
    * Direct access to the actor's [[ActionQueue]]. Useful if you are building custom actions.
@@ -459,8 +466,7 @@ export class ActorImpl extends Entity implements Actionable, Eventable, PointerE
    * @param y         The starting y coordinate of the actor
    * @param width     The starting width of the actor
    * @param height    The starting height of the actor
-   * @param color     The starting color of the actor. Leave null to draw a transparent actor. The opacity of the color will be used as the
-   * initial [[opacity]].
+   * @param color   The starting color of the actor. Leave null to draw a transparent actor.
    */
   constructor(xOrConfig?: number | ActorArgs, y?: number, width?: number, height?: number, color?: Color) {
     super([new TransformComponent(), new GraphicsComponent(), new CanvasDrawComponent((ctx, delta) => this.draw(ctx, delta))]);
@@ -519,8 +525,6 @@ export class ActorImpl extends Entity implements Actionable, Eventable, PointerE
 
     if (color) {
       this.color = color;
-      // set default opacity of an actor to the color
-      this.opacity = color.a;
     }
 
     if (color) {
@@ -1109,11 +1113,6 @@ export class ActorImpl extends Entity implements Actionable, Eventable, PointerE
     // Update action queue
     this.actionQueue.update(delta);
 
-    // Update color only opacity
-    if (this.color) {
-      this.color.a = this.opacity;
-    }
-
     // capture old transform
     this.body.captureOldTransform();
 
@@ -1197,6 +1196,7 @@ export class ActorImpl extends Entity implements Actionable, Eventable, PointerE
       this.currentDrawing.draw({ ctx, x: offsetX, y: offsetY, opacity: this.opacity });
     } else {
       if (this.color && this.body && this.body.collider && this.body.collider.shape) {
+        ctx.globalAlpha = this.opacity;
         this.body.collider.shape.draw(ctx, this.color, new Vector(0, 0));
       }
     }

--- a/src/engine/Drawing/Animation.ts
+++ b/src/engine/Drawing/Animation.ts
@@ -322,7 +322,7 @@ export class AnimationImpl implements Drawable, HasTick {
       flipHorizontal: options.flipHorizontal ?? this.flipHorizontal,
       flipVertical: options.flipVertical ?? this.flipVertical,
       anchor: options.anchor ?? this.anchor,
-      opacity: options.opacity ?? this._opacity
+      opacity: (options.opacity ?? 1) * (this._opacity ?? 1)
     };
 
     this._updateValues();

--- a/src/engine/Drawing/Polygon.ts
+++ b/src/engine/Drawing/Polygon.ts
@@ -138,7 +138,7 @@ export class Polygon implements Drawable {
       flipVertical: options.flipVertical ?? this.flipVertical,
       anchor: options.anchor ?? this.anchor,
       offset: options.offset ?? this.offset,
-      opacity: options.opacity ?? this.opacity
+      opacity: (options.opacity ?? 1) * (this.opacity ?? 1)
     };
 
     const xpoint = drawWidth * anchor.x + offset.x + x;
@@ -183,7 +183,7 @@ export class Polygon implements Drawable {
     }
 
     const oldAlpha = ctx.globalAlpha;
-    ctx.globalAlpha = opacity ?? 1;
+    ctx.globalAlpha = opacity;
     ctx.stroke();
     ctx.globalAlpha = oldAlpha;
 

--- a/src/engine/Drawing/Sprite.ts
+++ b/src/engine/Drawing/Sprite.ts
@@ -349,7 +349,7 @@ export class SpriteImpl implements Drawable {
       flipVertical: options.flipVertical ?? this.flipVertical,
       anchor: options.anchor ?? this.anchor,
       offset: options.offset ?? this.offset,
-      opacity: options.opacity ?? this._opacity
+      opacity: (options.opacity ?? 1) * (this._opacity ?? 1)
     };
 
     if (this._dirtyEffect) {
@@ -391,7 +391,7 @@ export class SpriteImpl implements Drawable {
       ctx.scale(1, -1);
     }
     const oldAlpha = ctx.globalAlpha;
-    ctx.globalAlpha = opacity ?? 1;
+    ctx.globalAlpha = opacity;
     // Context is already rotated and scaled
     ctx.drawImage(
       this._spriteCanvas,

--- a/src/engine/Label.ts
+++ b/src/engine/Label.ts
@@ -31,7 +31,7 @@ export interface LabelOptions {
  */
 export class LabelImpl extends Actor {
   public font: Font = new Font();
-  private _text: Text = new Text({ text: '', font: this.font});
+  private _text: Text = new Text({ text: '', font: this.font });
 
   /**
    * The text to draw.
@@ -52,6 +52,14 @@ export class LabelImpl extends Actor {
     this._text.color = color;
   }
 
+  public get opacity(): number {
+    return this._text.opacity;
+  }
+
+  public set opacity(opacity: number) {
+    this._text.opacity = opacity;
+  }
+
   /**
    * Sets or gets the bold property of the label's text, by default it's false
    * @deprecated Use [[Font.bold|Label.font.bold]]
@@ -67,7 +75,6 @@ export class LabelImpl extends Actor {
   public set bold(isBold: boolean) {
     this.font.bold = isBold;
   }
-
 
   /**
    * The CSS font family string (e.g. `sans-serif`, `Droid Sans Pro`). Web fonts
@@ -117,7 +124,6 @@ export class LabelImpl extends Actor {
   public set fontStyle(style: FontStyle) {
     this.font.style = style;
   }
-
 
   /**
    * The css units for a font size such as px, pt, em (SpriteFont only support px), by default is 'px';
@@ -192,7 +198,6 @@ export class LabelImpl extends Actor {
     }
   }
 
-
   /**
    * Gets or sets the letter spacing on a Label. Only supported with Sprite Fonts.
    * @deprecated Use [[SpriteFont.spacing]]
@@ -229,11 +234,11 @@ export class LabelImpl extends Actor {
       pos = vec(x ?? 0, y ?? 0);
     }
 
-    this.addComponent(new TransformComponent);
+    this.addComponent(new TransformComponent());
     this.get(TransformComponent).pos = pos;
 
     this.addComponent(new CanvasDrawComponent((ctx, delta) => this.draw(ctx, delta)));
-    this.addComponent(new GraphicsComponent);
+    this.addComponent(new GraphicsComponent());
     const gfx = this.get(GraphicsComponent);
     gfx.anchor = Vector.Zero;
     gfx.use(this._text);

--- a/src/engine/Particles.ts
+++ b/src/engine/Particles.ts
@@ -314,9 +314,17 @@ export class ParticleEmitterImpl extends Actor {
    */
   public particleLife: number = 2000;
   /**
-   * Gets or sets the opacity of each particle from 0 to 1.0
+   * Gets the opacity of each particle from 0 to 1.0
    */
-  public opacity: number = 1;
+  public get opacity(): number {
+    return super.opacity;
+  }
+  /**
+   * Gets the opacity of each particle from 0 to 1.0
+   */
+  public set opacity(opacity: number) {
+    super.opacity = opacity;
+  }
   /**
    * Gets or sets the fade flag which causes particles to gradually fade out over the course of their life.
    */

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -488,24 +488,24 @@ describe('A game actor', () => {
     expect(actor.enableCapturePointer).toBeTruthy();
   });
 
-  it('changes opacity on color', () => {
+  it('does not change opacity on color', () => {
     actor.color = ex.Color.Black.clone();
     expect(actor.color.a).toBe(1);
     expect(actor.color.r).toBe(0);
     expect(actor.color.g).toBe(0);
     expect(actor.color.b).toBe(0);
-
     expect(actor.opacity).toBe(1.0);
-    actor.opacity = 0.5;
 
+    actor.opacity = 0.5;
     actor.update(engine, 100);
-    expect(actor.color.a).toBe(0.5);
+    expect(actor.color.a).toBe(1.0);
     expect(actor.color.r).toBe(0);
     expect(actor.color.g).toBe(0);
     expect(actor.color.b).toBe(0);
+    expect(actor.opacity).toBe(0.5);
   });
 
-  it('not drawn on opacity 0', () => {
+  it('is drawn on opacity 0', () => {
     const invisibleActor = new ex.Actor();
     spyOn(invisibleActor, 'draw');
     scene.add(invisibleActor);
@@ -515,7 +515,7 @@ describe('A game actor', () => {
     scene.update(engine, 100);
     scene.draw(engine.ctx, 100);
 
-    expect(invisibleActor.draw).not.toHaveBeenCalled();
+    expect(invisibleActor.draw).toHaveBeenCalled();
   });
 
   it('can be drawn with a z-index', (done) => {


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass **(after being updated for new behaviour)**
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

Closes #874 (maybe)

## Changes:

This is a proposal to:

 * Make the behaviour of `Actor.opacity` more logical, so they behaves as developers would probably expect.
   * `Actor.opacity` and `Actor.color.a` are now independent values and both are honoured (wherever relevant) by multiplying them to determine the overall opacity.
   * Corresponding changes to the `Drawable` types (`Sprite`, `Animation`, `Polygon`) that multiply any `opacity` passed to `draw` as an option with the `opacity` field of the object.
 * Deprecate `Actor.opacity` in favour of `GraphicsComponent.opacity`, which already behaves in a sensible way.
 * Delete unused `Actor.previousOpacity` field.
 * Fix `Actor` turning "permanently" invisible after setting `Actor.opacity = 0`.

This changeset is technically backwards incompatible because it removes the interaction between `Actor.color.a` and `Actor.opacity`. Instead, `Actor.color.a` and `Actor.opacity` are treated as independent values and both are honored by multiplying them. I think this should maintain compatibility with any sensible usage of the API, but it's perfectly possible that there are some games that rely on the old behaviour.

Some examples of behaviour (that I would consider dubious) that would be incompatible with this change:

 * Constructing an `Actor` with an initial color and then expecting to be able to read that color's alpha value back by reading `Actor.opacity`.
 * Setting `Actor.opacity` and then expecting to be able to read that value back by reading `Actor.color.a`.
 * Setting `Actor.opacity = 0`, waiting at least one frame, and then expecting that Actor to stay invisible even if the opacity is subsequently set to a value > 0.
 * Setting the `opacity` field of a `Drawable` to a value other than `1` or `undefined` and then expecting that value to be overridden by `opacity` specified as an argument to `draw` (instead they will be multiplied).

I think any other usage of `Actor.color`, `Actor.opacity`, or `Drawable.opacity` should continue to work as before.

There is precedent for making this backwards incompatible change in that a similar change has already been applied to `Label`.

This changeset also removes an optimisation which would skip the `Actor.draw` call altogether for Actors with `opacity === 0`, but it's hard to retain that optimisation without also keeping confusing behaviour. I think it's a fair compromise to remove this optimization and deprecate `Actor.opacity` in favor of `GraphicsComponent.opacity`

It's not quite ready to merge (see incomplete checklist items above), but I'm submitting it as a PR early for discussion. I'll address the remaining items if Excalibur developers are broadly happy with the thrust of this changeset.