### PR TITLE
fix #2049: ImageSource loading error message

### DIFF
--- a/src/engine/Graphics/ImageSource.ts
+++ b/src/engine/Graphics/ImageSource.ts
@@ -82,8 +82,8 @@ export class ImageSource implements Loadable<HTMLImageElement> {
 
       // Set results
       this.data = image;
-    } catch {
-      await Promise.reject('Error loading texture');
+    } catch (error) {
+      throw `Error loading ImageSource from path '${this.path}' with error [${error.message}]`;
     }
     // todo emit complete
     this._loadedResolve(this.data);

--- a/src/engine/Resources/Resource.ts
+++ b/src/engine/Resources/Resource.ts
@@ -65,7 +65,7 @@ export class Resource<T> implements Loadable<T> {
         if (request.status !== 0 && request.status !== 200) {
           this.logger.error('Failed to load resource ', this.path, ' server responded with error code', request.status);
           this.events.emit('error', request.response);
-          reject(request.response);
+          reject(new Error(request.statusText));
           return;
         }
 

--- a/src/spec/GraphicsImageSourceSpec.ts
+++ b/src/spec/GraphicsImageSourceSpec.ts
@@ -88,4 +88,12 @@ describe('A ImageSource', () => {
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg=='
     );
   });
+
+  it('will return error if image doesn\'t exist', async () => {
+    const spriteFontImage = new ex.ImageSource('42.png');
+
+    await expectAsync(spriteFontImage.load()).toBeRejectedWith(
+      'Error loading ImageSource from path \'42.png\' with error [Not Found]'
+    );
+  });
 });


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #2049

## Changes:

- Improve ImageSource error with specific information
- Wrap the previous error [object](https://github.com/excaliburjs/Excalibur/blob/main/src/engine/Resources/Resource.ts#L68), with a generic `Error` to enhance error handling
- Provide a syntax more lightweight when dealing with [error propagation](https://github.com/excaliburjs/Excalibur/blob/main/src/engine/Graphics/ImageSource.ts#L86)
- Add new test case
