### PR TITLE
fix: [#1897] Prevent backing bitmap from growing with padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue with Raster padding which caused images to grow over time ([#1897](https://github.com/excaliburjs/Excalibur/issues/1897))
 - Fixed N+1 repeat/repeatForever bug ([#1891](https://github.com/excaliburjs/Excalibur/issues/1891))
 - Fixed repeat/repeatForever issue with `rotateTo` ([#635](https://github.com/excaliburjs/Excalibur/issues/635))
 - Entity update lifecycle is now called correctly

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,6 +11,7 @@ module.exports = (config) => {
     singleRun: true,
     frameworks: ['jasmine'],
     client: {
+      captureConsole: false,
       jasmine: {
         timeoutInterval: 30000
       }

--- a/src/engine/Graphics/Raster.ts
+++ b/src/engine/Graphics/Raster.ts
@@ -86,7 +86,7 @@ export abstract class Raster extends Graphic {
    * to be flagged dirty causing a re-raster on the next draw.
    */
   public get width() {
-    return this._bitmap.width;
+    return this._originalWidth;
   }
   public set width(value: number) {
     this._bitmap.width = value;
@@ -100,7 +100,7 @@ export abstract class Raster extends Graphic {
    * to be flagged dirty causing a re-raster on the next draw.
    */
   public get height() {
-    return this._bitmap.height;
+    return this._originalHeight;
   }
 
   public set height(value: number) {
@@ -117,6 +117,9 @@ export abstract class Raster extends Graphic {
     return (this._originalHeight ?? this._bitmap.height) + this.padding * 2;
   }
 
+  /**
+   * Returns the local bounds of the Raster including the padding
+   */
   public get localBounds() {
     return BoundingBox.fromDimension(this._getTotalWidth() * this.scale.x, this._getTotalHeight() * this.scale.y, Vector.Zero);
   }

--- a/src/engine/Graphics/Raster.ts
+++ b/src/engine/Graphics/Raster.ts
@@ -39,7 +39,7 @@ export abstract class Raster extends Graphic {
     }
 
     this._bitmap = document.createElement('canvas');
-    // get the default canvasi width as a fallback
+    // get the default canvas width/height as a fallback
     const bitmapWidth = options?.width ?? this._bitmap.width;
     const bitmapHeight = options?.height ?? this._bitmap.height;
     // Rasters use power of two images as an optimization for webgl

--- a/src/engine/Graphics/Raster.ts
+++ b/src/engine/Graphics/Raster.ts
@@ -203,7 +203,7 @@ export abstract class Raster extends Graphic {
    */
   public rasterize(): void {
     this._dirty = false;
-    this._ctx.clearRect(0, 0, this.width, this.height);
+    this._ctx.clearRect(0, 0, this._getTotalWidth(), this._getTotalHeight());
     this._ctx.save();
     this._applyRasterProperites(this._ctx);
     this.execute(this._ctx);

--- a/src/engine/Graphics/Raster.ts
+++ b/src/engine/Graphics/Raster.ts
@@ -39,11 +39,12 @@ export abstract class Raster extends Graphic {
     }
 
     this._bitmap = document.createElement('canvas');
+    // get the default canvasi width as a fallback
     const bitmapWidth = options?.width ?? this._bitmap.width;
     const bitmapHeight = options?.height ?? this._bitmap.height;
     // Rasters use power of two images as an optimization for webgl
-    this._bitmap.width = ensurePowerOfTwo(bitmapWidth);
-    this._bitmap.height = ensurePowerOfTwo(bitmapHeight);
+    this.width = ensurePowerOfTwo(bitmapWidth);
+    this.height = ensurePowerOfTwo(bitmapHeight);
     const maybeCtx = this._bitmap.getContext('2d');
     if (!maybeCtx) {
       /* istanbul ignore next */
@@ -79,6 +80,7 @@ export abstract class Raster extends Graphic {
     this._dirty = true;
   }
 
+  private _originalWidth: number;
   /**
    * Gets or sets the current width of the Raster graphic. Setting the width will cause the raster
    * to be flagged dirty causing a re-raster on the next draw.
@@ -88,9 +90,11 @@ export abstract class Raster extends Graphic {
   }
   public set width(value: number) {
     this._bitmap.width = value;
+    this._originalWidth = value;
     this.flagDirty();
   }
 
+  private _originalHeight: number;
   /**
    * Gets or sets the current height of the Raster graphic. Setting the height will cause the raster
    * to be flagged dirty causing a re-raster on the next draw.
@@ -98,13 +102,23 @@ export abstract class Raster extends Graphic {
   public get height() {
     return this._bitmap.height;
   }
+
   public set height(value: number) {
     this._bitmap.height = value;
+    this._originalHeight = value;
     this.flagDirty();
   }
 
+  private _getTotalWidth() {
+    return (this._originalWidth ?? this._bitmap.width) + this.padding * 2;
+  }
+
+  private _getTotalHeight() {
+    return (this._originalHeight ?? this._bitmap.height) + this.padding * 2;
+  }
+
   public get localBounds() {
-    return BoundingBox.fromDimension(this.width * this.scale.x, this.height * this.scale.y, Vector.Zero);
+    return BoundingBox.fromDimension(this._getTotalWidth() * this.scale.x, this._getTotalHeight() * this.scale.y, Vector.Zero);
   }
 
   private _smoothing: boolean = false;
@@ -199,8 +213,8 @@ export abstract class Raster extends Graphic {
   }
 
   protected _applyRasterProperites(ctx: CanvasRenderingContext2D) {
-    this._bitmap.width = this._bitmap.width + this.padding * 2;
-    this._bitmap.height = this._bitmap.height + this.padding * 2;
+    this._bitmap.width = this._getTotalWidth();
+    this._bitmap.height = this._getTotalHeight();
     ctx.translate(this.padding, this.padding);
     ctx.imageSmoothingEnabled = this.smoothing;
     ctx.lineWidth = this.lineWidth;

--- a/src/spec/GraphicsRasterSpec.ts
+++ b/src/spec/GraphicsRasterSpec.ts
@@ -104,4 +104,28 @@ describe('A Raster', () => {
     sut.smoothing = false;
     expect(sut.dirty).toBe(true);
   });
+
+  it('can have padding and maintain correct size and not grow after each draw', () => {
+    const sut = new TestRaster();
+    expect(sut.localBounds.width).toBe(50);
+    expect(sut.localBounds.height).toBe(50);
+    sut.padding = 4;
+    expect(sut.localBounds.width).toBe(58);
+    expect(sut.localBounds.height).toBe(58);
+
+    sut.flagDirty();
+    sut.draw(ctx, 0, 0);
+    expect(sut._bitmap.width).toBe(58);
+    expect(sut._bitmap.height).toBe(58);
+
+    sut.flagDirty();
+    sut.draw(ctx, 0, 0);
+    expect(sut._bitmap.width).toBe(58);
+    expect(sut._bitmap.height).toBe(58);
+
+    sut.flagDirty();
+    sut.draw(ctx, 0, 0);
+    expect(sut._bitmap.width).toBe(58);
+    expect(sut._bitmap.height).toBe(58);
+  });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1897

## Changes:

- Fixes issue where Raster bitmap grows every time it is rasterized using padding

