### PR TITLE
fix: [#2076] Defer initialization until after final resolution calculated

### DIFF
--- a/sandbox/tests/fitscreen/fitscreen.ts
+++ b/sandbox/tests/fitscreen/fitscreen.ts
@@ -1,0 +1,34 @@
+
+async function main() {
+    const game = new ex.Engine({
+        width: 2000,
+        height: 2000,
+        // suppressHiDPIScaling: true,
+        displayMode: ex.DisplayMode.FitScreen,
+    });
+
+    await game.start();
+
+    const paddle = new ex.Actor({
+        x: 220,
+        y: 220,
+        width: 400,
+        height: 400,
+        color: ex.Color.White,
+    });
+
+    console.log('Game:', game.drawWidth, '·', game.drawHeight);
+    console.log('Canv:', game.canvasWidth, '·', game.canvasHeight);
+    // console.log('Camera: ', game.currentScene.camera.pos);
+    // console.log('Center: ', game.screen.center);
+    // game.currentScene.camera.pos = game.screen.center;
+
+    game.add(paddle);
+    return [game, paddle];
+}
+
+main().then(([game, paddle]) => {
+    console.log('Promise from main()');
+    (window as any).game = game;
+    (window as any).paddle = paddle;
+});

--- a/sandbox/tests/fitscreen/fitscreen.ts
+++ b/sandbox/tests/fitscreen/fitscreen.ts
@@ -1,9 +1,9 @@
 
 async function main() {
     const game = new ex.Engine({
-        width: 6000,
-        height: 6000,
-        // suppressHiDPIScaling: true,
+        width: 3000,
+        height: 3000,
+        suppressHiDPIScaling: true,
         displayMode: ex.DisplayMode.FitScreen,
     });
 

--- a/sandbox/tests/fitscreen/fitscreen.ts
+++ b/sandbox/tests/fitscreen/fitscreen.ts
@@ -1,8 +1,8 @@
 
 async function main() {
     const game = new ex.Engine({
-        width: 2000,
-        height: 2000,
+        width: 6000,
+        height: 6000,
         // suppressHiDPIScaling: true,
         displayMode: ex.DisplayMode.FitScreen,
     });

--- a/sandbox/tests/fitscreen/index.html
+++ b/sandbox/tests/fitscreen/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>FitScreen</title>
+  <style>
+    body {
+        background: #000;
+        color: #F8F9FA;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        width: 100%;
+    }
+</style>
+</head>
+<body>
+  <script src="../../lib/excalibur.js"></script>
+  <script src="./fitscreen.js"></script>
+</body>
+</html>

--- a/sandbox/tests/gif/animatedGif.ts
+++ b/sandbox/tests/gif/animatedGif.ts
@@ -7,6 +7,8 @@ var game = new ex.Engine({
   height: 400
 });
 
+game.currentScene.camera.zoom = 2;
+
 var gif: ex.Gif = new ex.Gif('./sword.gif', ex.Color.Black);
 var loader = new ex.Loader([gif]);
 game.start(loader).then(() => {

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -586,12 +586,24 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
   public _initialize(_engine: Engine) {
     if (!this.isInitialized) {
       this._engine = _engine;
-      this._halfWidth = _engine.halfDrawWidth;
-      this._halfHeight = _engine.halfDrawHeight;
+
+      let center = vec(0, 0);
+      if (this._engine.loadingComplete) {
+        center = this._engine.screen.center;
+      } else {
+        // If there was a loading screen peek the resolution
+        const res = this._engine.screen.peekResolution();
+        if (res) {
+          center = vec(res.width / 2, res.height / 2);
+        } else {
+          center = this._engine.screen.center;
+        }
+      }
+      this._halfWidth = center.x;
+      this._halfHeight = center.x;
       // pos unset apply default position is center screen
       if (!this._posChanged) {
-        this.pos.x = _engine.halfDrawWidth;
-        this.pos.y = _engine.halfDrawHeight;
+        this.pos = center;
       }
 
       this.onInitialize(_engine);

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -587,21 +587,19 @@ export class Camera extends Class implements CanUpdate, CanInitialize {
     if (!this.isInitialized) {
       this._engine = _engine;
 
-      let center = vec(0, 0);
-      if (this._engine.loadingComplete) {
-        center = this._engine.screen.center;
-      } else {
-        // If there was a loading screen peek the resolution
+      const currentRes = this._engine.screen.resolution;
+      let center = vec(currentRes.width / 2, currentRes.height / 2);
+      if (!this._engine.loadingComplete) {
+        // If there was a loading screen, we peek the configured resolution
         const res = this._engine.screen.peekResolution();
         if (res) {
           center = vec(res.width / 2, res.height / 2);
-        } else {
-          center = this._engine.screen.center;
         }
       }
       this._halfWidth = center.x;
       this._halfHeight = center.x;
-      // pos unset apply default position is center screen
+
+      // If the user has not set the camera pos, apply default center screen position
       if (!this._posChanged) {
         this.pos = center;
       }

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -607,8 +607,6 @@ O|===|* >________________>\n\
       pixelRatio: options.suppressHiDPIScaling ? 1 : null
     });
 
-    this.screen.applyResolutionAndViewport();
-
     if (options.backgroundColor) {
       this.backgroundColor = options.backgroundColor.clone();
     }
@@ -1148,11 +1146,13 @@ O|===|* >________________>\n\
     if (!this._compatible) {
       return Promise.reject('Excalibur is incompatible with your browser');
     }
+    let loadingComplete: Promise<void>;
+    // Push the current user entered resolution/viewport
     this.screen.pushResolutionAndViewport();
+    // Configure resolution for loader
     this.screen.resolution = this.screen.viewport;
     this.screen.applyResolutionAndViewport();
     this.graphicsContext.updateViewport();
-    let loadingComplete: Promise<void>;
     if (loader) {
       this._loader = loader;
       this._loader.suppressPlayButton = this._suppressPlayButton || this._loader.suppressPlayButton;

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -609,16 +609,6 @@ O|===|* >________________>\n\
 
     this.screen.applyResolutionAndViewport();
 
-    if (this.graphicsContext instanceof ExcaliburGraphicsContextWebGL) {
-      const supported = this.graphicsContext.checkIfResolutionSupported({ width: this.screen.scaledWidth, height: this.screen.scaledHeight });
-      if (!supported) {
-        this._logger.warn(
-          `The currently configured resolution (${this.screen.resolution.width}x${this.screen.resolution.height})` +
-          ' is too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly' +
-          ' Try reducing the resolution or disabling Hi DPI scaling to avoid this (read more here https://excaliburjs.com/docs/screens#understanding-viewport--resolution).')
-      }
-    }
-
     if (options.backgroundColor) {
       this.backgroundColor = options.backgroundColor.clone();
     }
@@ -1006,29 +996,27 @@ O|===|* >________________>\n\
       return;
     }
 
-    // if (this._loadingComplete) {
-      this._overrideInitialize(this);
+    this._overrideInitialize(this);
 
-      // Publish preupdate events
-      this._preupdate(delta);
+    // Publish preupdate events
+    this._preupdate(delta);
 
-      // process engine level events
-      this.currentScene.update(this, delta);
+    // process engine level events
+    this.currentScene.update(this, delta);
 
-      // update animations
-      // TODO remove
-      this._animations = this._animations.filter(function (a) {
-        return !a.animation.isDone();
-      });
+    // update animations
+    // TODO remove
+    this._animations = this._animations.filter(function (a) {
+      return !a.animation.isDone();
+    });
 
-      // Update input listeners
-      this.input.keyboard.update();
-      this.input.pointers.update();
-      this.input.gamepads.update();
+    // Update input listeners
+    this.input.keyboard.update();
+    this.input.pointers.update();
+    this.input.gamepads.update();
 
-      // Publish update event
-      this._postupdate(delta);
-    // }
+    // Publish update event
+    this._postupdate(delta);
   }
 
   /**
@@ -1070,39 +1058,37 @@ O|===|* >________________>\n\
       return;
     }
 
-    // if (this._loadingComplete) {
-      // TODO move to graphics systems?
-      this.graphicsContext.backgroundColor = this.backgroundColor;
-  
-      this.currentScene.draw(this.ctx, delta);
-  
-      // todo needs to be a better way of doing this
-      let a = 0;
-      const len = this._animations.length;
-      for (a; a < len; a++) {
-        this._animations[a].animation.draw(ctx, this._animations[a].x, this._animations[a].y);
+    // TODO move to graphics systems?
+    this.graphicsContext.backgroundColor = this.backgroundColor;
+
+    this.currentScene.draw(this.ctx, delta);
+
+    // todo needs to be a better way of doing this
+    let a = 0;
+    const len = this._animations.length;
+    for (a; a < len; a++) {
+      this._animations[a].animation.draw(ctx, this._animations[a].x, this._animations[a].y);
+    }
+
+    // Draw debug information
+    // TODO don't access ctx directly
+    if (this.isDebug) {
+      this.ctx.font = 'Consolas';
+      this.ctx.fillStyle = this.debugColor.toString();
+      const keys = this.input.keyboard.getKeys();
+      for (let j = 0; j < keys.length; j++) {
+        this.ctx.fillText(keys[j].toString() + ' : ' + (Input.Keys[keys[j]] ? Input.Keys[keys[j]] : 'Not Mapped'), 100, 10 * j + 10);
       }
-  
-      // Draw debug information
-      // TODO don't access ctx directly
-      if (this.isDebug) {
-        this.ctx.font = 'Consolas';
-        this.ctx.fillStyle = this.debugColor.toString();
-        const keys = this.input.keyboard.getKeys();
-        for (let j = 0; j < keys.length; j++) {
-          this.ctx.fillText(keys[j].toString() + ' : ' + (Input.Keys[keys[j]] ? Input.Keys[keys[j]] : 'Not Mapped'), 100, 10 * j + 10);
-        }
-  
-        this.ctx.fillText('FPS:' + this.stats.currFrame.fps.toFixed(2).toString(), 10, 10);
-      }
-  
-      // Post processing
-      for (let i = 0; i < this.postProcessors.length; i++) {
-        this.postProcessors[i].process(this.ctx.getImageData(0, 0, this.canvasWidth, this.canvasHeight), this.ctx);
-      }
-  
-      this._postdraw(ctx, delta);
-    // }
+
+      this.ctx.fillText('FPS:' + this.stats.currFrame.fps.toFixed(2).toString(), 10, 10);
+    }
+
+    // Post processing
+    for (let i = 0; i < this.postProcessors.length; i++) {
+      this.postProcessors[i].process(this.ctx.getImageData(0, 0, this.canvasWidth, this.canvasHeight), this.ctx);
+    }
+
+    this._postdraw(ctx, delta);
   }
 
   /**

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -609,6 +609,16 @@ O|===|* >________________>\n\
 
     this.screen.applyResolutionAndViewport();
 
+    if (this.graphicsContext instanceof ExcaliburGraphicsContextWebGL) {
+      const supported = this.graphicsContext.checkIfResolutionSupported({ width: this.screen.scaledWidth, height: this.screen.scaledHeight });
+      if (!supported) {
+        this._logger.warn(
+          `The currently configured resolution (${this.screen.resolution.width}x${this.screen.resolution.height})` +
+          ' is too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly' +
+          ' Try reducing the resolution or disabling Hi DPI scaling to avoid this (read more here https://excaliburjs.com/docs/screens#understanding-viewport--resolution).')
+      }
+    }
+
     if (options.backgroundColor) {
       this.backgroundColor = options.backgroundColor.clone();
     }
@@ -996,7 +1006,7 @@ O|===|* >________________>\n\
       return;
     }
 
-    if (this._loadingComplete) {
+    // if (this._loadingComplete) {
       this._overrideInitialize(this);
 
       // Publish preupdate events
@@ -1018,7 +1028,7 @@ O|===|* >________________>\n\
 
       // Publish update event
       this._postupdate(delta);
-    }
+    // }
   }
 
   /**
@@ -1060,7 +1070,7 @@ O|===|* >________________>\n\
       return;
     }
 
-    if (this._loadingComplete) {
+    // if (this._loadingComplete) {
       // TODO move to graphics systems?
       this.graphicsContext.backgroundColor = this.backgroundColor;
   
@@ -1092,7 +1102,7 @@ O|===|* >________________>\n\
       }
   
       this._postdraw(ctx, delta);
-    }
+    // }
   }
 
   /**
@@ -1137,6 +1147,12 @@ O|===|* >________________>\n\
 
   private _loadingComplete: boolean = false;
   /**
+   * Returns true when loading is totally complete and the player has clicked start
+   */
+  public get loadingComplete() {
+    return this._loadingComplete;
+  }
+  /**
    * Starts the internal game loop for Excalibur after loading
    * any provided assets.
    * @param loader  Optional [[Loader]] to use to load resources. The default loader is [[Loader]], override to provide your own
@@ -1169,6 +1185,7 @@ O|===|* >________________>\n\
     });
 
     if (!this._hasStarted) {
+      // has started is a slight misnomer, it's really mainloop started
       this._hasStarted = true;
       this._logger.debug('Starting game...');
       this.browser.resume();

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -996,7 +996,7 @@ O|===|* >________________>\n\
       return;
     }
 
-    if (this._gameStart) {
+    if (this._loadingComplete) {
       this._overrideInitialize(this);
 
       // Publish preupdate events
@@ -1060,7 +1060,7 @@ O|===|* >________________>\n\
       return;
     }
 
-    if (this._gameStart) {
+    if (this._loadingComplete) {
       // TODO move to graphics systems?
       this.graphicsContext.backgroundColor = this.backgroundColor;
   
@@ -1135,7 +1135,7 @@ O|===|* >________________>\n\
     return this._isDebug;
   }
 
-  private _gameStart: boolean = false;
+  private _loadingComplete: boolean = false;
   /**
    * Starts the internal game loop for Excalibur after loading
    * any provided assets.
@@ -1165,7 +1165,7 @@ O|===|* >________________>\n\
       this.screen.applyResolutionAndViewport();
       this.graphicsContext.updateViewport();
       this.emit('start', new GameStartEvent(this));
-      this._gameStart = true;
+      this._loadingComplete = true;
     });
 
     if (!this._hasStarted) {

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContext.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContext.ts
@@ -89,7 +89,7 @@ export interface ExcaliburGraphicsContext {
   resetTransform(): void;
 
   /**
-   * Update the context with the curren tviewport dimensions (used in resizing)
+   * Update the context with the current viewport dimensions (used in resizing)
    */
   updateViewport(): void;
 

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
@@ -167,8 +167,6 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
     // Setup viewport and view matrix
     this._ortho = Matrix.ortho(0, gl.canvas.width, gl.canvas.height, 0, 400, -400);
     gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
-    
-    //console.log(`Draw Buffer (${gl.drawingBufferWidth} x ${gl.drawingBufferHeight})`);
 
     // Clear background
     gl.clearColor(this.backgroundColor.r / 255, this.backgroundColor.g / 255, this.backgroundColor.b / 255, this.backgroundColor.a);

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
@@ -150,6 +150,8 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
     // Setup viewport and view matrix
     this._ortho = Matrix.ortho(0, gl.canvas.width, gl.canvas.height, 0, 400, -400);
     gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
+    
+    //console.log(`Draw Buffer (${gl.drawingBufferWidth} x ${gl.drawingBufferHeight})`);
 
     // Clear background
     gl.clearColor(this.backgroundColor.r / 255, this.backgroundColor.g / 255, this.backgroundColor.b / 255, this.backgroundColor.a);

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
@@ -136,14 +136,14 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
    * @param dim
    */
   public checkIfResolutionSupported(dim: ScreenDimension): boolean {
+    // Slight hack based on this thread https://groups.google.com/g/webgl-dev-list/c/AHONvz3oQTo
     const gl = this.__gl;
-    const oldViewport = { width: this.__gl.canvas.width, height: this.__gl.canvas.height };
+    // If any dimension is greater than max texture size (divide by 4 bytes per pixel)
+    const maxDim = gl.getParameter(gl.MAX_TEXTURE_SIZE) / 4;
     let supported = true;
-    gl.viewport(0, 0, dim.width, dim.height);
-    if (gl.drawingBufferWidth !== dim.width || gl.drawingBufferHeight !== dim.height) {
+    if (dim.width > maxDim ||dim.height > maxDim) {
       supported = false;
     }
-    gl.viewport(0, 0, oldViewport.width, oldViewport.height);
     return supported;
   }
 

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
@@ -20,6 +20,7 @@ import { PointRenderer } from './point-renderer';
 import { Canvas } from '../Canvas';
 import { GraphicsDiagnostics } from '../GraphicsDiagnostics';
 import { DebugText } from './debug-text';
+import { ScreenDimension } from '../../Screen';
 
 class ExcaliburGraphicsContextWebGLDebug implements DebugDraw {
   private _debugText = new DebugText();
@@ -128,6 +129,22 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
 
   public get height() {
     return this.__gl.canvas.height;
+  }
+
+  /**
+   * Checks the underlying webgl implementation if the requested internal resolution is supported
+   * @param dim
+   */
+  public checkIfResolutionSupported(dim: ScreenDimension): boolean {
+    const gl = this.__gl;
+    const oldViewport = { width: this.__gl.canvas.width, height: this.__gl.canvas.height };
+    let supported = true;
+    gl.viewport(0, 0, dim.width, dim.height);
+    if (gl.drawingBufferWidth !== dim.width || gl.drawingBufferHeight !== dim.height) {
+      supported = false;
+    }
+    gl.viewport(0, 0, oldViewport.width, oldViewport.height);
+    return supported;
   }
 
   constructor(options: ExcaliburGraphicsContextOptions) {

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -217,6 +217,7 @@ export class Screen {
     this._mediaQueryList.addEventListener('change', this._pixelRatioChangeHandler);
 
     this._canvas.addEventListener('fullscreenchange', this._fullscreenChangeHandler);
+    this.applyResolutionAndViewport();
   }
 
   public dispose(): void {
@@ -298,19 +299,6 @@ export class Screen {
 
   public set resolution(resolution: ScreenDimension) {
     this._resolution = resolution;
-    if (this._ctx instanceof ExcaliburGraphicsContextWebGL) {
-      const supported = this._ctx.checkIfResolutionSupported({
-        width: this.scaledWidth,
-        height: this.scaledHeight
-      });
-      if (!supported) {
-        this._logger.warn(
-          `The currently configured resolution (${this.resolution.width}x${this.resolution.height})` +
-          ' is too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly.' +
-          ' Try reducing the resolution or disabling Hi DPI scaling to avoid this' +
-          ' (read more here https://excaliburjs.com/docs/screens#understanding-viewport--resolution).');
-      }
-    }
   }
 
   public get viewport(): ScreenDimension {
@@ -364,6 +352,20 @@ export class Screen {
   public applyResolutionAndViewport() {
     this._canvas.width = this.scaledWidth;
     this._canvas.height = this.scaledHeight;
+
+    if (this._ctx instanceof ExcaliburGraphicsContextWebGL) {
+      const supported = this._ctx.checkIfResolutionSupported({
+        width: this.scaledWidth,
+        height: this.scaledHeight
+      });
+      if (!supported) {
+        this._logger.warn(
+          `The currently configured resolution (${this.resolution.width}x${this.resolution.height})` +
+          ' is too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly.' +
+          ' Try reducing the resolution or disabling Hi DPI scaling to avoid this' +
+          ' (read more here https://excaliburjs.com/docs/screens#understanding-viewport--resolution).');
+      }
+    }
 
     if (this._antialiasing) {
       this._canvas.style.imageRendering = 'auto';
@@ -603,9 +605,9 @@ export class Screen {
    */
   public get drawWidth(): number {
     if (this._camera) {
-      return this.scaledWidth / this._camera.zoom / this.pixelRatio;
+      return this.resolution.width / this._camera.zoom;
     }
-    return this.scaledWidth / this.pixelRatio;
+    return this.resolution.width;
   }
 
   /**
@@ -620,9 +622,9 @@ export class Screen {
    */
   public get drawHeight(): number {
     if (this._camera) {
-      return this.scaledHeight / this._camera.zoom / this.pixelRatio;
+      return this.resolution.height / this._camera.zoom;
     }
-    return this.scaledHeight / this.pixelRatio;
+    return this.resolution.height;
   }
 
   /**

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -349,6 +349,7 @@ export class Screen {
     this.viewport = this._viewportStack.pop();
   }
 
+  private _alreadyWarned = false;
   public applyResolutionAndViewport() {
     this._canvas.width = this.scaledWidth;
     this._canvas.height = this.scaledHeight;
@@ -358,7 +359,8 @@ export class Screen {
         width: this.scaledWidth,
         height: this.scaledHeight
       });
-      if (!supported) {
+      if (!supported && !this._alreadyWarned) {
+        this._alreadyWarned = true; // warn once
         this._logger.warn(
           `The currently configured resolution (${this.resolution.width}x${this.resolution.height})` +
           ' is too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly.' +

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -5,6 +5,7 @@ import { BrowserEvents } from './Util/Browser';
 import { BoundingBox } from './Collision/Index';
 import { ExcaliburGraphicsContext } from './Graphics/Context/ExcaliburGraphicsContext';
 import { getPosition } from './Util/Util';
+import { ExcaliburGraphicsContextWebGL } from './Graphics/Context/ExcaliburGraphicsContextWebGL';
 
 /**
  * Enum representing the different display modes available to Excalibur.
@@ -297,6 +298,19 @@ export class Screen {
 
   public set resolution(resolution: ScreenDimension) {
     this._resolution = resolution;
+    if (this._ctx instanceof ExcaliburGraphicsContextWebGL) {
+      const supported = this._ctx.checkIfResolutionSupported({
+        width: this.scaledWidth,
+        height: this.scaledHeight
+      });
+      if (!supported) {
+        this._logger.warn(
+          `The currently configured resolution (${this.resolution.width}x${this.resolution.height})` +
+          ' is too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly.' +
+          ' Try reducing the resolution or disabling Hi DPI scaling to avoid this' +
+          ' (read more here https://excaliburjs.com/docs/screens#understanding-viewport--resolution).');
+      }
+    }
   }
 
   public get viewport(): ScreenDimension {

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -334,6 +334,14 @@ export class Screen {
     this.viewport = { ...this.viewport };
   }
 
+  public peekViewport(): ScreenDimension {
+    return this._viewportStack[this._viewportStack.length - 1];
+  }
+
+  public peekResolution(): ScreenDimension {
+    return this._resolutionStack[this._resolutionStack.length - 1];
+  }
+
   public popResolutionAndViewport() {
     this.resolution = this._resolutionStack.pop();
     this.viewport = this._viewportStack.pop();

--- a/src/spec/CameraSpec.ts
+++ b/src/spec/CameraSpec.ts
@@ -39,6 +39,40 @@ describe('A camera', () => {
     engine.stop();
   });
 
+  it('should be center screen by default (when loading not complete)', () => {
+    engine = TestUtils.engine({
+      viewport: {width: 100, height: 100},
+      resolution: {width: 1000, height: 1200 }
+    });
+    engine.screen.pushResolutionAndViewport();
+    engine.screen.resolution = {width: 100, height: 1000};
+    spyOnProperty(engine, 'loadingComplete', 'get').and.returnValue(false);
+    spyOn(engine.screen, 'peekResolution').and.callThrough();
+
+    const sut = new ex.Camera();
+    sut.zoom = 2; // zoom should not change the center position
+    sut._initialize(engine);
+
+    expect(sut.pos).toBeVector(ex.vec(500, 600));
+    expect(engine.screen.peekResolution).toHaveBeenCalled();
+  });
+
+  it('should be center screen by default (when loading complete)', () => {
+    engine = TestUtils.engine({
+      viewport: {width: 100, height: 100},
+      resolution: {width: 1000, height: 1200 }
+    });
+
+    spyOnProperty(engine, 'loadingComplete', 'get').and.returnValue(true);
+    spyOn(engine.screen, 'peekResolution').and.callThrough();
+    const sut = new ex.Camera();
+    sut.zoom = 2; // zoom should not change the center position
+    sut._initialize(engine);
+
+    expect(sut.pos).toBeVector(ex.vec(500, 600));
+    expect(engine.screen.peekResolution).not.toHaveBeenCalled();
+  });
+
   it('can focus on a point', () => {
     // set the focus with positional attributes
     Camera.x = 10;

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -578,4 +578,39 @@ describe('A Screen', () => {
 
     expect(sut.center).toBeVector(ex.vec(200, 150));
   });
+
+  it('will warn if the resolution is too large', () => {
+    const logger = ex.Logger.getInstance();
+    spyOn(logger, 'warn');
+
+    const canvasElement = document.createElement('canvas');
+    canvasElement.width = 100;
+    canvasElement.height = 100;
+
+    const context = new ex.ExcaliburGraphicsContextWebGL({
+      canvasElement: canvasElement,
+      enableTransparency: false,
+      snapToPixel: true,
+      backgroundColor: ex.Color.White
+    });
+
+    spyOn(context, 'checkIfResolutionSupported').and.returnValue(false);
+
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      viewport: { width: 800, height: 600 },
+      pixelRatio: 2
+    });
+
+    sut.resolution = { width: 3000, height: 3000 };
+    expect(context.checkIfResolutionSupported).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      `The currently configured resolution (${sut.resolution.width}x${sut.resolution.height})` +
+          ' is too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly.' +
+          ' Try reducing the resolution or disabling Hi DPI scaling to avoid this' +
+          ' (read more here https://excaliburjs.com/docs/screens#understanding-viewport--resolution).'
+    );
+  });
 });

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -605,6 +605,7 @@ describe('A Screen', () => {
     });
 
     sut.resolution = { width: 3000, height: 3000 };
+    sut.applyResolutionAndViewport();
     expect(context.checkIfResolutionSupported).toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
       `The currently configured resolution (${sut.resolution.width}x${sut.resolution.height})` +

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -606,7 +606,7 @@ describe('A Screen', () => {
     sut.resolution = { width: 3000, height: 3000 };
     sut.applyResolutionAndViewport();
     expect(context.checkIfResolutionSupported).toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledOnceWith(
       `The currently configured resolution (${sut.resolution.width}x${sut.resolution.height})` +
           ' is too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly.' +
           ' Try reducing the resolution or disabling Hi DPI scaling to avoid this' +

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -594,8 +594,6 @@ describe('A Screen', () => {
       backgroundColor: ex.Color.White
     });
 
-    spyOn(context, 'checkIfResolutionSupported').and.returnValue(false);
-
     const sut = new ex.Screen({
       canvas,
       context,
@@ -604,6 +602,7 @@ describe('A Screen', () => {
       pixelRatio: 2
     });
 
+    spyOn(context, 'checkIfResolutionSupported').and.returnValue(false);
     sut.resolution = { width: 3000, height: 3000 };
     sut.applyResolutionAndViewport();
     expect(context.checkIfResolutionSupported).toHaveBeenCalled();


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

TODO:
* [x] WebGL will silently fail at high resolutions which is easy to get to with hidpi scaling
* [x] Warn when l.drawingBufferHeight/l.drawingBufferWidth don't match height/width
* [x] Documentation improvement for original issue for different displaymodes
* [x] Fix tests

Closes #2076

## Changes:

- Deferred initialization of scene/camera until final resolution is calculated
