### PR TITLE
fix: #1439 engine level pointer events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed issue where pointer events propagate in an unexpected order, now they go from high z-index to low z-index ([#1922](https://github.com/excaliburjs/Excalibur/issues/1922)))
+- Fixed issue where pointer events were not firing at the ex.Engine.input.pointers level ([#1439](https://github.com/excaliburjs/Excalibur/issues/1439))
+- Fixed issue where pointer events propagate in an unexpected order, now they go from high z-index to low z-index ([#1922](https://github.com/excaliburjs/Excalibur/issues/1922))
 - Fixed issue with Raster padding which caused images to grow over time ([#1897](https://github.com/excaliburjs/Excalibur/issues/1897))
 - Fixed N+1 repeat/repeatForever bug ([#1891](https://github.com/excaliburjs/Excalibur/issues/1891))
 - Fixed repeat/repeatForever issue with `rotateTo` ([#635](https://github.com/excaliburjs/Excalibur/issues/635))

--- a/src/engine/Input/Pointers.ts
+++ b/src/engine/Input/Pointers.ts
@@ -402,6 +402,7 @@ export class Pointers extends Class {
 
         eventArr.push(pe);
         pointer.eventDispatcher.emit(eventName, pe);
+        this.emit(eventName, pe);
         // only with multi-pointer
         if (this._pointers.length > 1) {
           if (eventName === 'up') {
@@ -440,6 +441,7 @@ export class Pointers extends Class {
 
       eventArr.push(pe);
       pointer.eventDispatcher.emit(eventName, pe);
+      this.emit(eventName, pe);
 
       // only with multi-pointer
       if (this._pointers.length > 1) {
@@ -488,6 +490,7 @@ export class Pointers extends Class {
 
       eventArr.push(we);
       this.at(0).eventDispatcher.emit(eventName, we);
+      this.emit(eventName, we);
     };
   }
 

--- a/src/spec/PointerInputSpec.ts
+++ b/src/spec/PointerInputSpec.ts
@@ -215,4 +215,38 @@ describe('A pointer', () => {
 
     expect(actualOrder).toEqual(['actor4', 'actor3']);
   });
+
+  describe('at the engine level', () => {
+    it('should fire pointer up events', () => {
+      const upHandler = jasmine.createSpy('upHandler');
+      engine.input.pointers.on('up', upHandler);
+
+      executeMouseEvent('pointerup', <any>document, null, 50, 50);
+      expect(upHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fire pointer down events', () => {
+      const downHandler = jasmine.createSpy('downHandler');
+      engine.input.pointers.on('down', downHandler);
+
+      executeMouseEvent('pointerdown', <any>document, null, 50, 50);
+      expect(downHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fire pointer move events', () => {
+      const moveHandler = jasmine.createSpy('moveHandler');
+      engine.input.pointers.on('move', moveHandler);
+
+      executeMouseEvent('pointermove', <any>document, null, 50, 50);
+      expect(moveHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fire wheel events', () => {
+      const wheelHandler = jasmine.createSpy('wheelHandler');
+      engine.input.pointers.on('wheel', wheelHandler);
+
+      executeMouseEvent('wheel', <any>document, null, 50, 50);
+      expect(wheelHandler).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1439

## Changes:

- Emit event at engine pointers level
