### PR TITLE
revert: VSCode Workbench Colors configurations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,22 +25,5 @@
   "typescript.tsdk": "./node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  },
-  "workbench.colorCustomizations": {
-    "activityBar.activeBackground": "#1d87d7",
-    "activityBar.activeBorder": "#f4abd4",
-    "activityBar.background": "#1d87d7",
-    "activityBar.foreground": "#e7e7e7",
-    "activityBar.inactiveForeground": "#e7e7e799",
-    "activityBarBadge.background": "#f4abd4",
-    "activityBarBadge.foreground": "#15202b",
-    "statusBar.background": "#176baa",
-    "statusBar.foreground": "#e7e7e7",
-    "statusBarItem.hoverBackground": "#1d87d7",
-    "titleBar.activeBackground": "#176baa",
-    "titleBar.activeForeground": "#e7e7e7",
-    "titleBar.inactiveBackground": "#176baa99",
-    "titleBar.inactiveForeground": "#e7e7e799"
-  },
-  "peacock.color": "#176BAA"
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Internal Actions implementation converted to ECS system and component, this is a backwards compatible change with v0.25.0
   - `ex.ActionsSystem` and `ex.ActionsComponent` now wrap the existing `ex.ActionContext`
   - Actions can be shared with all entities now!
+  - Revert VSCode Workbench Colors
 ### Deprecated
 
 - Actions `asPromise()` renamed to `toPromise()`


### PR DESCRIPTION
Hi, I reverted this configurations that was added on the commit (https://github.com/excaliburjs/Excalibur/commit/012b02cdd4a9c66fb9ea82eb7340268648decd11#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357)

this kind of configurations are super personal and in some cases (I use a dark theme) effect to the usability:

![image](https://user-images.githubusercontent.com/2272323/138547677-90d948ba-3910-4bba-94b7-96a1cc0895f7.png)
![image](https://user-images.githubusercontent.com/2272323/138547682-1dd0c900-5f1a-469d-b3cc-9d424cab250e.png)

this can be easily been ported to the settings.json.


===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [X] :microscope: existing tests still pass
- [X] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [X] :page_facing_up: changelog entry added (or not needed)

==================

## Changes:

- Revert VSCode Workbench Colors
