### PR TITLE
Refactor: Remove .call() in EventDispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
--
+- EventDispatcher
+  - `EventDispatcher` - doesn't require the target object. The context of `this` is not tampered anymore.
+- Pointers
+  - `PointerAbstraction` - is fixed to maintain reference
 
 ### Updates
 
--
+- The following Engine's pieces: `Collision` `Graphics` `Resources` `Trigger` are updated to reflect the new EventDispatcher behavior.
 
 ### Changed
 

--- a/src/engine/Class.ts
+++ b/src/engine/Class.ts
@@ -12,7 +12,7 @@ export class Class implements Eventable {
   public eventDispatcher: EventDispatcher;
 
   constructor() {
-    this.eventDispatcher = new EventDispatcher(this);
+    this.eventDispatcher = new EventDispatcher();
   }
 
   /**

--- a/src/engine/Collision/BodyComponent.ts
+++ b/src/engine/Collision/BodyComponent.ts
@@ -32,7 +32,7 @@ export class BodyComponent extends Component<'ex.body'> implements Clonable<Body
   public dependencies = [TransformComponent, MotionComponent];
   public static _ID = 0;
   public readonly id: Id<'body'> = createId('body', BodyComponent._ID++);
-  public events = new EventDispatcher(this);
+  public events = new EventDispatcher();
 
   constructor(options?: BodyComponentOptions) {
     super();

--- a/src/engine/Collision/ColliderComponent.ts
+++ b/src/engine/Collision/ColliderComponent.ts
@@ -17,7 +17,7 @@ import { Shape } from './Colliders/Shape';
 export class ColliderComponent extends Component<'ex.collider'> {
   public readonly type = 'ex.collider';
 
-  public events = new EventDispatcher(this);
+  public events = new EventDispatcher();
   /**
    * Observable that notifies when a collider is added to the body
    */

--- a/src/engine/Collision/Colliders/Collider.ts
+++ b/src/engine/Collision/Colliders/Collider.ts
@@ -18,7 +18,7 @@ import { ExcaliburGraphicsContext } from '../../Graphics/Context/ExcaliburGraphi
 export abstract class Collider implements Clonable<Collider> {
   private static _ID = 0;
   public readonly id: Id<'collider'> = createId('collider', Collider._ID++);
-  public events: EventDispatcher<Collider> = new EventDispatcher<Collider>(this);
+  public events: EventDispatcher<Collider> = new EventDispatcher<Collider>();
 
   /**
    * Returns a boolean indicating whether this body collided with

--- a/src/engine/EventDispatcher.ts
+++ b/src/engine/EventDispatcher.ts
@@ -5,15 +5,6 @@ export class EventDispatcher<T = any> implements Eventable {
   private _handlers: { [key: string]: { (event: GameEvent<T>): void }[] } = {};
   private _wiredEventDispatchers: Eventable[] = [];
 
-  private _target: T;
-
-  /**
-   * @param target  The object that will be the recipient of events from this event dispatcher
-   */
-  constructor(target: T) {
-    this._target = target;
-  }
-
   /**
    * Clears any existing handlers or wired event dispatchers on this event dispatcher
    */
@@ -33,16 +24,8 @@ export class EventDispatcher<T = any> implements Eventable {
       return;
     }
     eventName = eventName.toLowerCase();
-    const target = this._target;
     if (!event) {
       event = new GameEvent();
-    }
-    try {
-      if (!event.target) {
-        event.target = target;
-      }
-    } catch {
-      // pass
     }
     let i: number, len: number;
 
@@ -51,7 +34,7 @@ export class EventDispatcher<T = any> implements Eventable {
       len = this._handlers[eventName].length;
 
       for (i; i < len; i++) {
-        this._handlers[eventName][i].call(target, event);
+        this._handlers[eventName][i](event);
       }
     }
 
@@ -117,14 +100,8 @@ export class EventDispatcher<T = any> implements Eventable {
   public once(eventName: string, handler: (event: GameEvent<T>) => void) {
     const metaHandler = (event: GameEvent<T>) => {
       const ev = event || new GameEvent();
-      try {
-        ev.target = ev.target || this._target;
-      } catch {
-        // pass
-      }
-
       this.off(eventName, handler);
-      handler.call(ev.target, ev);
+      handler(ev);
     };
 
     this.on(eventName, metaHandler);

--- a/src/engine/Graphics/Animation.ts
+++ b/src/engine/Graphics/Animation.ts
@@ -100,7 +100,7 @@ export type AnimationEvents = {
  */
 export class Animation extends Graphic implements HasTick {
   private static _LOGGER = Logger.getInstance();
-  public events = new EventDispatcher<any>(this); // TODO replace with new Emitter
+  public events = new EventDispatcher<any>(); // TODO replace with new Emitter
   public frames: Frame[] = [];
   public strategy: AnimationStrategy = AnimationStrategy.Loop;
   public frameDuration: number = 100;

--- a/src/engine/Input/PointerAbstraction.ts
+++ b/src/engine/Input/PointerAbstraction.ts
@@ -50,14 +50,13 @@ export class PointerAbstraction extends Class {
     super.off(event, handler);
   }
 
-
-  private _onPointerMove(ev: PointerEvent): void {
+  private _onPointerMove = (ev: PointerEvent): void => {
     this.lastPagePos = new Vector(ev.pagePos.x, ev.pagePos.y);
     this.lastScreenPos = new Vector(ev.screenPos.x, ev.screenPos.y);
     this.lastWorldPos = new Vector(ev.worldPos.x, ev.worldPos.y);
   }
 
-  private _onPointerDown(ev: PointerEvent): void {
+  private _onPointerDown = (ev: PointerEvent): void => {
     this.lastPagePos = new Vector(ev.pagePos.x, ev.pagePos.y);
     this.lastScreenPos = new Vector(ev.screenPos.x, ev.screenPos.y);
     this.lastWorldPos = new Vector(ev.worldPos.x, ev.worldPos.y);

--- a/src/engine/Resources/Resource.ts
+++ b/src/engine/Resources/Resource.ts
@@ -9,7 +9,7 @@ import { EventDispatcher } from '../EventDispatcher';
 export class Resource<T> implements Loadable<T> {
   public data: T = null;
   public logger: Logger = Logger.getInstance();
-  public events: EventDispatcher = new EventDispatcher(this);
+  public events: EventDispatcher = new EventDispatcher();
 
   /**
    * @param path          Path to the remote resource

--- a/src/engine/Trigger.ts
+++ b/src/engine/Trigger.ts
@@ -82,7 +82,7 @@ export class Trigger extends Actor {
 
     this.graphics.visible = opts.visible;
     this.body.collisionType = CollisionType.Passive;
-    this.eventDispatcher = new EventDispatcher(this);
+    this.eventDispatcher = new EventDispatcher();
 
     this.events.on('collisionstart', (evt: CollisionStartEvent<Actor>) => {
       if (this.filter(evt.other)) {

--- a/src/spec/CollisionSpec.ts
+++ b/src/spec/CollisionSpec.ts
@@ -337,8 +337,8 @@ describe('A Collision', () => {
     passiveBlock.vel.x = -100;
     engine.add(passiveBlock);
 
-    const collisionEnd = function () {
-      expect(this).toBe(activeBlock);
+    const collisionEnd = function (event: ex.GameEvent<unknown>) {
+      expect(event.target).toBe(activeBlock);
       done();
     };
 
@@ -362,8 +362,8 @@ describe('A Collision', () => {
     passiveBlock.vel.x = -100;
     engine.add(passiveBlock);
 
-    const collisionEnd = function () {
-      expect(this).toBe(activeBlock);
+    const collisionEnd = function (event: ex.GameEvent<unknown>) {
+      expect(event.target).toBe(activeBlock);
       done();
     };
 

--- a/src/spec/EventSpec.ts
+++ b/src/spec/EventSpec.ts
@@ -3,7 +3,7 @@ import * as ex from '@excalibur';
 describe('An Event Dispatcher', () => {
   let pubsub: ex.EventDispatcher;
   beforeEach(() => {
-    pubsub = new ex.EventDispatcher(null);
+    pubsub = new ex.EventDispatcher();
   });
 
   it('exists', () => {
@@ -23,16 +23,16 @@ describe('An Event Dispatcher', () => {
     expect(eventFired).toBeTruthy();
   });
 
-  it('can published against a target', () => {
+  it('cannot published against a target', () => {
     let targetContext = null;
     const target = new ex.Actor();
 
-    pubsub = new ex.EventDispatcher(target);
+    pubsub = new ex.EventDispatcher();
     pubsub.on('event', function() {
       targetContext = this;
     });
     pubsub.emit('event', null);
-    expect(target).toBe(targetContext);
+    expect(target).not.toBe(targetContext);
   });
 
   it('has an emit alias for publish', () => {
@@ -67,7 +67,7 @@ describe('An Event Dispatcher', () => {
   });
 
   it('can wire to other event dispatchers', () => {
-    const newPubSub = new ex.EventDispatcher(null);
+    const newPubSub = new ex.EventDispatcher();
     pubsub.wire(newPubSub);
 
     let eventFired = false;
@@ -80,7 +80,7 @@ describe('An Event Dispatcher', () => {
   });
 
   it('can unwire from other event dispatchers', () => {
-    const newPubSub = new ex.EventDispatcher(null);
+    const newPubSub = new ex.EventDispatcher();
     pubsub.wire(newPubSub);
 
     let eventFired = false;
@@ -103,7 +103,7 @@ describe('An Event Dispatcher', () => {
   });
 
   it('can listen to a handler only once', () => {
-    const pubsub = new ex.EventDispatcher(null);
+    const pubsub = new ex.EventDispatcher();
 
     let callCount = 0;
     pubsub.once('onlyonce', () => {


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2047

## Changes:

- `EventDispatcher` - doesn't require the target object. The context of `this` is not tampered anymore.
- `PointerAbstraction` - is fixed to maintain reference
- The following Engine's pieces: `Collision` `Graphics` `Resources` `Trigger` are updated to accomodate the new EventDispatcher behavior.
