### PR TITLE
fix: Arcade Solver Jitter on stacked/overlapped tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
--
+- Fixed issue with `ArcadeSolver` where stacked/overlapped tiles would double solve the position of the collider for the same overlap
 
 ### Updates
 

--- a/src/engine/Collision/Solver/ArcadeSolver.ts
+++ b/src/engine/Collision/Solver/ArcadeSolver.ts
@@ -50,6 +50,11 @@ export class ArcadeSolver extends CollisionSolver {
 
   public solvePosition(contacts: CollisionContact[]) {
     for (const contact of contacts) {
+      // if bounds no longer interesect skip to the next
+      // this removes jitter from overlapping/stacked solid tiles or a wall of solid tiles
+      if (!contact.colliderA.bounds.intersect(contact.colliderB.bounds)) {
+        continue;
+      }
       let mtv = contact.mtv;
       const colliderA = contact.colliderA;
       const colliderB = contact.colliderB;

--- a/src/spec/ArcadeSolverSpec.ts
+++ b/src/spec/ArcadeSolverSpec.ts
@@ -11,7 +11,7 @@ describe('An ArcadeSolver', () => {
   });
 
   it('should only solve position for overlapping contacts', ()=> {
-    
+
     const wall1 = new ex.Actor({x: 0, y: 0, width: 100, height: 100, collisionType: ex.CollisionType.Fixed});
     const wall2 = new ex.Actor({x: 100, y: 0, width: 100, height: 100, collisionType: ex.CollisionType.Fixed});
 
@@ -28,8 +28,8 @@ describe('An ArcadeSolver', () => {
     sut.solvePosition(contacts);
 
     // Each contact has the same mtv
-    expect(contacts[0].mtv).toBeVector(ex.vec(0, -1))
-    expect(contacts[1].mtv).toBeVector(ex.vec(0, -1))
+    expect(contacts[0].mtv).toBeVector(ex.vec(0, -1));
+    expect(contacts[1].mtv).toBeVector(ex.vec(0, -1));
 
     // Only 1 contact mtv is applied
     expect(player.pos.y).toBe(100);

--- a/src/spec/ArcadeSolverSpec.ts
+++ b/src/spec/ArcadeSolverSpec.ts
@@ -1,6 +1,11 @@
 import * as ex from '@excalibur';
+import { ExcaliburMatchers } from 'excalibur-jasmine';
 
 describe('An ArcadeSolver', () => {
+  beforeAll(() => {
+    jasmine.addMatchers(ExcaliburMatchers);
+  });
+
   it('should exist', () => {
     expect(ex.ArcadeSolver).toBeDefined();
   });
@@ -22,6 +27,11 @@ describe('An ArcadeSolver', () => {
 
     sut.solvePosition(contacts);
 
+    // Each contact has the same mtv
+    expect(contacts[0].mtv).toBeVector(ex.vec(0, -1))
+    expect(contacts[1].mtv).toBeVector(ex.vec(0, -1))
+
+    // Only 1 contact mtv is applied
     expect(player.pos.y).toBe(100);
     expect(player.pos.x).toBe(50);
   });

--- a/src/spec/ArcadeSolverSpec.ts
+++ b/src/spec/ArcadeSolverSpec.ts
@@ -1,0 +1,28 @@
+import * as ex from '@excalibur';
+
+describe('An ArcadeSolver', () => {
+  it('should exist', () => {
+    expect(ex.ArcadeSolver).toBeDefined();
+  });
+
+  it('should only solve position for overlapping contacts', ()=> {
+    
+    const wall1 = new ex.Actor({x: 0, y: 0, width: 100, height: 100, collisionType: ex.CollisionType.Fixed});
+    const wall2 = new ex.Actor({x: 100, y: 0, width: 100, height: 100, collisionType: ex.CollisionType.Fixed});
+
+    const player = new ex.Actor({x: 50, y: 99, width: 100, height: 100, collisionType: ex.CollisionType.Active});
+
+    const pair1 = new ex.Pair(player.collider.get(), wall1.collider.get());
+    const pair2 = new ex.Pair(player.collider.get(), wall2.collider.get());
+
+    const contacts = [...pair1.collide(), ...pair2.collide()];
+    expect(contacts.length).toBe(2);
+
+    const sut = new ex.ArcadeSolver();
+
+    sut.solvePosition(contacts);
+
+    expect(player.pos.y).toBe(100);
+    expect(player.pos.x).toBe(50);
+  });
+});


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Fixes an issue where overlapping tiles would cause a jitter, due to the arcade solver double solving the same mtv




## Changes:

- Check if contact overlaps before solving position


Before 

![jitter](https://user-images.githubusercontent.com/612071/141393252-a8c69930-00e5-4db7-82bf-624f978a788a.gif)

After

![no-jitter](https://user-images.githubusercontent.com/612071/141393859-fbe914a4-74d1-4887-901c-b178504457cb.gif)


