### PR TITLE
fix: [#1848] Add polyfill for decodeAudioData on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `ex.Actor.easeTo` actions, they now use velocity to move Actors ([#1638](https://github.com/excaliburjs/Excalibur/issues/1638))
 - Fixed `Scene` constructor signature to make the `Engine` argument optional ([#1363](https://github.com/excaliburjs/Excalibur/issues/1363))
 - Fixed `anchor` properly of single shape `Actor` [#1535](https://github.com/excaliburjs/Excalibur/issues/1535)
+- Fixed Safari bug where `Sound` resources would fail to load ([#1848](https://github.com/excaliburjs/Excalibur/issues/1848))
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->

--- a/src/engine/Polyfill.ts
+++ b/src/engine/Polyfill.ts
@@ -34,6 +34,16 @@ export function polyfill() {
   }
   /* istanbul ignore next */
   if (typeof window !== 'undefined' && !(<any>window).AudioContext) {
+    if ((<any>window).webkitAudioContext) {
+      const ctx = (<any>window).webkitAudioContext;
+      const replaceMe = ctx.prototype.decodeAudioData;
+      (<any>window).webkitAudioContext.prototype.decodeAudioData = function (arrayBuffer: ArrayBuffer) {
+        return new Promise((resolve, reject) => {
+          replaceMe.call(this, arrayBuffer, resolve, reject);
+        });
+      };
+    }
+
     (<any>window).AudioContext =
       (<any>window).AudioContext ||
       (<any>window).webkitAudioContext ||

--- a/src/engine/Resources/Sound/AudioContext.ts
+++ b/src/engine/Resources/Sound/AudioContext.ts
@@ -8,7 +8,7 @@ export class AudioContextFactory {
   public static create(): AudioContext {
     if (!this._INSTANCE) {
       if ((<any>window).AudioContext || (<any>window).webkitAudioContext) {
-        this._INSTANCE = new (<any>window).AudioContext();
+        this._INSTANCE = new AudioContext();
       }
     }
 


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [X] :pushpin: issue exists in github for these changes
- [X] :microscope: existing tests still pass
- [X] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [X] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #1848

## Changes:

`webkitAudioContext.decodeAudioData` does not support the newer Promise-style API offered by the standard and instead uses the older callback-based method:

https://stackoverflow.com/a/52536753

This PR adds a polyfill that emulates the Promise-style API in webkit browsers.
