### PR TITLE
fix: [#1863] Support width/height args for Sprites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where `GraphicsOptions` `width/height` could not be used to define a `Sprite` with equivalent `sourceView` and `destSize` ([#1863](https://github.com/excaliburjs/Excalibur/issues/1863))
 - Fixed issue where `Scene.onActivate/onDeactivate` were called with the wrong arguments ([#1850](https://github.com/excaliburjs/Excalibur/issues/1850))
 - Fixed issue where no width/height argmunents to engine throws an error
 - Fixed issue where zero dimension image draws on the ExcaliburGraphicsContext throw an error

--- a/src/engine/Graphics/Sprite.ts
+++ b/src/engine/Graphics/Sprite.ts
@@ -37,8 +37,9 @@ export class Sprite extends Graphic {
   constructor(options: GraphicOptions & SpriteOptions) {
     super(options);
     this.image = options.image;
-    this.sourceView = options.sourceView ?? { x: 0, y: 0, width: 0, height: 0 };
-    this.destSize = options.destSize ?? { width: 0, height: 0 };
+    const { width, height } = options;
+    this.sourceView = options.sourceView ?? { x: 0, y: 0, width: width ?? 0, height: height ?? 0 };
+    this.destSize = options.destSize ?? { width: width ?? 0, height: height ?? 0 };
     this._updateSpriteDimensions();
     this.image.ready.then(() => {
       this._updateSpriteDimensions();

--- a/src/spec/GraphicsSpriteSpec.ts
+++ b/src/spec/GraphicsSpriteSpec.ts
@@ -49,6 +49,34 @@ describe('A Sprite Graphic', () => {
     expect(clone.image).toEqual(sut.image);
   });
 
+  it('can specify a source/dest viewof an image with default width and height', async () => {
+    const image = new ex.Graphics.ImageSource('base/src/spec/images/GraphicsTextSpec/spritefont.png');
+    const sut = new ex.Graphics.Sprite({
+      image,
+      width: 16,
+      height: 16
+    });
+
+    expect(sut.width).withContext('Graphic width should be 16').toBe(16);
+    expect(sut.height).withContext('Graphic height should be 16').toBe(16);
+    expect(sut.sourceView.x).toBe(0);
+    expect(sut.sourceView.y).toBe(0);
+    expect(sut.sourceView.width).withContext('Graphic sourceView width should be 16').toBe(16);
+    expect(sut.sourceView.height).withContext('Graphic sourceView height should be 16').toBe(16);
+    expect(sut.destSize.width).withContext('Graphic destSize width should be 16').toBe(16);
+    expect(sut.destSize.height).withContext('Graphic destSize height should be 16').toBe(16);
+    expect(sut.localBounds.width).withContext('Graphic local bounds width should be 16').toBe(16);
+    expect(sut.localBounds.height).withContext('Graphic local bounds height should be 16').toBe(16);
+
+    await image.load();
+    await image.ready;
+
+    ctx.clear();
+    sut.draw(ctx, 50 - sut.width / 2, 50 - sut.width / 2);
+
+    await expectAsync(canvasElement).toEqualImage('src/spec/images/GraphicsSpriteSpec/source-view.png');
+  });
+
   it('can specify a source view of an image by default is same dimension as the source', async () => {
     const image = new ex.Graphics.ImageSource('base/src/spec/images/GraphicsTextSpec/spritefont.png');
     const sut = new ex.Graphics.Sprite({


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1863

## Changes:

- Support `GraphicsOptions` width and height
- Tests
