### PR TITLE
feat: [#577] [#1170] Implement new Clock API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
--
+- The static `Engine.createMainLoop` is now marked deprecated and will be removed in v0.26.0, it is replaced by the `Clock` api
 
 ### Added
+
+- Added new `Clock` api to manage the core main loop. Clocks hide the implementation detail of how the mainloop runs, users just knows that it ticks somehow. Clocks additionally encapsulate any related browser timing, like `performance.now()`
+  1. `StandardClock` encapsulates the existing `requestAnimationFrame` api logic
+  2. `TestClock` allows a user to manually step the mainloop, this can be useful for frame by frame debugging #1170 
+  3. The base abstract clock implements the specifics of elapsed time 
 
 - Added a new feature to Engine options to set a maximum fps `new ex.Engine({...options, maxFps: 30})`. This can be useful when needing to deliver a consistent experience across devices.
 - Pointers can now be configured to use the collider or the graphics bounds as the target for pointers with the `ex.PointerComponent`
@@ -39,7 +44,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The following Engine's pieces: `Collision` `Graphics` `Resources` `Trigger` are updated to reflect the new EventDispatcher behavior.
 
 ### Changed
-
+- Excalibur FPS is now sampled over 100ms blocks, this gives a more usable fps in the stats. The sampler is available off of the engine clock `engine.clock.fpsSampler.fps` 
 - Pointer Events:
   * Event types (up, down, move, etc) now all exist in 2 types `ex.Input.PointerEvent` and `ex.Input.WheelEvent`
   * The `stopPropagation()` method used to cancel further dispatches has been renamed to `cancel()` to match other events API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added a new feature to Engine options to set a maximum fps `new ex.Engine({...options, maxFps: 30})`. This can be useful when needing to deliver a consistent experience across devices.
 - Pointers can now be configured to use the collider or the graphics bounds as the target for pointers with the `ex.PointerComponent`
   - `useColliderShape` - (default true) uses the collider component geometry for pointer events
   - `useGraphicsBounds` - (default false) uses the graphics bounds for pointer events

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -117,7 +117,8 @@ var game = new ex.Engine({
   suppressPlayButton: true,
   pointerScope: ex.Input.PointerScope.Canvas,
   antialiasing: false,
-  snapToPixel: true
+  snapToPixel: true,
+  maxFps: 60
 });
 
 fullscreenButton.addEventListener('click', () => {

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -45,6 +45,7 @@ declare module dat {
   class GUI {
     constructor(options: { name: string });
     addFolder(name: string): GUI;
+    add<T>(object: T): any;
     add<T>(object: T, prop: keyof T, min?: number, max?: number, step?: number): any;
     addColor(object: any, prop: any): any;
   }
@@ -59,6 +60,14 @@ document.body.appendChild(stats.dom);
 
 var bootstrap = (game: ex.Engine) => {
   gui.add({toggleDebug: false}, 'toggleDebug').onChange(() => game.toggleDebug());
+  let clock = gui.addFolder('clock');
+  clock.add({"Use Test Clock": () => game.debug.useTestClock()}, "Use Test Clock");
+  clock.add({"Use Standard Clock": () => game.debug.useStandardClock()}, "Use Standard Clock");
+  let msStep = {
+    "Step MS": 1000
+  }
+  clock.add(msStep, "Step MS", 1, 2000, 16);
+  clock.add({"Step": () => (game.clock as any).step(msStep["Step MS"]) }, "Step");
   var supportedKeys = ['filter', 'entity', 'transform', 'motion', 'body', 'collider', 'physics', 'graphics', 'camera'];
   for (let key of supportedKeys) {
     let folder = gui.addFolder(key);
@@ -705,7 +714,7 @@ game.input.keyboard.on('down', (keyDown?: ex.Input.KeyEvent) => {
 });
 
 var isColliding = false;
-player.on('precollision', (data?: ex.PreCollisionEvent) => {
+player.on('postcollision', (data: ex.PostCollisionEvent) => {
   if (data.side === ex.Side.Bottom) {
     isColliding = true;
 

--- a/src/engine/Debug/Debug.ts
+++ b/src/engine/Debug/Debug.ts
@@ -160,6 +160,22 @@ export class Debug implements DebugFlags {
     this.colorBlindMode = new ColorBlindFlags(this._engine);
   }
 
+  public useTestClock() {
+    const clock = this._engine.clock;
+    clock.stop();
+    const testClock = clock.toTestClock();
+    testClock.start();
+    this._engine.clock = testClock;
+  }
+
+  public useStandardClock() {
+    const currentClock = this._engine.clock;
+    currentClock.stop();
+    const standardClock = currentClock.toStandardClock();
+    standardClock.start();
+    this._engine.clock = standardClock;
+  }
+
   /**
    * Performance statistics
    */

--- a/src/engine/Debug/Debug.ts
+++ b/src/engine/Debug/Debug.ts
@@ -2,6 +2,7 @@ import { DebugFlags, ColorBlindFlags } from './DebugFlags';
 import { Engine } from '../Engine';
 import { Color } from '../Color';
 import { CollisionContact } from '../Collision/Detection/CollisionContact';
+import { StandardClock, TestClock } from '..';
 
 /**
  * Debug stats containing current and previous frame statistics
@@ -160,20 +161,43 @@ export class Debug implements DebugFlags {
     this.colorBlindMode = new ColorBlindFlags(this._engine);
   }
 
-  public useTestClock() {
+  /**
+   * Switch the current excalibur clock with the [[TestClock]] and return 
+   * it in the same running state.
+   * 
+   * This is useful when you need to debug frame by frame.
+   */
+  public useTestClock(): TestClock {
     const clock = this._engine.clock;
+    const wasRunning = clock.isRunning();
     clock.stop();
+
     const testClock = clock.toTestClock();
-    testClock.start();
+    if (wasRunning) {
+      testClock.start();
+    }
     this._engine.clock = testClock;
+    return testClock;
   }
 
-  public useStandardClock() {
+  /**
+   * Switch the current excalibur clock with the [[StandardClock]] and 
+   * return it in the same runnign state.
+   * 
+   * This is useful when you need to switch back to normal mode after
+   * debugging.
+   */
+  public useStandardClock(): StandardClock {
     const currentClock = this._engine.clock;
+    const wasRunning = currentClock.isRunning();
     currentClock.stop();
+
     const standardClock = currentClock.toStandardClock();
-    standardClock.start();
+    if (wasRunning) {
+      standardClock.start();
+    }
     this._engine.clock = standardClock;
+    return standardClock;
   }
 
   /**

--- a/src/engine/Debug/Debug.ts
+++ b/src/engine/Debug/Debug.ts
@@ -162,9 +162,9 @@ export class Debug implements DebugFlags {
   }
 
   /**
-   * Switch the current excalibur clock with the [[TestClock]] and return 
+   * Switch the current excalibur clock with the [[TestClock]] and return
    * it in the same running state.
-   * 
+   *
    * This is useful when you need to debug frame by frame.
    */
   public useTestClock(): TestClock {
@@ -181,9 +181,9 @@ export class Debug implements DebugFlags {
   }
 
   /**
-   * Switch the current excalibur clock with the [[StandardClock]] and 
+   * Switch the current excalibur clock with the [[StandardClock]] and
    * return it in the same runnign state.
-   * 
+   *
    * This is useful when you need to switch back to normal mode after
    * debugging.
    */

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1173,7 +1173,9 @@ O|===|* >________________>\n\
     return this._isReady;
   }
   private _isReadyResolve: () => any;
-  private _isReadyPromise = new Promise<void>(resolve => { this._isReadyResolve = resolve; });
+  private _isReadyPromise = new Promise<void>(resolve => {
+    this._isReadyResolve = resolve;
+  });
   public isReady(): Promise<void> {
     return this._isReadyPromise;
   }
@@ -1184,7 +1186,7 @@ O|===|* >________________>\n\
    * any provided assets.
    * @param loader  Optional [[Loader]] to use to load resources. The default loader is [[Loader]], override to provide your own
    * custom loader.
-   * 
+   *
    * Note: start() only resolves AFTER the user has clicked the play button
    */
   public async start(loader?: Loader): Promise<void> {

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1025,7 +1025,6 @@ O|===|* >________________>\n\
       return;
     }
 
-    this._overrideInitialize(this);
 
     // Publish preupdate events
     this._preupdate(delta);
@@ -1227,7 +1226,11 @@ O|===|* >________________>\n\
 
     this._loadingComplete = true;
 
+    // Initialize before ready
+    this._overrideInitialize(this);
+
     this._isReady = true;
+
     this._isReadyResolve();
     this.emit('start', new GameStartEvent(this));
     return this._isReadyPromise;

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -170,9 +170,9 @@ export interface EngineOptions {
 
   /**
    * Optionally set the maximum fps if not set Excalibur will go as fast as the device allows.
-   * 
+   *
    * You may want to constrain max fps if your game cannot maintain fps consistenly, it can look and feel better to have a 30fps game than
-   * one that bounces between 30fps and 60fps  
+   * one that bounces between 30fps and 60fps
    */
   maxFps?: number;
 }
@@ -214,9 +214,9 @@ export class Engine extends Class implements CanInitialize, CanUpdate, CanDraw {
 
   /**
    * Optionally set the maximum fps if not set Excalibur will go as fast as the device allows.
-   * 
+   *
    * You may want to constrain max fps if your game cannot maintain fps consistenly, it can look and feel better to have a 30fps game than
-   * one that bounces between 30fps and 60fps  
+   * one that bounces between 30fps and 60fps
    */
   public maxFps: number = Number.POSITIVE_INFINITY;
 

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -640,7 +640,6 @@ O|===|* >________________>\n\
     this.clock = new StandardClock({
       maxFps: this.maxFps,
       tick: this._mainloop.bind(this),
-      raf: (cb) => window.requestAnimationFrame(cb),
       onFatalException: (e) => this.onFatalException(e)
     });
 

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1208,7 +1208,6 @@ O|===|* >________________>\n\
       this._hasStarted = true;
       this._logger.debug('Starting game...');
       this.browser.resume();
-      // Engine.createMainLoop(this, window.requestAnimationFrame, () => performance.now())();
       this.clock.start();
       this._logger.debug('Game started');
     } else {

--- a/src/engine/EntityComponentSystem/SystemManager.ts
+++ b/src/engine/EntityComponentSystem/SystemManager.ts
@@ -62,7 +62,7 @@ export class SystemManager<ContextType> {
 
   /**
    * Initialize all systems in the manager
-   * 
+   *
    * Systems added after initialize() will be initialized on add
    */
   public initialize() {

--- a/src/engine/EntityComponentSystem/SystemManager.ts
+++ b/src/engine/EntityComponentSystem/SystemManager.ts
@@ -61,12 +61,11 @@ export class SystemManager<ContextType> {
   }
 
   /**
-   * Updates all systems
-   * @param type whether this is an update or draw system
-   * @param context context reference
-   * @param delta time in milliseconds
+   * Initialize all systems in the manager
+   * 
+   * Systems added after initialize() will be initialized on add
    */
-  public updateSystems(type: SystemType, context: ContextType, delta: number) {
+  public initialize() {
     if (!this.initialized) {
       this.initialized = true;
       for (const s of this.systems) {
@@ -75,7 +74,15 @@ export class SystemManager<ContextType> {
         }
       }
     }
+  }
 
+  /**
+   * Updates all systems
+   * @param type whether this is an update or draw system
+   * @param context context reference
+   * @param delta time in milliseconds
+   */
+  public updateSystems(type: SystemType, context: ContextType, delta: number) {
     const systems = this.systems.filter((s) => s.systemType === type);
     for (const s of systems) {
       if (s.preupdate) {

--- a/src/engine/Loader.ts
+++ b/src/engine/Loader.ts
@@ -240,10 +240,11 @@ export class Loader extends Class implements Loadable<Loadable<any>[]> {
   /**
    * Shows the play button and returns a promise that resolves when clicked
    */
-  public showPlayButton(): Promise<void> {
+  public async showPlayButton(): Promise<void> {
     if (this.suppressPlayButton) {
       this.hidePlayButton();
-      return Promise.resolve();
+      // Delay is to give the logo a chance to show, otherwise don't delay
+      await delay(500, this._engine?.clock);
     } else {
       const resizeHandler = () => {
         this._positionPlayButton();
@@ -258,7 +259,8 @@ export class Loader extends Class implements Loadable<Loadable<any>[]> {
           this._playButton.click();
         }
       });
-      const promise = new Promise<void>((resolve) => {
+      this._positionPlayButton();
+      const playButtonClicked = new Promise<void>((resolve) => {
         const startButtonHandler = (e: Event) => {
           // We want to stop propogation to keep bubbling to the engine pointer handlers
           e.stopPropagation();
@@ -274,7 +276,7 @@ export class Loader extends Class implements Loadable<Loadable<any>[]> {
         this._playButton.addEventListener('pointerup', startButtonHandler);
       });
 
-      return promise;
+      return await playButtonClicked;
     }
   }
 

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -255,6 +255,8 @@ export class Scene extends Class implements CanInitialize, CanActivate, CanDeact
       // Initialize camera first
       this.camera._initialize(engine);
 
+      this.world.systemManager.initialize();
+
       // This order is important! we want to be sure any custom init that add actors
       // fire before the actor init
       this.onInitialize.call(this, engine);

--- a/src/engine/Util/Clock.ts
+++ b/src/engine/Util/Clock.ts
@@ -1,0 +1,191 @@
+import { FpsSampler } from './Fps';
+
+export interface ClockOptions {
+  tick: (elapsedMs: number) => any;
+  onFatalException: (e: unknown) => any;
+  maxFps?: number;
+}
+
+
+export abstract class Clock {
+  protected tick: (elapsedMs: number) => any;
+  private _onFatalException: (e: unknown) => any;
+  private _maxFps: number = Infinity;
+  private _lastTime: number = 0;
+  public fpsSampler: FpsSampler;
+  private _options: ClockOptions;
+  private _elapsed: number = 1;
+  constructor(options: ClockOptions) {
+    this._options = options;
+    this.tick = options.tick;
+    this._lastTime = this.now() ?? 0;
+    this._maxFps = options.maxFps ?? this._maxFps;
+    this._onFatalException = options.onFatalException;
+    this.fpsSampler = new FpsSampler({
+      initialFps: 60,
+      nowFn: () => this.now()
+    });
+  }
+
+  public elapsed(): number {
+    return this._elapsed;
+  }
+
+  public now(): number {
+    return performance.now();
+  }
+
+  public toTestClock() {
+    const testClock = new TestClock({
+      ...this._options,
+      defaultUpdateMs: 16.6
+    });
+    return testClock;
+  }
+
+  public toStandardClock() {
+    const clock = new StandardClock({
+      ...this._options,
+      raf: (cb) => window.requestAnimationFrame(cb)
+    });
+    return clock;
+  }
+
+  protected update(overrideUpdateMs?: number): void {
+    try {
+      this.fpsSampler.start();
+      // Get the time to calculate time-elapsed
+      const now = this.now();
+      let elapsed = now - this._lastTime || 1; // first frame
+
+      // Constrain fps
+      const fpsInterval = this._maxFps === Infinity ? 0 : 1000 / this._maxFps;
+      if (elapsed <= fpsInterval) {
+        return; // too fast 😎 skip this frame
+      }
+
+      // Resolves issue #138 if the game has been paused, or blurred for
+      // more than a 200 milliseconds, reset elapsed time to 1. This improves reliability
+      // and provides more expected behavior when the engine comes back
+      // into focus
+      if (elapsed > 200) {
+        elapsed = 1;
+      }
+
+      // tick the mainloop
+      this._elapsed = overrideUpdateMs || elapsed;
+      this.tick(overrideUpdateMs || elapsed);
+
+      // if fps interval is not a multple
+      if (fpsInterval > 0) {
+        this._lastTime = now - (elapsed % fpsInterval);
+      } else {
+        this._lastTime = now;
+      }
+      this.fpsSampler.end();
+    } catch (e) {
+      this._onFatalException(e);
+      this.stop();
+    }
+  }
+
+  /**
+   * Returns if the clock is currently running
+   */
+  public abstract isRunning(): boolean;
+
+  /**
+   * Start the clock, it will then periodically call the tick(elapsedMilliseconds) since the last tick
+   */
+  public abstract start(): void;
+
+  /**
+   * Stop the clock, tick() is no longer called
+   */
+  public abstract stop(): void;
+}
+
+export interface StandardClockOptions {
+  raf: (func: () => void) => number;
+}
+
+export class StandardClock extends Clock {
+
+  private _running = false;
+  private _raf: (func: () => void) => number;
+  private _requestId: number;
+  constructor(options: ClockOptions & StandardClockOptions) {
+    super(options);
+    this._raf = options.raf;
+  }
+
+  public isRunning(): boolean {
+    return this._running;
+  }
+
+  public start(): void {
+    this._running = true;
+    const mainloop = () => {
+      // stop the loop
+      if (!this._running) {
+        return;
+      }
+      try {
+        // request next loop
+        this._requestId = this._raf(mainloop);
+        this.update();
+      } catch (e) {
+        window.cancelAnimationFrame(this._requestId);
+        throw e;
+      }
+    };
+
+    // begin the first frame
+    mainloop();
+  }
+
+  public stop(): void {
+    this._running = false;
+  }
+}
+
+export interface TestClockOptions {
+  /**
+   * Specify the update milliseconds to use for each manual step()
+   */
+  defaultUpdateMs: number;
+}
+
+/**
+ * The TestClock is meant for debugging interactions in excalibur that require precise timing to replicate or test
+ */
+export class TestClock extends Clock {
+  private _updateMs: number;
+  private _running: boolean;
+  private _currentTime = 0;
+  constructor(options: ClockOptions & TestClockOptions) {
+    super({
+      ...options
+    });
+    this._updateMs = options.defaultUpdateMs;
+  }
+  public override now() {
+    return this._currentTime;
+  }
+
+  public isRunning(): boolean {
+    return this._running;
+  }
+  public start(): void {
+    this._running = true;
+  }
+  public stop(): void {
+    this._running = false;
+  }
+  step(overrideUpdateMs?: number): void {
+    if (this._running) {
+      this.update(overrideUpdateMs ?? this._updateMs);
+      this._currentTime += overrideUpdateMs ?? this._updateMs;
+    }
+  }
+}

--- a/src/engine/Util/Clock.ts
+++ b/src/engine/Util/Clock.ts
@@ -80,11 +80,11 @@ export abstract class Clock {
 
   /**
    * Schedule a callback to fire given a a timeout in milliseconds using the excalibur [[Clock]]
-   * 
-   * This is useful to use over the built in browser `setTimeout` because callbacks will be tied to the 
-   * excalibur update clock, instead of browser time, this means that callbacks wont fire if the game is 
+   *
+   * This is useful to use over the built in browser `setTimeout` because callbacks will be tied to the
+   * excalibur update clock, instead of browser time, this means that callbacks wont fire if the game is
    * stopped or paused.
-   * 
+   *
    * @param cb callback to fire
    * @param timeoutMs Optionally sepcify a timeout in milliseconds from now, default is 0ms which means the next possible tick
    */
@@ -259,8 +259,8 @@ export class TestClock extends Clock {
 
   /**
    * Run a number of steps that tick the clock, optionally specify an elapsed time in milliseconds
-   * @param numberOfSteps 
-   * @param overrideUpdateMs 
+   * @param numberOfSteps
+   * @param overrideUpdateMs
    */
   run(numberOfSteps: number, overrideUpdateMs?: number): void {
     for (let i = 0; i < numberOfSteps; i++) {

--- a/src/engine/Util/Clock.ts
+++ b/src/engine/Util/Clock.ts
@@ -79,14 +79,14 @@ export abstract class Clock {
   }
 
   /**
-   * Schedule a callback to fire given a a timeout in milliseconds using the excalibur [[Clock]]
+   * Schedule a callback to fire given a timeout in milliseconds using the excalibur [[Clock]]
    *
    * This is useful to use over the built in browser `setTimeout` because callbacks will be tied to the
    * excalibur update clock, instead of browser time, this means that callbacks wont fire if the game is
    * stopped or paused.
    *
    * @param cb callback to fire
-   * @param timeoutMs Optionally sepcify a timeout in milliseconds from now, default is 0ms which means the next possible tick
+   * @param timeoutMs Optionally specify a timeout in milliseconds from now, default is 0ms which means the next possible tick
    */
   public schedule(cb: () => any, timeoutMs: number = 0) {
     const scheduledTime = this.now() + timeoutMs;

--- a/src/engine/Util/Clock.ts
+++ b/src/engine/Util/Clock.ts
@@ -18,17 +18,17 @@ export interface ClockOptions {
 
 /**
  * Abstract Clock is the base type of all Clocks
- * 
+ *
  * It has a few opinions
  * 1. It manages the calculation of what "elapsed" time means and thus maximum fps
  * 2. The default timing api is implemented in now()
- * 
- * To implement your own clock, extend Clock and override start/stop to start and stop the clock, then call update() with whatever 
+ *
+ * To implement your own clock, extend Clock and override start/stop to start and stop the clock, then call update() with whatever
  * method is unique to your clock implementation.
  */
 export abstract class Clock {
   protected tick: (elapsedMs: number) => any;
-  private _onFatalException: (e: unknown) => any = () => {};
+  private _onFatalException: (e: unknown) => any = () => { /* default nothing */ };
   private _maxFps: number = Infinity;
   private _lastTime: number = 0;
   public fpsSampler: FpsSampler;
@@ -211,7 +211,7 @@ export class TestClock extends Clock {
 
   /**
    * Manually step the clock forward 1 tick, optionally specify an elapsed time in milliseconds
-   * @param overrideUpdateMs 
+   * @param overrideUpdateMs
    */
   step(overrideUpdateMs?: number): void {
     if (this._running) {

--- a/src/engine/Util/Fps.ts
+++ b/src/engine/Util/Fps.ts
@@ -1,0 +1,70 @@
+export interface FpsSamplerOptions {
+  /**
+   * Specify the sampling period in milliseconds (default 100)
+   */
+  samplePeriod?: number;
+  /**
+   * Specify the initial FPS
+   */
+  initialFps: number;
+
+  /**
+   * Specify the function used to return the current time (in millseconds)
+   */
+  nowFn: () => number;
+}
+
+export class FpsSampler {
+  private _fps: number;
+  private _samplePeriod: number = 100;
+  private _currentFrameTime: number = 0;
+  private _frames: number = 0;
+  private _previousSampleTime: number = 0;
+  private _beginFrameTime: number = 0;
+  private _nowFn: () => number;
+
+  constructor(options: FpsSamplerOptions) {
+    this._fps = options.initialFps;
+    this._samplePeriod = options.samplePeriod ?? this._samplePeriod;
+    this._currentFrameTime = 1000/options.initialFps;
+    this._nowFn = options.nowFn;
+    this._previousSampleTime = this._nowFn();
+  }
+
+  /**
+   * Start of code block to sample FPS for
+   */
+  start() {
+    this._beginFrameTime = this._nowFn();
+  }
+
+  /**
+   * End of code block to sample FPS for
+   */
+  end() {
+    this._frames++;
+    const time = this._nowFn();
+
+    this._currentFrameTime = time - this._beginFrameTime;
+
+    if (time >= this._previousSampleTime + this._samplePeriod) {
+      this._fps = (this._frames * 1000) / (time - this._previousSampleTime);
+      this._previousSampleTime = time;
+      this._frames = 0;
+    }
+  }
+
+  /**
+   * Return the currenty sampled fps over the last sample period, by default every 100ms
+   */
+  get fps() {
+    return this._fps;
+  }
+
+  /**
+   * Return the instantanteous fps, this can be less useful because it will fluctuate given the current frames time
+   */
+  get instant() {
+    return 1000 / this._currentFrameTime;
+  }
+}

--- a/src/engine/Util/Util.ts
+++ b/src/engine/Util/Util.ts
@@ -1,6 +1,7 @@
 import { Vector } from '../Math/vector';
 import { Random } from '../Math/Random';
 import { Side } from '../Collision/Side';
+import { Clock } from '..';
 
 /**
  * Two PI constant
@@ -387,12 +388,17 @@ export const range = (from: number, to: number) => Array.from(new Array(to - fro
 
 /**
  * Create a promise that resolves after a certain number of milliseconds
+ * 
+ * It is strongly recommended you pass the excalibur clock so delays are bound to the
+ * excalibur clock which would be unaffected by stop/pause.
  * @param milliseconds
+ * @param clock
  */
-export function delay(milliseconds: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve();
+export function delay(milliseconds: number, clock?: Clock): Promise<void> {
+  const schedule = clock?.schedule.bind(clock) ?? setTimeout
+  return new Promise<void>(resolve => {
+    schedule(() => {
+        resolve();
     }, milliseconds);
   });
 }

--- a/src/engine/Util/Util.ts
+++ b/src/engine/Util/Util.ts
@@ -388,17 +388,17 @@ export const range = (from: number, to: number) => Array.from(new Array(to - fro
 
 /**
  * Create a promise that resolves after a certain number of milliseconds
- * 
+ *
  * It is strongly recommended you pass the excalibur clock so delays are bound to the
  * excalibur clock which would be unaffected by stop/pause.
  * @param milliseconds
  * @param clock
  */
 export function delay(milliseconds: number, clock?: Clock): Promise<void> {
-  const schedule = clock?.schedule.bind(clock) ?? setTimeout
+  const schedule = clock?.schedule.bind(clock) ?? setTimeout;
   return new Promise<void>(resolve => {
     schedule(() => {
-        resolve();
+      resolve();
     }, milliseconds);
   });
 }

--- a/src/engine/Util/WebAudio.ts
+++ b/src/engine/Util/WebAudio.ts
@@ -70,7 +70,6 @@ export class WebAudio {
       );
     });
 
-
     return promise;
   }
 

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -83,6 +83,7 @@ export * from './Util/Observable';
 export * from './Util/Log';
 export * from './Util/SortedList';
 export * from './Util/Pool';
+export * from './Util/Clock';
 
 // ex.Deprecated
 export * from './Promises';

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -85,6 +85,7 @@ export * from './Util/SortedList';
 export * from './Util/Pool';
 export * from './Util/Fps';
 export * from './Util/Clock';
+export * from './Util/WebAudio';
 
 // ex.Deprecated
 export * from './Promises';

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -83,6 +83,7 @@ export * from './Util/Observable';
 export * from './Util/Log';
 export * from './Util/SortedList';
 export * from './Util/Pool';
+export * from './Util/Fps';
 export * from './Util/Clock';
 
 // ex.Deprecated

--- a/src/engine/tsconfig.json
+++ b/src/engine/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "experimentalDecorators": true,
-    "target": "es2015",
+    "target": "es2018",
     "module": "es2015",
     "declaration": true,
     "removeComments": false,
@@ -21,13 +21,7 @@
     "lib": [
       "dom",
       "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise",
-      "es2018.promise",
-      "es2015.proxy",
-      "es2016",
-      "es2017.object"
+      "es2018"
     ]
   }
 }

--- a/src/spec/ActionSpec.ts
+++ b/src/spec/ActionSpec.ts
@@ -19,6 +19,8 @@ describe('Action', () => {
     engine.addScene('test', scene);
     engine.goToScene('test');
     engine.start();
+    const clock = engine.clock as ex.TestClock;
+    clock.step(100);
 
     spyOn(scene, 'draw').and.callThrough();
     spyOn(actor, 'draw');

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -44,6 +44,8 @@ describe('A game actor', () => {
     spyOn(actor, 'debugDraw');
 
     engine.start();
+    const clock = engine.clock as ex.TestClock;
+    clock.step(1);
     collisionSystem.initialize(scene);
     scene.world.systemManager.get(ex.Input.PointerSystem).initialize(scene);
 
@@ -601,6 +603,8 @@ describe('A game actor', () => {
     engine.addScene('test', scene);
     engine.goToScene('test');
     engine.start();
+    const clock = engine.clock as ex.TestClock;
+    clock.step(1);
 
     const green = new ex.Actor({ x: 35, y: 35, width: 50, height: 50, color: ex.Color.Green });
     const blue = new ex.Actor({ x: 65, y: 65, width: 50, height: 50, color: ex.Color.Blue });

--- a/src/spec/ClockSpec.ts
+++ b/src/spec/ClockSpec.ts
@@ -52,7 +52,7 @@ describe('Clocks', () => {
 
       testClock.step();
       expect(testClock.isRunning()).toBe(false);
-      expect(logger.warn).toHaveBeenCalledWith('The clock is not running, no step will be performed')
+      expect(logger.warn).toHaveBeenCalledWith('The clock is not running, no step will be performed');
     });
 
     it('works with delay()', (done) => {

--- a/src/spec/ClockSpec.ts
+++ b/src/spec/ClockSpec.ts
@@ -1,0 +1,113 @@
+import * as ex from '@excalibur';
+
+describe('Clocks', () => {
+  describe('A TestClock', () => {
+    it('exists', () => {
+      expect(ex.TestClock).toBeDefined();
+    });
+
+    it('can manually tick', () => {
+      const tickSpy = jasmine.createSpy('tick');
+      const testClock = new ex.TestClock({
+        tick: tickSpy,
+        defaultUpdateMs: 1000
+      });
+      testClock.start();
+      expect(testClock.isRunning()).toBe(true);
+      expect(tickSpy).not.toHaveBeenCalled();
+
+      testClock.step();
+      expect(tickSpy).toHaveBeenCalledWith(1000);
+      expect(testClock.elapsed()).toBe(1000);
+
+      testClock.step();
+      expect(testClock.now()).toBe(2000);
+
+      testClock.step(22);
+      expect(testClock.elapsed()).toBe(22);
+      expect(testClock.now()).toBe(2022);
+
+      testClock.stop();
+      expect(testClock.isRunning()).toBe(false);
+    });
+
+    it('can be converted to a standard clock', () => {
+      const testClock = new ex.TestClock({
+        tick: () => {},
+        defaultUpdateMs: 1000
+      });
+
+      const standard = testClock.toStandardClock();
+      expect(standard).toBeInstanceOf(ex.StandardClock);
+    });
+  });
+
+  describe('A StandardClock', () => {
+    it('exists', () => {
+      expect(ex.StandardClock).toBeDefined();
+    });
+
+    it('can tick', () => {
+      const tickSpy = jasmine.createSpy('tick');
+      const clock = new ex.StandardClock({
+        tick: tickSpy
+      });
+
+      expect(tickSpy).not.toHaveBeenCalled();
+      clock.start();
+      
+      expect(clock.isRunning()).toBe(true);
+      expect(tickSpy).toHaveBeenCalled();
+
+      clock.stop();
+      expect(clock.isRunning()).toBe(false);
+    });
+
+    it('can limit fps', (done) => {
+      const tickSpy = jasmine.createSpy('tick');
+      const clock = new ex.StandardClock({
+        tick: tickSpy,
+        maxFps: 15
+      });
+
+      clock.start();
+      setTimeout(() => {
+        expect(clock.fpsSampler.fps).toBeCloseTo(15, 0);
+        stop();
+        done();
+      }, 300)
+    });
+
+    it('can handle exceptions and stop', () => {
+      const errorSpy = jasmine.createSpy('error');
+      const clock = new ex.StandardClock({
+        tick: () => { throw new Error('some error') },
+        onFatalException: errorSpy
+      });
+      spyOn(clock, 'stop');
+
+      clock.start();
+
+      expect(errorSpy).toHaveBeenCalledWith(new Error('some error'));
+      expect(clock.stop).toHaveBeenCalled();
+    });
+
+    it('can return the elapsed time', () => {
+      const clock = new ex.StandardClock({
+        tick: () => {}
+      });
+      (clock as any).update(100);
+      expect(clock.elapsed()).toBe(100);
+    });
+
+    it('can be converted to a test clock', () => {
+      const clock = new ex.StandardClock({
+        tick: () => {}
+      });
+
+      const test = clock.toTestClock();
+
+      expect(test).toBeInstanceOf(ex.TestClock);
+    });
+  });
+})

--- a/src/spec/ClockSpec.ts
+++ b/src/spec/ClockSpec.ts
@@ -33,7 +33,7 @@ describe('Clocks', () => {
 
     it('can be converted to a standard clock', () => {
       const testClock = new ex.TestClock({
-        tick: () => {},
+        tick: () => { /* nothing */ },
         defaultUpdateMs: 1000
       });
 
@@ -55,7 +55,7 @@ describe('Clocks', () => {
 
       expect(tickSpy).not.toHaveBeenCalled();
       clock.start();
-      
+
       expect(clock.isRunning()).toBe(true);
       expect(tickSpy).toHaveBeenCalled();
 
@@ -72,16 +72,18 @@ describe('Clocks', () => {
 
       clock.start();
       setTimeout(() => {
-        expect(clock.fpsSampler.fps).toBeCloseTo(15, 0);
+        expect(clock.fpsSampler.fps).toBeCloseTo(15, -1);
         stop();
         done();
-      }, 300)
+      }, 300);
     });
 
     it('can handle exceptions and stop', () => {
       const errorSpy = jasmine.createSpy('error');
       const clock = new ex.StandardClock({
-        tick: () => { throw new Error('some error') },
+        tick: () => {
+          throw new Error('some error');
+        },
         onFatalException: errorSpy
       });
       spyOn(clock, 'stop');
@@ -94,7 +96,7 @@ describe('Clocks', () => {
 
     it('can return the elapsed time', () => {
       const clock = new ex.StandardClock({
-        tick: () => {}
+        tick: () => { /* nothing */ }
       });
       (clock as any).update(100);
       expect(clock.elapsed()).toBe(100);
@@ -102,7 +104,7 @@ describe('Clocks', () => {
 
     it('can be converted to a test clock', () => {
       const clock = new ex.StandardClock({
-        tick: () => {}
+        tick: () => { /* nothing */ }
       });
 
       const test = clock.toTestClock();
@@ -110,4 +112,4 @@ describe('Clocks', () => {
       expect(test).toBeInstanceOf(ex.TestClock);
     });
   });
-})
+});

--- a/src/spec/CollisionShapeSpec.ts
+++ b/src/spec/CollisionShapeSpec.ts
@@ -23,6 +23,8 @@ describe('Collision Shape', () => {
       engine.add('test', scene);
       engine.goToScene('test');
       engine.start();
+      const clock = engine.clock as ex.TestClock;
+      clock.step(1);
 
       actor = new ex.Actor({ x: 0, y: 0, width: 20, height: 20 });
       circle = actor.collider.useCircleCollider(10, ex.Vector.Zero);
@@ -381,6 +383,8 @@ describe('Collision Shape', () => {
       engine.addScene('test', scene);
       engine.goToScene('test');
       engine.start();
+      const clock = engine.clock as ex.TestClock;
+      clock.step(1);
     });
 
     afterEach(() => {
@@ -731,6 +735,8 @@ describe('Collision Shape', () => {
       engine.addScene('test', scene);
       engine.goToScene('test');
       engine.start();
+      const clock = engine.clock as ex.TestClock;
+      clock.step(1);
 
       actor = new ex.Actor({ x: 5, y: 0, width: 10, height: 10 });
       edge = actor.collider.useEdgeCollider(new ex.Vector(-5, 0), new ex.Vector(5, 0));

--- a/src/spec/CollisionSpec.ts
+++ b/src/spec/CollisionSpec.ts
@@ -1,18 +1,15 @@
 import * as ex from '@excalibur';
 import { TestUtils } from './util/TestUtils';
-import { Mocks } from './util/Mocks';
 
 describe('A Collision', () => {
   let actor1: ex.Actor = null;
   let actor2: ex.Actor = null;
-  const scene: ex.Scene = null;
   let engine: ex.Engine = null;
-  const mock = new Mocks.Mocker();
-  let loop: Mocks.GameLoopLike;
+  let clock: ex.TestClock = null;
 
   beforeEach(() => {
     engine = TestUtils.engine({ width: 600, height: 400 });
-    loop = mock.loop(engine);
+    clock = engine.clock = engine.clock.toTestClock();
 
     actor1 = new ex.Actor({x: 0, y: 0, width: 10, height: 10});
     actor2 = new ex.Actor({x: 5, y: 5, width: 10, height: 10});
@@ -32,7 +29,7 @@ describe('A Collision', () => {
     actor2 = null;
   });
 
-  it('should throw one event for each actor participating', () => {
+  it('should throw one event for each actor participating', async () => {
     let actor1Collision = 0;
     let actor2Collision = 0;
     actor1.on('precollision', (e: ex.PreCollisionEvent) => {
@@ -44,9 +41,7 @@ describe('A Collision', () => {
       actor2Collision++;
     });
 
-    for (let i = 0; i < 50; i++) {
-      loop.advance(100);
-    }
+    clock.run(1, 100);
 
     expect(actor1Collision).toBe(1);
     expect(actor2Collision).toBe(1);
@@ -151,9 +146,7 @@ describe('A Collision', () => {
 
     actor2.body.collisionType = ex.CollisionType.Passive;
 
-    for (let i = 0; i < 50; i++) {
-      loop.advance(100);
-    }
+    clock.run(1, 100);
 
     expect(actor1Collision).toBe(1);
     expect(actor2Collision).toBe(1);
@@ -172,9 +165,7 @@ describe('A Collision', () => {
 
     actor2.kill();
 
-    for (let i = 0; i < 50; i++) {
-      loop.advance(100);
-    }
+    clock.run(1, 100);
 
     expect(actor1Collision).toBe(0);
     expect(actor2Collision).toBe(0);
@@ -188,9 +179,7 @@ describe('A Collision', () => {
       }
     });
 
-    for (let i = 0; i < 50; i++) {
-      loop.advance(100);
-    }
+    clock.run(5, 100);
 
     expect(touching).toBe(true);
   });
@@ -224,9 +213,7 @@ describe('A Collision', () => {
 
     activeBlock.once('precollision', collisionHandler);
 
-    for (let i = 0; i < 20; i++) {
-      loop.advance(1000);
-    }
+    clock.run(5, 1000);
   });
 
   it('should emit a start collision once when objects start colliding', () => {
@@ -250,9 +237,7 @@ describe('A Collision', () => {
 
     activeBlock.on('collisionstart', collisionStart);
 
-    for (let i = 0; i < 20; i++) {
-      loop.advance(1000);
-    }
+    clock.run(5, 1000)
 
     expect(count).toBe(1);
   });
@@ -278,9 +263,7 @@ describe('A Collision', () => {
 
     activeBlock.on('collisionend', collisionEnd);
 
-    for (let i = 0; i < 20; i++) {
-      loop.advance(1000);
-    }
+    clock.run(5, 1000);
 
     expect(count).toBe(1);
   });
@@ -297,9 +280,7 @@ describe('A Collision', () => {
     fixedBlock.body.collisionType = ex.CollisionType.Fixed;
     engine.add(fixedBlock);
 
-    for (let i = 0; i < 20; i++) {
-      loop.advance(1000);
-    }
+    clock.run(5, 1000);
 
     expect(activeBlock.vel.x).toBe(0);
   });
@@ -317,9 +298,7 @@ describe('A Collision', () => {
 
     activeBlock.vel = ex.vec(-100, activeBlock.vel.y);
 
-    for (let i = 0; i < 20; i++) {
-      loop.advance(1000);
-    }
+    clock.run(5, 1000);
 
     expect(activeBlock.vel.x).toBe(-100);
   });
@@ -344,9 +323,7 @@ describe('A Collision', () => {
 
     activeBlock.on('collisionstart', collisionEnd);
 
-    for (let i = 0; i < 20; i++) {
-      loop.advance(1000);
-    }
+    clock.run(5, 1000);
   });
 
   it('should have the actor as the handler context for collisionend', (done) => {
@@ -369,8 +346,6 @@ describe('A Collision', () => {
 
     activeBlock.on('collisionend', collisionEnd);
 
-    for (let i = 0; i < 20; i++) {
-      loop.advance(1000);
-    }
+    clock.run(5, 1000);
   });
 });

--- a/src/spec/CollisionSpec.ts
+++ b/src/spec/CollisionSpec.ts
@@ -237,7 +237,7 @@ describe('A Collision', () => {
 
     activeBlock.on('collisionstart', collisionStart);
 
-    clock.run(5, 1000)
+    clock.run(5, 1000);
 
     expect(count).toBe(1);
   });

--- a/src/spec/ColorBlindCorrectorSpec.ts
+++ b/src/spec/ColorBlindCorrectorSpec.ts
@@ -6,14 +6,20 @@ import { ColorBlindness } from '@excalibur';
 describe('A ColorBlindCorrector', () => {
   let bg: ex.LegacyDrawing.Texture;
   let engine: ex.Engine;
+  let clock: ex.TestClock;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     jasmine.addMatchers(ExcaliburMatchers);
 
     engine = TestUtils.engine({ width: 800, height: 200 });
     bg = new ex.LegacyDrawing.Texture('src/spec/images/ColorBlindCorrectorSpec/actor.png', true);
-
-    return engine.start(new ex.Loader([bg]));
+    const loader = new ex.Loader([bg]);
+    const start = engine.start(loader);
+    clock = engine.clock as ex.TestClock;
+    await loader.areResourcesLoaded();
+    clock.run(2, 100);
+    await start;
+    clock.run(5, 100);
   });
 
   afterEach(() => {
@@ -30,6 +36,7 @@ describe('A ColorBlindCorrector', () => {
         done();
       });
     });
+    clock.step(1);
   });
 
   it('corrects deuteranopia', (done) => {
@@ -43,6 +50,7 @@ describe('A ColorBlindCorrector', () => {
         done();
       });
     });
+    clock.step(1);
   });
 
   it('simulates deuteranopia', (done) => {
@@ -56,6 +64,7 @@ describe('A ColorBlindCorrector', () => {
         done();
       });
     });
+    clock.step(1);
   });
 
   it('corrects protanopia', (done) => {
@@ -69,6 +78,7 @@ describe('A ColorBlindCorrector', () => {
         done();
       });
     });
+    clock.step(1);
   });
 
   it('simulates protanopia', (done) => {
@@ -82,6 +92,7 @@ describe('A ColorBlindCorrector', () => {
         done();
       });
     });
+    clock.step(1);
   });
 
   it('corrects tritanopia', (done) => {
@@ -95,6 +106,7 @@ describe('A ColorBlindCorrector', () => {
         done();
       });
     });
+    clock.step(1);
   });
 
   it('simulates tritanopia', (done) => {
@@ -108,5 +120,6 @@ describe('A ColorBlindCorrector', () => {
         done();
       });
     });
+    clock.step(1);
   });
 });

--- a/src/spec/ColorBlindCorrectorSpec.ts
+++ b/src/spec/ColorBlindCorrectorSpec.ts
@@ -14,12 +14,8 @@ describe('A ColorBlindCorrector', () => {
     engine = TestUtils.engine({ width: 800, height: 200 });
     bg = new ex.LegacyDrawing.Texture('src/spec/images/ColorBlindCorrectorSpec/actor.png', true);
     const loader = new ex.Loader([bg]);
-    const start = engine.start(loader);
     clock = engine.clock as ex.TestClock;
-    await loader.areResourcesLoaded();
-    clock.run(2, 100);
-    await start;
-    clock.run(5, 100);
+    await TestUtils.runToReady(engine, loader);
   });
 
   afterEach(() => {

--- a/src/spec/DebugSystemSpec.ts
+++ b/src/spec/DebugSystemSpec.ts
@@ -26,6 +26,18 @@ describe('DebugSystem', () => {
     expect(ex.DebugSystem).toBeDefined();
   });
 
+  it('can use a test clock', () => {
+    engine.debug.useTestClock();
+    expect(engine.clock).toBeInstanceOf(ex.TestClock);
+    expect(engine.clock.isRunning());
+  });
+
+  it('can use a standard clock', () => {
+    engine.debug.useStandardClock();
+    expect(engine.clock).toBeInstanceOf(ex.StandardClock);
+    expect(engine.clock.isRunning());
+  });
+
   it('does not crash with an empty collider', async () => {
     const debugSystem = new ex.DebugSystem();
     engine.currentScene.world.add(debugSystem);

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -55,7 +55,7 @@ describe('The engine', () => {
         expectAsync(engine.canvas).toEqualImage('src/spec/images/EngineSpec/engine-load-complete.png').then(() => {
           done();
         });
-      })
+      });
     });
   });
 
@@ -79,7 +79,7 @@ describe('The engine', () => {
         color: ex.Color.Red
       })
     );
-    
+
     const testClock = engine.clock as ex.TestClock;
     const loader = new ex.Loader([new ex.ImageSource('src/spec/images/SpriteSpec/icon.png')]);
 
@@ -476,11 +476,11 @@ describe('The engine', () => {
     it('can have onInitialize overridden safely', async () => {
       await TestUtils.runToReady(engine);
       let initCalled = false;
-      
+
       engine.onInitialize = (engine) => {
         expect(engine).not.toBe(null);
       };
-      
+
       engine.on('initialize', () => {
         initCalled = true;
       });

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -44,7 +44,7 @@ describe('The engine', () => {
     const imageSource = new ex.ImageSource('src/spec/images/SpriteSpec/icon.png');
 
     const loader = new ex.Loader([imageSource]);
-    const start = engine.start(loader);
+    engine.start(loader);
     const testClock = engine.clock as ex.TestClock;
 
     loader.areResourcesLoaded().then(() => {
@@ -79,22 +79,16 @@ describe('The engine', () => {
         color: ex.Color.Red
       })
     );
-
+    
     const testClock = engine.clock as ex.TestClock;
     const loader = new ex.Loader([new ex.ImageSource('src/spec/images/SpriteSpec/icon.png')]);
-    engine.start(loader).then(() => {
+
+    TestUtils.runToReady(engine, loader).then(() => {
       // With suppress play there is another 500 ms delay in engine load()
-      testClock.step(500);
-      setTimeout(() => {
-        expectAsync(engine.canvas).toEqualImage('src/spec/images/EngineSpec/engine-suppress-play.png').then(() => {
-          done();
-        });
-      })
-    });
-  
-    loader.areResourcesLoaded().then(() => {
-      // Once resources are there is a 200 ms delay in excalibur loader
-      testClock.step(200);
+      testClock.step(1);
+      expectAsync(engine.canvas).toEqualImage('src/spec/images/EngineSpec/engine-suppress-play.png').then(() => {
+        done();
+      });
     });
   });
 
@@ -479,25 +473,32 @@ describe('The engine', () => {
       engine = null;
     });
 
-    it('can have onInitialize overridden safely', () => {
+    it('can have onInitialize overridden safely', async () => {
+      await TestUtils.runToReady(engine);
       let initCalled = false;
+      
       engine.onInitialize = (engine) => {
         expect(engine).not.toBe(null);
       };
-
+      
       engine.on('initialize', () => {
         initCalled = true;
       });
 
       spyOn(engine, 'onInitialize').and.callThrough();
 
-      (<any>engine)._update(100);
+      const clock = engine.clock as ex.TestClock;
+      clock.step(1);
 
       expect(initCalled).toBe(true);
       expect(engine.onInitialize).toHaveBeenCalledTimes(1);
     });
 
     it('can have onPostUpdate overridden safely', () => {
+      engine.start();
+      const clock = engine.clock as ex.TestClock;
+      expect(engine.clock.isRunning()).toBe(true);
+
       engine.onPostUpdate = (engine, delta) => {
         expect(engine).not.toBe(null);
         expect(delta).toBe(100);
@@ -506,14 +507,18 @@ describe('The engine', () => {
       spyOn(engine, 'onPostUpdate').and.callThrough();
       spyOn(engine, '_postupdate').and.callThrough();
 
-      (<any>engine)._update(100);
-      (<any>engine)._update(100);
+      clock.step(100);
+      clock.step(100);
 
       expect(engine._postupdate).toHaveBeenCalledTimes(2);
       expect(engine.onPostUpdate).toHaveBeenCalledTimes(2);
     });
 
     it('can have onPreUpdate overridden safely', () => {
+      engine.start();
+      const clock = engine.clock as ex.TestClock;
+      expect(engine.clock.isRunning()).toBe(true);
+
       engine.onPreUpdate = (engine, delta) => {
         expect(engine).not.toBe(null);
         expect(delta).toBe(100);
@@ -522,14 +527,18 @@ describe('The engine', () => {
       spyOn(engine, 'onPreUpdate').and.callThrough();
       spyOn(engine, '_preupdate').and.callThrough();
 
-      (<any>engine)._update(100);
-      (<any>engine)._update(100);
+      clock.step(100);
+      clock.step(100);
 
       expect(engine._preupdate).toHaveBeenCalledTimes(2);
       expect(engine.onPreUpdate).toHaveBeenCalledTimes(2);
     });
 
     it('can have onPreDraw overridden safely', () => {
+      engine.start();
+      const clock = engine.clock as ex.TestClock;
+      expect(engine.clock.isRunning()).toBe(true);
+
       engine.currentScene._initialize(engine);
       engine.onPreDraw = (ctx, delta) => {
         expect(<any>ctx).not.toBe(null);
@@ -538,14 +547,18 @@ describe('The engine', () => {
       spyOn(engine, 'onPreDraw').and.callThrough();
       spyOn(engine, '_predraw').and.callThrough();
 
-      (<any>engine)._draw(100);
-      (<any>engine)._draw(100);
+      clock.step(100);
+      clock.step(100);
 
       expect(engine._predraw).toHaveBeenCalledTimes(2);
       expect(engine.onPreDraw).toHaveBeenCalledTimes(2);
     });
 
     it('can have onPostDraw overridden safely', () => {
+      engine.start();
+      const clock = engine.clock as ex.TestClock;
+      expect(engine.clock.isRunning()).toBe(true);
+
       engine.currentScene._initialize(engine);
       engine.onPostDraw = (ctx, delta) => {
         expect(<any>ctx).not.toBe(null);
@@ -555,8 +568,8 @@ describe('The engine', () => {
       spyOn(engine, 'onPostDraw').and.callThrough();
       spyOn(engine, '_postdraw').and.callThrough();
 
-      (<any>engine)._draw(100);
-      (<any>engine)._draw(100);
+      clock.step(100);
+      clock.step(100);
 
       expect(engine._postdraw).toHaveBeenCalledTimes(2);
       expect(engine.onPostDraw).toHaveBeenCalledTimes(2);

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -474,7 +474,6 @@ describe('The engine', () => {
     });
 
     it('can have onInitialize overridden safely', async () => {
-      await TestUtils.runToReady(engine);
       let initCalled = false;
 
       engine.onInitialize = (engine) => {
@@ -487,6 +486,7 @@ describe('The engine', () => {
 
       spyOn(engine, 'onInitialize').and.callThrough();
 
+      await TestUtils.runToReady(engine);
       const clock = engine.clock as ex.TestClock;
       clock.step(1);
 

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -361,11 +361,11 @@ describe('The engine', () => {
     let _currentTime = 0;
     const mockNow = () => {
       return _currentTime;
-    }
+    };
     // 16ms tick
-    let actualFpsInterval = 1000/60;
+    const actualFpsInterval = 1000/60;
     const tick = () => _currentTime += actualFpsInterval;
-    
+
     const sut = Engine.createMainLoop(game, mockRAF, mockNow);
 
     for (let i = 0; i < 6; i++) {
@@ -388,11 +388,11 @@ describe('The engine', () => {
     let _currentTime = 0;
     const mockNow = () => {
       return _currentTime;
-    }
-    
-    let actualFpsInterval = 1000/120;
+    };
+
+    const actualFpsInterval = 1000/120;
     const tick = () => _currentTime += actualFpsInterval;
-  
+
     const sut = Engine.createMainLoop(game, mockRAF, mockNow);
     game.on('postframe', tick);
 

--- a/src/spec/FrameStatsSpec.ts
+++ b/src/spec/FrameStatsSpec.ts
@@ -1,12 +1,12 @@
 import * as ex from '@excalibur';
 import { TestUtils } from './util/TestUtils';
 import { Mocks } from './util/Mocks';
+import { TestClock } from '@excalibur';
 
 describe('The engine', () => {
   let engine: ex.Engine;
   let scene: ex.Scene;
   const mock = new Mocks.Mocker();
-  let loop: Mocks.GameLoopLike;
   let actor: ex.Actor;
   let stats: ex.FrameStats;
 
@@ -20,13 +20,11 @@ describe('The engine', () => {
     engine.addScene('root', scene);
     engine.goToScene('root');
     actor = new ex.Actor({ x: 0, y: 0, width: 10, height: 10, color: ex.Color.Red });
-    loop = mock.loop(engine);
 
     scene.add(actor);
-    engine.start();
-
-    loop.advance(100);
-
+    TestUtils.runToReady(engine);
+    const clock = engine.clock as TestClock;
+    clock.step(16.6);
     stats = engine.stats.currFrame;
   });
 

--- a/src/spec/FrameStatsSpec.ts
+++ b/src/spec/FrameStatsSpec.ts
@@ -42,11 +42,11 @@ describe('The engine', () => {
 
   describe('after frame is ended', () => {
     it('should collect frame delta', () => {
-      expect(stats.delta).toBe(16, 'Frame stats delta is wrong');
+      expect(stats.delta).withContext('Frame stats delta should be ~16ms').toBeCloseTo(16.6, 0);
     });
 
     it('should collect frame fps', () => {
-      expect(stats.fps).toBe(62.5, 'Frame stats fps is wrong');
+      expect(stats.fps).withContext('Frame stats fps should be ~60fps').toBeCloseTo(60);
     });
 
     it('should collect frame actor stats', () => {

--- a/src/spec/LoaderSpec.ts
+++ b/src/spec/LoaderSpec.ts
@@ -176,6 +176,7 @@ describe('A loader', () => {
 
   it('can have the enter key pressed to start', (done) => {
     const loader = new ex.Loader([, , , ,]);
+    loader.wireEngine(engine);
     loader.loadingBarPosition = ex.vec(0, 0);
     loader.loadingBarColor = ex.Color.Red;
     loader.markResourceComplete();

--- a/src/spec/LoaderSpec.ts
+++ b/src/spec/LoaderSpec.ts
@@ -215,24 +215,26 @@ describe('A loader', () => {
     target.dispatchEvent(evt);
   }
 
-  it('does not propagate the start button click to pointers', (done) => {
+  it('does not propagate the start button click to pointers', async () => {
     const engine = new ex.Engine({ width: 1000, height: 1000 });
+    (ex.WebAudio as any)._UNLOCKED = true;
+    const clock = engine.clock = engine.clock.toTestClock();
     const pointerHandler = jasmine.createSpy('pointerHandler');
     engine.input.pointers.primary.on('up', pointerHandler);
     const loader = new Loader([new ex.ImageSource('src/spec/images/GraphicsTextSpec/spritefont.png')]);
     engine.start(loader);
 
-    setTimeout(() => {
-      const btn = (loader as any)._playButton;
-      const btnClickHandler = jasmine.createSpy('btnClickHandler');
-      btn.addEventListener('pointerup', btnClickHandler);
-      const rect = btn.getBoundingClientRect();
-      executeMouseEvent('pointerup', btn as any, ex.Input.NativePointerButton.Left, rect.x + rect.width / 2, rect.y + rect.height / 2);
+    await loader.areResourcesLoaded();
+    clock.step(200);
 
-      expect(pointerHandler).not.toHaveBeenCalled();
-      expect(btnClickHandler).toHaveBeenCalled();
-      done();
-    }, 1000);
+    const btn = (loader as any)._playButton;
+    const btnClickHandler = jasmine.createSpy('btnClickHandler');
+    btn.addEventListener('pointerup', btnClickHandler);
+    const rect = btn.getBoundingClientRect();
+    executeMouseEvent('pointerup', btn as any, ex.Input.NativePointerButton.Left, rect.x + rect.width / 2, rect.y + rect.height / 2);
+
+    expect(pointerHandler).not.toHaveBeenCalled();
+    expect(btnClickHandler).toHaveBeenCalled();
   });
 
   it('updates the play button postion on resize', () => {

--- a/src/spec/ParticleSpec.ts
+++ b/src/spec/ParticleSpec.ts
@@ -42,6 +42,9 @@ describe('A particle', () => {
     engine.addScene('root', scene);
     engine.start();
 
+    const clock = engine.clock as ex.TestClock;
+    clock.step(1);
+
     texture = new ex.LegacyDrawing.Texture('src/spec/images/SpriteFontSpec/SpriteFont.png', true);
   });
   afterEach(() => {

--- a/src/spec/PointerInputSpec.ts
+++ b/src/spec/PointerInputSpec.ts
@@ -27,7 +27,7 @@ describe('A pointer', () => {
       pointerScope: ex.Input.PointerScope.Document
     });
     engine.start();
-    
+
     const clock = engine.clock as ex.TestClock;
     clock.step(1);
   });

--- a/src/spec/PointerInputSpec.ts
+++ b/src/spec/PointerInputSpec.ts
@@ -27,6 +27,9 @@ describe('A pointer', () => {
       pointerScope: ex.Input.PointerScope.Document
     });
     engine.start();
+    
+    const clock = engine.clock as ex.TestClock;
+    clock.step(1);
   });
 
   afterEach(() => {

--- a/src/spec/ResourceSpec.ts
+++ b/src/spec/ResourceSpec.ts
@@ -39,6 +39,11 @@ describe('A generic Resource', () => {
         game.stop();
         done();
       });
+
+      emptyLoader.areResourcesLoaded().then(() => {
+        const clock = game.clock as ex.TestClock;
+        clock.step(200);
+      })
     });
   });
 

--- a/src/spec/ResourceSpec.ts
+++ b/src/spec/ResourceSpec.ts
@@ -34,16 +34,11 @@ describe('A generic Resource', () => {
     it('should not fail on load', (done) => {
       const emptyLoader = new ex.Loader();
       const game = TestUtils.engine();
-      game.start(emptyLoader).then(() => {
+      TestUtils.runToReady(game, emptyLoader).then(() => {
         expect(emptyLoader.isLoaded()).toBe(true);
         game.stop();
         done();
       });
-
-      emptyLoader.areResourcesLoaded().then(() => {
-        const clock = game.clock as ex.TestClock;
-        clock.step(200);
-      })
     });
   });
 

--- a/src/spec/ScaleSpec.ts
+++ b/src/spec/ScaleSpec.ts
@@ -29,7 +29,7 @@ describe('A scaled and rotated actor', () => {
     const clock = engine.clock as ex.TestClock;
     const bg = new ex.LegacyDrawing.Texture('./src/spec/images/ScaleSpec/logo.png', true);
     const loader = new ex.Loader([bg]);
-    engine.start(loader).then(() => {
+    TestUtils.runToReady(engine, loader).then(() => {
       const actor = new ex.Actor({
         x: engine.halfDrawWidth,
         y: engine.halfDrawHeight,
@@ -42,7 +42,7 @@ describe('A scaled and rotated actor', () => {
       engine.add(actor);
 
       actor.rotation = Math.PI / 2;
-        
+
       actor.on('postdraw', (ev: ex.PostDrawEvent) => {
         engine.stop();
         ensureImagesLoaded(engine.canvas, 'src/spec/images/ScaleSpec/scale.png').then(([canvas, image]) => {
@@ -50,11 +50,7 @@ describe('A scaled and rotated actor', () => {
           done();
         });
       });
-      clock.step(500);
-    });
-
-    loader.areResourcesLoaded().then(() => {
-      clock.step(200);
+      clock.step(1);
     });
   });
 });

--- a/src/spec/ScaleSpec.ts
+++ b/src/spec/ScaleSpec.ts
@@ -26,9 +26,10 @@ describe('A scaled and rotated actor', () => {
   });
 
   it('is drawn correctly scaled at 90 degrees', (done) => {
+    const clock = engine.clock as ex.TestClock;
     const bg = new ex.LegacyDrawing.Texture('./src/spec/images/ScaleSpec/logo.png', true);
-
-    engine.start(new ex.Loader([bg])).then(() => {
+    const loader = new ex.Loader([bg]);
+    engine.start(loader).then(() => {
       const actor = new ex.Actor({
         x: engine.halfDrawWidth,
         y: engine.halfDrawHeight,
@@ -41,7 +42,7 @@ describe('A scaled and rotated actor', () => {
       engine.add(actor);
 
       actor.rotation = Math.PI / 2;
-
+        
       actor.on('postdraw', (ev: ex.PostDrawEvent) => {
         engine.stop();
         ensureImagesLoaded(engine.canvas, 'src/spec/images/ScaleSpec/scale.png').then(([canvas, image]) => {
@@ -49,6 +50,11 @@ describe('A scaled and rotated actor', () => {
           done();
         });
       });
+      clock.step(500);
+    });
+
+    loader.areResourcesLoaded().then(() => {
+      clock.step(200);
     });
   });
 });

--- a/src/spec/SceneSpec.ts
+++ b/src/spec/SceneSpec.ts
@@ -673,7 +673,6 @@ describe('A scene', () => {
     });
 
     it('can have onInitialize overridden safely', () => {
-      TestUtils.runToReady(engine);
       const clock = engine.clock as ex.TestClock;
       let initCalled = false;
       scene.onInitialize = (engine) => {
@@ -686,6 +685,7 @@ describe('A scene', () => {
 
       spyOn(scene, 'onInitialize').and.callThrough();
 
+      TestUtils.runToReady(engine);
       engine.goToScene('root');
       clock.step(100);
 

--- a/src/spec/SceneSpec.ts
+++ b/src/spec/SceneSpec.ts
@@ -19,6 +19,9 @@ describe('A scene', () => {
     engine.addScene('root', scene);
     engine.goToScene('root');
     engine.start();
+
+    const clock = engine.clock as ex.TestClock;
+    clock.step(100);
   });
 
   afterEach(() => {
@@ -343,6 +346,8 @@ describe('A scene', () => {
 
     engine.goToScene('root');
     engine.start();
+    const clock = engine.clock as ex.TestClock;
+    clock.step(100);
   });
 
   it('fires initialize before actor initialize before activate', (done) => {
@@ -372,22 +377,26 @@ describe('A scene', () => {
     scene.add(actor);
     engine.goToScene('root');
     engine.start();
+    const clock = engine.clock as ex.TestClock;
+    clock.step(100);
   });
 
   it('can only be initialized once', () => {
     engine = TestUtils.engine({ width: 100, height: 100 });
+    const clock = engine.clock as ex.TestClock;
     scene = new ex.Scene();
-
+    
     engine.removeScene('root');
     engine.addScene('root', scene);
-
+    
     let initializeCount = 0;
     scene.on('initialize', (evt) => {
       initializeCount++;
     });
-
+    
     engine.goToScene('root');
     engine.start();
+    clock.step(1);
     scene.update(engine, 100);
     scene.update(engine, 100);
     scene._initialize(engine);
@@ -399,6 +408,7 @@ describe('A scene', () => {
 
   it('should initialize before actors in the scene', () => {
     engine = TestUtils.engine({ width: 100, height: 100 });
+    const clock = engine.clock as ex.TestClock;
     scene = new ex.Scene();
 
     engine.removeScene('root');
@@ -416,6 +426,7 @@ describe('A scene', () => {
 
     engine.goToScene('root');
     engine.start();
+    clock.step(1);
     scene.update(engine, 100);
   });
 

--- a/src/spec/SceneSpec.ts
+++ b/src/spec/SceneSpec.ts
@@ -385,15 +385,15 @@ describe('A scene', () => {
     engine = TestUtils.engine({ width: 100, height: 100 });
     const clock = engine.clock as ex.TestClock;
     scene = new ex.Scene();
-    
+
     engine.removeScene('root');
     engine.addScene('root', scene);
-    
+
     let initializeCount = 0;
     scene.on('initialize', (evt) => {
       initializeCount++;
     });
-    
+
     engine.goToScene('root');
     engine.start();
     clock.step(1);

--- a/src/spec/SceneSpec.ts
+++ b/src/spec/SceneSpec.ts
@@ -673,6 +673,8 @@ describe('A scene', () => {
     });
 
     it('can have onInitialize overridden safely', () => {
+      TestUtils.runToReady(engine);
+      const clock = engine.clock as ex.TestClock;
       let initCalled = false;
       scene.onInitialize = (engine) => {
         expect(engine).not.toBe(null);
@@ -685,7 +687,7 @@ describe('A scene', () => {
       spyOn(scene, 'onInitialize').and.callThrough();
 
       engine.goToScene('root');
-      (<any>engine)._update(100);
+      clock.step(100);
 
       expect(initCalled).toBe(true);
       expect(scene.onInitialize).toHaveBeenCalledTimes(1);

--- a/src/spec/ScreenElementSpec.ts
+++ b/src/spec/ScreenElementSpec.ts
@@ -27,6 +27,9 @@ describe('A ScreenElement', () => {
     engine.goToScene('test');
     engine.start();
 
+    const clock = engine.clock as ex.TestClock;
+    clock.step(1);
+
     spyOn(scene, 'draw').and.callThrough();
     spyOn(screenElement, 'draw').and.callThrough();
   });
@@ -92,9 +95,11 @@ describe('A ScreenElement', () => {
 
   it('is drawn on the top left with empty constructor', (done) => {
     const game = TestUtils.engine({ width: 720, height: 480 });
+    const clock = game.clock as ex.TestClock;
     const bg = new ex.LegacyDrawing.Texture('src/spec/images/ScreenElementSpec/emptyctor.png', true);
+    const loader = new ex.Loader([bg]);
 
-    game.start(new ex.Loader([bg])).then(() => {
+    game.start(loader).then(() => {
       const screenElement = new ex.ScreenElement();
       screenElement.addDrawing(bg);
       game.add(screenElement);
@@ -107,6 +112,11 @@ describe('A ScreenElement', () => {
           done();
         });
       });
+      clock.step(500);
+    });
+
+    loader.areResourcesLoaded().then(() => {
+      clock.step(200);
     });
   });
 });

--- a/src/spec/ScreenElementSpec.ts
+++ b/src/spec/ScreenElementSpec.ts
@@ -7,7 +7,6 @@ describe('A ScreenElement', () => {
   let screenElement: ex.ScreenElement;
   let engine: ex.Engine;
   let scene: ex.Scene;
-  const mock = new Mocks.Mocker();
 
   beforeEach(() => {
     jasmine.addMatchers(ExcaliburMatchers);
@@ -98,8 +97,7 @@ describe('A ScreenElement', () => {
     const clock = game.clock as ex.TestClock;
     const bg = new ex.LegacyDrawing.Texture('src/spec/images/ScreenElementSpec/emptyctor.png', true);
     const loader = new ex.Loader([bg]);
-
-    game.start(loader).then(() => {
+    TestUtils.runToReady(game, loader).then(() => {
       const screenElement = new ex.ScreenElement();
       screenElement.addDrawing(bg);
       game.add(screenElement);
@@ -112,11 +110,7 @@ describe('A ScreenElement', () => {
           done();
         });
       });
-      clock.step(500);
-    });
-
-    loader.areResourcesLoaded().then(() => {
-      clock.step(200);
+      clock.step(1);
     });
   });
 });

--- a/src/spec/TileMapSpec.ts
+++ b/src/spec/TileMapSpec.ts
@@ -17,7 +17,7 @@ describe('A TileMap', () => {
   let engine: ex.Engine;
   let scene: ex.Scene;
   let texture: ex.LegacyDrawing.Texture;
-  beforeEach(() => {
+  beforeEach(async () => {
     jasmine.addMatchers(ExcaliburMatchers);
     jasmine.addAsyncMatchers(ExcaliburAsyncMatchers);
     engine = TestUtils.engine({
@@ -27,8 +27,10 @@ describe('A TileMap', () => {
     scene = new ex.Scene();
     engine.addScene('root', scene);
     engine.start();
-
+    const clock = engine.clock as ex.TestClock;
     texture = new ex.LegacyDrawing.Texture('src/spec/images/TileMapSpec/Blocks.png', true);
+    await texture.load();
+    clock.step(1);
   });
   afterEach(() => {
     engine.stop();

--- a/src/spec/TimescalingSpec.ts
+++ b/src/spec/TimescalingSpec.ts
@@ -5,21 +5,18 @@ import { TestUtils } from './util/TestUtils';
 describe('The engine', () => {
   let engine: ex.Engine;
   let scene: ex.Scene;
-  const mock = new Mocks.Mocker();
-  let loop: Mocks.GameLoopLike;
   let actor: ex.Actor;
+  let clock: ex.TestClock;
 
-  beforeEach((done) => {
+  beforeEach(async () => {
     engine = TestUtils.engine({ width: 0, height: 0 });
     scene = new ex.Scene();
     engine.add('test', scene);
     engine.goToScene('test');
     actor = new ex.Actor({x: 0, y: 0, width: 10, height: 10, color: ex.Color.Red});
     scene.add(actor);
-    loop = mock.loop(engine);
-    engine.start().then(() => {
-      done();
-    });
+    clock = engine.clock as ex.TestClock;
+    await TestUtils.runToReady(engine);
   });
 
   afterEach(() => {
@@ -40,7 +37,7 @@ describe('The engine', () => {
     // 1s = 5px
     // 5px * 2x = 10px
     // actor moves twice as fast
-    loop.advance(1100);
+    clock.step(1000);
 
     expect(actor.pos.x).toBe(10, 'actor did not move twice as fast');
   });
@@ -54,7 +51,7 @@ describe('The engine', () => {
     // 2s = 10px
     // 10px * 0.5x = 5px
     // actor moves twice as slow
-    loop.advance(2000);
+    clock.step(2000);
 
     expect(actor.pos.x).toBeCloseTo(5, 0.2, 'actor did not move twice as slow');
   });

--- a/src/spec/TriggerSpec.ts
+++ b/src/spec/TriggerSpec.ts
@@ -5,19 +5,17 @@ import { TestUtils } from './util/TestUtils';
 describe('A Trigger', () => {
   let scene: ex.Scene;
   let engine: ex.Engine;
-  const mock = new Mocks.Mocker();
-  let loop: Mocks.GameLoopLike;
+  let clock: ex.TestClock;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     engine = TestUtils.engine({ width: 600, height: 400 });
 
     scene = new ex.Scene();
     engine.addScene('test', scene);
     engine.goToScene('test');
 
-    loop = mock.loop(engine);
-    engine.start();
-    const clock = engine.clock as ex.TestClock;
+    await TestUtils.runToReady(engine);
+    clock = engine.clock as ex.TestClock;
     clock.step(1);
   });
 
@@ -153,9 +151,7 @@ describe('A Trigger', () => {
 
     // Act
     actor.vel = ex.vec(0, 10);
-    for (let i = 0; i < 40; i++) {
-      loop.advance(1000);
-    }
+    clock.run(40, 1000);
 
     expect(fired).toBe(1);
   });
@@ -183,9 +179,7 @@ describe('A Trigger', () => {
 
     // Act
     actor.vel = ex.vec(0, 10);
-    for (let i = 0; i < 40; i++) {
-      loop.advance(1000);
-    }
+    clock.run(40, 1000);
 
     // Assert
     expect(exitSpy).toHaveBeenCalledTimes(1);
@@ -204,9 +198,7 @@ describe('A Trigger', () => {
 
     spyOn(trigger, 'draw');
     // Act
-    for (let i = 0; i < 2; i++) {
-      loop.advance(1000);
-    }
+    clock.run(2, 1000);
 
     // Assert
     expect(trigger.draw).not.toHaveBeenCalled();
@@ -225,9 +217,7 @@ describe('A Trigger', () => {
 
     spyOn(trigger, 'draw');
     // Act
-    for (let i = 0; i < 2; i++) {
-      loop.advance(1000);
-    }
+    clock.run(2, 1000);
 
     // Assert
     expect(trigger.draw).toHaveBeenCalled();
@@ -251,9 +241,7 @@ describe('A Trigger', () => {
     spyOn(trigger, 'action');
 
     // Act
-    for (let i = 0; i < 2; i++) {
-      loop.advance(1000);
-    }
+    clock.run(2, 1000);
 
     // Assert
     expect(trigger.action).not.toHaveBeenCalled();
@@ -279,9 +267,7 @@ describe('A Trigger', () => {
     spyOn(trigger, 'action').and.callThrough();
 
     // Act
-    for (let i = 0; i < 2; i++) {
-      loop.advance(1000);
-    }
+    clock.run(2, 1000);
 
     // Assert
     expect(trigger.action).toHaveBeenCalled();
@@ -305,9 +291,7 @@ describe('A Trigger', () => {
     spyOn(trigger, 'action');
 
     // Act
-    for (let i = 0; i < 2; i++) {
-      loop.advance(1000);
-    }
+    clock.run(2, 1000);
 
     // Assert
     expect(trigger.action).not.toHaveBeenCalled();

--- a/src/spec/TriggerSpec.ts
+++ b/src/spec/TriggerSpec.ts
@@ -17,6 +17,8 @@ describe('A Trigger', () => {
 
     loop = mock.loop(engine);
     engine.start();
+    const clock = engine.clock as ex.TestClock;
+    clock.step(1);
   });
 
   afterEach(() => {

--- a/src/spec/util/TestUtils.ts
+++ b/src/spec/util/TestUtils.ts
@@ -35,6 +35,9 @@ export namespace TestUtils {
     return game;
   }
 
+  /**
+   *
+   */
   export async function runToReady(engine: ex.Engine, loader?: ex.Loader) {
     const clock = engine.clock as ex.TestClock;
     const start = engine.start(loader);

--- a/src/spec/util/TestUtils.ts
+++ b/src/spec/util/TestUtils.ts
@@ -34,4 +34,18 @@ export namespace TestUtils {
 
     return game;
   }
+
+  export async function runToReady(engine: ex.Engine, loader?: ex.Loader) {
+    const clock = engine.clock as ex.TestClock;
+    const start = engine.start(loader);
+    // If loader
+    if (loader) {
+      await loader.areResourcesLoaded();
+      clock.step(200);
+      queueMicrotask(() => {
+        clock.step(500);
+      });
+      await engine.isReady();
+    }
+  }
 }

--- a/src/spec/util/TestUtils.ts
+++ b/src/spec/util/TestUtils.ts
@@ -26,6 +26,12 @@ export namespace TestUtils {
     flags.forEach(f => ex.Flags.enable(f));
     const game = new ex.Engine(options);
 
+    // Make all the clocks test clocks in the test utils
+    game.clock.stop();
+    game.clock = game.clock.toTestClock();
+
+    (ex.WebAudio as any)._UNLOCKED = true;
+
     return game;
   }
 }

--- a/wallaby.js
+++ b/wallaby.js
@@ -4,6 +4,7 @@ const webpack = require('webpack');
 module.exports = function (wallaby) {
   return {
     files: [
+      { pattern: 'src/spec/util/*.ts', load: false },
       { pattern: 'src/engine/**/*.ts', load: false },
       { pattern: 'src/engine/**/*.glsl', load: false },
       { pattern: 'src/spec/images/**/*.mp3' },


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes: #1170 
Closes: #577 

This PR implements a new Clock api to manage the core main loop. Clocks hide the implementation detail of how the mainloop runs, users just knows that it ticks somehow. Clocks additionally encapsulate any related browser timing, like `performance.now()`

1. `StandardClock` encapsulates the existing `requestAnimationFrame` api logic
2. `TestClock` allows a user to manually step the mainloop, this can be useful for frame by frame debugging #1170 
3. The base abstract clock implements the specifics of elapsed time 

* The new `maxFps` option is added to the engine constructor options. This is achieved by exiting the mainloop early in clock if the current elapsed time does not match the desired fps. This can be useful when you want to deliver a consistent experience across devices.

## Some fixed bugs that were illuminated as part of this
- Excalibur's initialize flow was flawed, this PR refactors the start() to mean "ready for game code to run", before it actually meant resources loaded and player clicked play
- Play button wasn't positioned until first update, now positioned on init
- Systems were not initialized until first update, now initialized with the scene

## Current game start flow

### After this PR (consolidate init before start resolves)

1. game.start(loader)
2. clock started
3. load resources
4. compute resolution 
5. run engine/scene/ecs system initialize
6. emit ready
7. start the game

### Before

1. game.start(loader);
2. mainloop raf started
3. load resources
4. run some initialize logic
5. compute resolution
4. start game
5. run initialize logic

## Changes:

- New Clock API for managing the mainloop
- Added `maxFps` engine option to constrain to a maximum fps 
- Updated fps sampling to be more useful
- Updates the tests to use the new TestClock (fun side-effect tests are ~20 seconds faster in CI!)
- Some small bug fixes that are related to clock timings