### PR TITLE
Adding property to get screen center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- New property `center` to `Screen` to encapsulate screen center coordinates calculation considering zoom and device pixel ratio
 - New `ex.Shape.Capsule(width, height)` helper for defining capsule colliders, these are useful for ramps or jagged floor colliders.
 - New collision group constructor argument added to Actor`new Actor({collisionGroup: collisionGroup})`
 - `SpriteSheet.getSprite(x, y)` can retrieve a sprite from the SpriteSheet by x and y coordinate. For example, `getSprite(0, 0)` returns the top left sprite in the sheet.

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -1,4 +1,4 @@
-import { Vector } from './Math/vector';
+import { Vector, vec } from './Math/vector';
 import { Logger } from './Util/Log';
 import { Camera } from './Camera';
 import { BrowserEvents } from './Util/Browser';
@@ -608,6 +608,13 @@ export class Screen {
    */
   public get halfDrawHeight(): number {
     return this.drawHeight / 2;
+  }
+
+  /**
+   * Returns screen center coordinates including zoom and device pixel ratio.
+   */
+  public get center(): Vector {
+    return vec(this.halfDrawWidth, this.halfDrawHeight);
   }
 
   private _computeFit() {

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -1,10 +1,12 @@
 import * as ex from '@excalibur';
 import { ExcaliburMatchers } from 'excalibur-jasmine';
 import { Camera } from '@excalibur';
+
 describe('A Screen', () => {
   let canvas: HTMLCanvasElement;
   let context: ex.ExcaliburGraphicsContext;
   let browser: ex.BrowserEvents;
+
   beforeEach(() => {
     jasmine.addMatchers(ExcaliburMatchers);
     // It's important nothing else is hanging out in the dom
@@ -515,5 +517,65 @@ describe('A Screen', () => {
     expect(bounds.right).toBe(600);
     expect(bounds.bottom).toBe(450);
     expect(bounds.top).toBe(150);
+  });
+
+  it('can calculate screen center without a camera and no relevant pixel ratio', () => {
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      viewport: { width: 800, height: 600 }
+    });
+
+    expect(sut.center).toBeVector(ex.vec(400, 300));
+  });
+
+  it('can calculate screen center with a camera with zoom and no relevant pixel ratio', () => {
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      viewport: { width: 800, height: 600 }
+    });
+
+    const camera = new Camera();
+    camera.x = 400;
+    camera.y = 300;
+    camera.zoom = 2;
+
+    sut.setCurrentCamera(camera);
+
+    expect(sut.center).toBeVector(ex.vec(200, 150));
+  });
+
+  it('can calculate screen center without a camera and relevant pixel ratio', () => {
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      viewport: { width: 800, height: 600 },
+      pixelRatio: 2
+    });
+
+    expect(sut.center).toBeVector(ex.vec(400, 300));
+  });
+
+  it('can calculate screen center with a camera with zoom and relevant pixel ratio', () => {
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      viewport: { width: 800, height: 600 },
+      pixelRatio: 2
+    });
+
+    const camera = new Camera();
+    camera.x = 400;
+    camera.y = 300;
+    camera.zoom = 2;
+
+    sut.setCurrentCamera(camera);
+
+    expect(sut.center).toBeVector(ex.vec(200, 150));
   });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [X] :pushpin: issue exists in github for these changes
- [X] :microscope: existing tests still pass
- [X] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [X] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [X] :page_facing_up: changelog entry added (or not needed)

==================
There's something I noticed while writing tests and don't know if I'm missing something or not. The properties `drawWidth` and `drawHeight` use `scaledWidth` and `scaleHeight` internally, and then multiply that by `pixelRatio`. The thing is that `scaledWidth` and `scaleHeight` are defined by `resolution.width/pixelRatio` and `resolution.height/pixelRatio` respectively. Therefore, wouldn't this cause `pixelRatio` to be ignored? Or am I not addressing something? 

Closes #2045

## Changes:

- Added new property to class `Screen` that encapsulates screen center coordinates calculations.
