### PR TITLE
fix: [#1922] Propagate pointer events in high->low z order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where pointer events propagate in an unexpected order, now they go from high z-index to low z-index ([#1922](https://github.com/excaliburjs/Excalibur/issues/1922)))
 - Fixed issue with Raster padding which caused images to grow over time ([#1897](https://github.com/excaliburjs/Excalibur/issues/1897))
 - Fixed N+1 repeat/repeatForever bug ([#1891](https://github.com/excaliburjs/Excalibur/issues/1891))
 - Fixed repeat/repeatForever issue with `rotateTo` ([#635](https://github.com/excaliburjs/Excalibur/issues/635))

--- a/sandbox/tests/graphics/index.html
+++ b/sandbox/tests/graphics/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Graphics Padding Test</title>
+</head>
+<body>
+  <script src="../../lib/excalibur.js"></script>
+  <script src="index.js"></script>
+</body>
+</html>

--- a/sandbox/tests/graphics/index.ts
+++ b/sandbox/tests/graphics/index.ts
@@ -1,0 +1,53 @@
+/// <reference path="../../lib/excalibur.d.ts" />
+
+
+/**
+ * Managed game class
+ */
+class Game extends ex.Engine {
+
+  constructor() {
+    super({
+      displayMode: ex.DisplayMode.Fill,
+      enableCanvasTransparency: true,
+
+    });
+  }
+
+  public start() {
+    const scene = new ex.Scene();
+    const actor = new ex.Actor({ pos: ex.vec(150, 150) });
+    const circle = new ex.Graphics.Circle({
+      radius: 30,
+      strokeColor: ex.Color.DarkGray,
+      lineWidth: 10,
+      padding: 20,
+      smoothing: true,
+
+    });
+    actor.graphics.add(circle);
+    scene.add(actor);
+    this.add('levelOne', scene);
+
+
+    // Automatically load all default resources
+    const loader = new ex.Loader();
+    this.simulate(circle);
+    return super.start(loader);
+  }
+
+  private async simulate(circle: ex.Graphics.Circle) {
+    while (true) {
+      await ex.Util.delay(1000);
+      circle.color = ex.Color.Red;
+      await ex.Util.delay(1000);
+      circle.color = ex.Color.Violet;
+    }
+  }
+}
+
+var game3 = new Game();
+game3.start().then(() => {
+  game3.goToScene('levelOne');
+});
+

--- a/sandbox/tests/pointer/index.html
+++ b/sandbox/tests/pointer/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pointer</title>
+</head>
+<body>
+  <p>Click on the squares to see events propagate in z order in the console. The black square cancels the event preventing propagation.</p>
+  <script src="../../lib/excalibur.js"></script>
+  <script src="pointer.js"></script>
+</body>
+</html>

--- a/sandbox/tests/pointer/pointer.ts
+++ b/sandbox/tests/pointer/pointer.ts
@@ -1,0 +1,49 @@
+/// <reference path='../../lib/excalibur.d.ts' />
+
+class Player extends ex.Actor {
+  constructor(color: ex.Color, size = 100) {
+    super({x: 300, y: 200, width: size, height: size, color});
+  }
+}
+
+class Game2 extends ex.Engine {
+  initialize() {
+    const player1 = new Player(ex.Color.Green);
+    this.add(player1);
+    player1.z = 10;
+    player1.on("pointerdown", (e) => {
+      console.log("green");
+    });
+
+    const player2 = new Player(ex.Color.Blue);
+    this.add(player2);
+    player2.rotation = 0.3;
+    player2.z = 5;
+    player2.on("pointerdown", (e) => {
+      console.log("blue");
+    });
+
+    const player3 = new Player(ex.Color.Rose);
+    this.add(player3);
+    player3.rotation = 0.6;
+    player3.z = 1;
+    player3.on("pointerdown", (e) => {
+      console.log("rose");
+    });
+
+    const player4 = new Player(ex.Color.Black, 20);
+    this.add(player4);
+    player4.z = 11;
+    player4.on('pointerdown', e => {
+      console.log('black');
+      console.log('event canceled');
+      e.cancel();
+    });
+
+    const loader = new ex.Loader();
+    this.start(loader);
+  }
+}
+var game2 = new Game2({width: 600, height: 400});
+
+game2.initialize();

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -1048,10 +1048,8 @@ export class ActorImpl extends Entity implements Actionable, Eventable, PointerE
    * @param recurse checks whether the x/y are contained in any child actors (if they exist).
    */
   public contains(x: number, y: number, recurse: boolean = false): boolean {
-    // These shenanigans are to handle child actor containment,
-    // the only time getWorldPos and pos are different is a child actor
-    const childShift = this.getGlobalPos().sub(this.pos);
-    const containment = this.body.collider.shape.contains(new Vector(x, y).add(childShift));
+    const point = vec(x, y);
+    const containment = this.body.collider.shape.contains(point);
 
     if (recurse) {
       return (

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -1051,7 +1051,7 @@ export class ActorImpl extends Entity implements Actionable, Eventable, PointerE
     // These shenanigans are to handle child actor containment,
     // the only time getWorldPos and pos are different is a child actor
     const childShift = this.getGlobalPos().sub(this.pos);
-    const containment = this.body.collider.bounds.translate(childShift).contains(new Vector(x, y));
+    const containment = this.body.collider.shape.contains(new Vector(x, y).add(childShift));
 
     if (recurse) {
       return (

--- a/src/engine/Input/Pointer.ts
+++ b/src/engine/Input/Pointer.ts
@@ -51,6 +51,13 @@ export class Pointer extends Class {
   private _actorsLastFrame: Actor[] = [];
   private _actorsNoLongerUnderPointer: Actor[] = [];
 
+  private _actorSortingFcn = (a: Actor, b: Actor) => {
+    if (a.z === b.z) {
+      return b.id - a.id;
+    }
+    return b.z - a.z;
+  };
+
   /**
    * Whether the Pointer is currently dragging.
    */
@@ -157,12 +164,7 @@ export class Pointer extends Class {
 
     // Actors are processed in z-order highest z to lowest
     // ties are broken by id highest id (newest) to lowest id (oldest)
-    this._actors.sort((a, b) => {
-      if (a.z === b.z) {
-        return b.id - a.id;
-      }
-      return b.z - a.z;
-    });
+    this._actors.sort(this._actorSortingFcn);
   }
 
   /**
@@ -197,8 +199,8 @@ export class Pointer extends Class {
    */
   public getActorsForEvents(): Actor[] {
     return this._actors.concat(this._actorsLastFrame).filter((actor, i, self) => {
-      return self.indexOf(actor) === i;
-    });
+      return self.indexOf(actor) === i; // de-dup
+    }).sort(this._actorSortingFcn); // sort by z
   }
 
   /**
@@ -217,7 +219,7 @@ export class Pointer extends Class {
    * @param actor
    */
   public wasActorUnderPointer(actor: Actor): boolean {
-    return this._actorsLastFrame.indexOf(actor) > -1; // || !!this._actorsUnderPointerLastFrame.hasOwnProperty(actor.id.toString());
+    return this._actorsLastFrame.indexOf(actor) > -1;
   }
 
   /**

--- a/src/engine/Input/Pointer.ts
+++ b/src/engine/Input/Pointer.ts
@@ -155,12 +155,13 @@ export class Pointer extends Class {
       this._actors.push(actor);
     }
 
-    // Actors under the pointer are sorted by z, ties are broken by id
+    // Actors are processed in z-order highest z to lowest
+    // ties are broken by id highest id (newest) to lowest id (oldest)
     this._actors.sort((a, b) => {
       if (a.z === b.z) {
-        return a.id - b.id;
+        return b.id - a.id;
       }
-      return a.z - b.z;
+      return b.z - a.z;
     });
   }
 

--- a/src/engine/Input/PointerEvents.ts
+++ b/src/engine/Input/PointerEvents.ts
@@ -102,12 +102,16 @@ export class PointerEvent extends GameEvent<Actor> {
   public _canceled = false;
 
   /**
-   * Cancels the event and prevents it from propagating to any other actors
+   * Cancels pointer event propogation, event will not be transmitted to any other actors
    */
   public cancel() {
     this._canceled = true;
   }
 
+ /**
+   * 
+   * @returns If the event is canceled it will no longer be transmitted to any other actors
+   */
   public isCanceled(){
     return this._canceled;
   }

--- a/src/engine/Input/PointerEvents.ts
+++ b/src/engine/Input/PointerEvents.ts
@@ -108,8 +108,8 @@ export class PointerEvent extends GameEvent<Actor> {
     this._canceled = true;
   }
 
- /**
-   * 
+  /**
+   *
    * @returns If the event is canceled it will no longer be transmitted to any other actors
    */
   public isCanceled(){
@@ -333,7 +333,7 @@ export class WheelEvent extends GameEvent<Actor> {
   }
 
   /**
-   * 
+   *
    * @returns If the event is canceled it will no longer be transmitted to any other actors
    */
   public isCanceled() {

--- a/src/engine/Input/PointerEvents.ts
+++ b/src/engine/Input/PointerEvents.ts
@@ -99,10 +99,23 @@ export class PointerEvent extends GameEvent<Actor> {
     return this.coordinates.worldPos.clone();
   }
 
+  public _canceled = false;
+
+  /**
+   * Cancels the event and prevents it from propagating to any other actors
+   */
+  public cancel() {
+    this._canceled = true;
+  }
+
+  public isCanceled(){
+    return this._canceled;
+  }
+
   public propagate(actor: Actor): void {
     this.doAction(actor);
 
-    if (this.bubbles && actor.parent) {
+    if (this.bubbles && !this.isCanceled() && actor.parent) {
       this.propagate(actor.parent as Actor); // TODO not true
     }
   }
@@ -191,7 +204,7 @@ export class PointerMoveEvent extends PointerEvent {
     if (this.pointer.isActorAliveUnderPointer(actor)) {
       this.doAction(actor);
 
-      if (this.bubbles && actor.parent) {
+      if (this.bubbles && !this.isCanceled() && actor.parent) {
         this.propagate(actor.parent as Actor); // TODO not true
       }
     }
@@ -304,6 +317,23 @@ export class WheelEvent extends GameEvent<Actor> {
     public ev: any
   ) {
     super();
+  }
+
+  private _isCanceled = false;
+
+  /**
+   * Cancels pointer event propogation, event will not be transmitted to any other actors
+   */
+  public cancel() {
+    this._isCanceled = true;
+  }
+
+  /**
+   * 
+   * @returns If the event is canceled it will no longer be transmitted to any other actors
+   */
+  public isCanceled() {
+    return this._isCanceled;
   }
 }
 

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -694,19 +694,19 @@ describe('A game actor', () => {
     child.addChild(child2);
 
     // check reality
-    expect(parent.contains(550, 50)).toBeTruthy();
-    expect(parent.contains(650, 150)).toBeTruthy();
+    expect(parent.contains(550.01, 50.01)).withContext('(550.1, 50.1) is top-left of parent should be contained').toBeTruthy();
+    expect(parent.contains(650, 150)).withContext('(650, 150) is bottom-right of parent should be contained').toBeTruthy();
 
     // in world coordinates this should be false
-    expect(child.contains(50, 50)).toBeFalsy();
+    expect(child.contains(50, 50)).withContext('(50, 50) world coords is outside child world pos').toBeFalsy();
 
     // in world coordinates this should be true
-    expect(child.contains(550, 50)).toBeTruthy();
-    expect(child.contains(650, 150)).toBeTruthy();
+    expect(child.contains(550.01, 50.01)).withContext('(550.1, 50.1) world should be top-left of of child').toBeTruthy();
+    expect(child.contains(650, 150)).withContext('(650, 150) world should be bottom-rght of child').toBeTruthy();
 
     // second order child shifted to the origin
-    expect(child2.contains(-50, -50)).toBeTruthy();
-    expect(child2.contains(50, 50)).toBeTruthy();
+    expect(child2.contains(-49.99, -49.99)).withContext('(-50, -50) world should be top left of second order child').toBeTruthy();
+    expect(child2.contains(50, 50)).withContext('(50, 50) world should be bottom right of second order child').toBeTruthy();
   });
 
   it('can recursively check containment', () => {

--- a/src/spec/PointerInputSpec.ts
+++ b/src/spec/PointerInputSpec.ts
@@ -142,4 +142,77 @@ describe('A pointer', () => {
     executeMouseEvent('pointerdown', <any>document, null, 50, 50);
     expect(engine.input.pointers.primary.isActorAliveUnderPointer(actor)).toBe(false);
   });
+
+  it('should dispatch events in z order high to low', () => {
+    const actualOrder = [];
+
+    const actor1 = new ex.Actor({ x: 50, y: 50, width: 100, height: 100 });
+    actor1.z = 0;
+    actor1.on('pointerdown', (e) => {
+      actualOrder.push('actor1');
+    });
+    const actor2 = new ex.Actor({ x: 50, y: 50, width: 100, height: 100 });
+    actor2.z = 1;
+    actor2.on('pointerdown', (e) => {
+      actualOrder.push('actor2');
+    });
+    const actor3 = new ex.Actor({ x: 50, y: 50, width: 100, height: 100 });
+    actor3.z = 2;
+    actor3.on('pointerdown', (e) => {
+      actualOrder.push('actor3');
+    });
+    const actor4 = new ex.Actor({ x: 50, y: 50, width: 100, height: 100 });
+    actor4.z = 3;
+    actor4.on('pointerdown', (e) => {
+      actualOrder.push('actor4');
+    });
+
+    engine.input.pointers.primary.addActorUnderPointer(actor1);
+    engine.input.pointers.primary.addActorUnderPointer(actor2);
+    engine.input.pointers.primary.addActorUnderPointer(actor3);
+    engine.input.pointers.primary.addActorUnderPointer(actor4);
+
+    executeMouseEvent('pointerdown', <any>document, null, 50, 50);
+
+    engine.input.pointers.dispatchPointerEvents();
+
+    expect(actualOrder).toEqual(['actor4', 'actor3', 'actor2', 'actor1']);
+  });
+
+  it('can have pointer event canceled', () => {
+    const actualOrder = [];
+
+    const actor1 = new ex.Actor({ x: 50, y: 50, width: 100, height: 100 });
+    actor1.z = 0;
+    actor1.on('pointerdown', (e) => {
+      actualOrder.push('actor1');
+    });
+    const actor2 = new ex.Actor({ x: 50, y: 50, width: 100, height: 100 });
+    actor2.z = 1;
+    actor2.on('pointerdown', (e) => {
+      actualOrder.push('actor2');
+    });
+    const actor3 = new ex.Actor({ x: 50, y: 50, width: 100, height: 100 });
+    actor3.z = 2;
+    actor3.on('pointerdown', (e) => {
+      actualOrder.push('actor3');
+      e.cancel();
+    });
+    const actor4 = new ex.Actor({ x: 50, y: 50, width: 100, height: 100 });
+    actor4.z = 3;
+    actor4.on('pointerdown', (e) => {
+      actualOrder.push('actor4');
+    });
+
+    engine.input.pointers.primary.addActorUnderPointer(actor1);
+    engine.input.pointers.primary.addActorUnderPointer(actor2);
+    engine.input.pointers.primary.addActorUnderPointer(actor3);
+    engine.input.pointers.primary.addActorUnderPointer(actor4);
+
+    executeMouseEvent('pointerdown', <any>document, null, 50, 50);
+
+    engine.input.pointers.dispatchPointerEvents();
+
+    expect(actualOrder).toEqual(['actor4', 'actor3']);
+  });
 });


### PR DESCRIPTION

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1922

## Changes:

- Sorts actors for pointer events in high->low z order (ties broken by ids)
