### PR TITLE
feat: [#1855] Add warning to ImageSource for partially supported images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `new ImageSource()` will now log a warning if an image type isn't fully supported. ([#1855](https://github.com/excaliburjs/Excalibur/issues/1855))
 - `Timer.start()` to explicitly start timers, and `Timer.stop()` to stop timers and "rewind" them.
 - `Timer.timeToNextAction` will return the milliseconds until the next action callback
 - `Timer.timeElapsedTowardNextAction` will return the milliseconds counted towards the next action callback

--- a/src/engine/Graphics/ImageSource.ts
+++ b/src/engine/Graphics/ImageSource.ts
@@ -2,8 +2,10 @@ import { Resource } from '../Resources/Resource';
 import { Texture } from '../Resources/Texture';
 import { Sprite } from './Sprite';
 import { Loadable } from '../Interfaces/Index';
+import { Logger } from '../Util/Log';
 
 export class ImageSource implements Loadable<HTMLImageElement> {
+  private _logger = Logger.getInstance();
   private _resource: Resource<Blob>;
 
   /**
@@ -48,6 +50,9 @@ export class ImageSource implements Loadable<HTMLImageElement> {
    */
   constructor(public readonly path: string, bustCache: boolean = false) {
     this._resource = new Resource(path, 'blob', bustCache);
+    if (path.endsWith('.svg') || path.endsWith('.gif')) {
+      this._logger.warn(`Image type is not fully supported, you may have mixed results ${path}. Fully supported: jpg, bmp, and png`);
+    }
     this.ready = new Promise<HTMLImageElement>((resolve) => {
       this._loadedResolve = resolve;
     });

--- a/src/spec/GraphicsImageSourceSpec.ts
+++ b/src/spec/GraphicsImageSourceSpec.ts
@@ -10,6 +10,15 @@ describe('A ImageSource', () => {
     expect(spriteFontImage).toBeDefined();
   });
 
+  it('logs a warning on image type not supported', () => {
+    const logger = ex.Logger.getInstance();
+    spyOn(logger, 'warn');
+    const image1 = new ex.Graphics.ImageSource('base/404/img.svg');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const image2 = new ex.Graphics.ImageSource('base/404/img.gif');
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
   it('can load images', async () => {
     const spriteFontImage = new ex.Graphics.ImageSource('base/src/spec/images/GraphicsTextSpec/spritefont.png');
     const whenLoaded = jasmine.createSpy('whenLoaded');


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #1855

## Changes:

- Add warning log for svg and gif
- Test
