### PR TITLE
fix: Clock runs game simulation too fast sometimes when limiting fps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed unreleased issue where clock when constraining fps would pass larger than expected elapsed times to the simulation causing things to "speed up" bizarrely
 - Fixed unreleased issue where games with no resources would crash
 - Fixed issue [#2152] where shared state in `ex.Font` and `ex.SpriteFont` prevented text from aligning properly when re-used
 - Fixed issue where fast moving `CompositeCollider`s were erroneously generating pairs for their constituent parts

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -130,8 +130,8 @@ var game = new ex.Engine({
   maxFps: 60
 });
 
-var colorblind = new ex.ColorBlindnessPostProcessor(ex.ColorBlindnessMode.Deuteranope);
-game.graphicsContext.addPostProcessor(colorblind);
+// var colorblind = new ex.ColorBlindnessPostProcessor(ex.ColorBlindnessMode.Deuteranope);
+// game.graphicsContext.addPostProcessor(colorblind);
 
 fullscreenButton.addEventListener('click', () => {
   if (game.screen.isFullScreen) {
@@ -266,7 +266,7 @@ var spriteFont = new ex.SpriteFont({
 });
 
 var spriteText = new ex.Text({
-  text: 'Sprite Text ❤️',
+  text: 'Sprite Text',
   font: spriteFont
 });
 

--- a/src/engine/Util/Clock.ts
+++ b/src/engine/Util/Clock.ts
@@ -122,8 +122,8 @@ export abstract class Clock {
         let leftover = 0;
         if (fpsInterval !== 0) {
           leftover = (elapsed % fpsInterval);
+          elapsed = elapsed - leftover; // shift elapsed to be "in phase" with the current loop fps
         }
-        elapsed = elapsed - leftover; // shift elapsed to be "in phase" with the current loop fps
 
         // Resolves issue #138 if the game has been paused, or blurred for
         // more than a 200 milliseconds, reset elapsed time to 1. This improves reliability

--- a/src/engine/Util/Clock.ts
+++ b/src/engine/Util/Clock.ts
@@ -115,11 +115,16 @@ export abstract class Clock {
       let elapsed = now - this._lastTime || 1; // first frame
 
       // Constrain fps
-      const fpsInterval = 1000 / this._maxFps;
+      const fpsInterval = (1000 / this._maxFps);
 
       // only run frame if enough time has elapsed
-      if (elapsed > fpsInterval) {
-        
+      if (elapsed >= fpsInterval) {
+        let leftover = 0;
+        if (fpsInterval !== 0) {
+          leftover = (elapsed % fpsInterval);
+        }
+        elapsed = elapsed - leftover; // shift elapsed to be "in phase" with the current loop fps
+
         // Resolves issue #138 if the game has been paused, or blurred for
         // more than a 200 milliseconds, reset elapsed time to 1. This improves reliability
         // and provides more expected behavior when the engine comes back
@@ -132,23 +137,13 @@ export abstract class Clock {
         this._elapsed = overrideUpdateMs || elapsed;
         this._totalElapsed += this._elapsed;
         this._runScheduledCbs();
-        // console.log('Elapsed', elapsed);
         this.tick(overrideUpdateMs || elapsed);
 
-        // if fps interval is not a multple
-        // const numElapsed = Math.floor(elapsed / fpsInterval);
-        // console.log(numElapsed);
-        if (elapsed > 2 * fpsInterval) {
-          elapsed = 0;
-        }
         if (fpsInterval !== 0) {
-          this._lastTime = now - (elapsed % fpsInterval);
+          this._lastTime = now - leftover; 
         } else {
           this._lastTime = now;
         }
-        // } else {
-        //   this._lastTime = now - (elapsed * numElapsed);
-        // }
         this.fpsSampler.end();
       }
     } catch (e) {

--- a/src/engine/Util/Clock.ts
+++ b/src/engine/Util/Clock.ts
@@ -132,7 +132,7 @@ export abstract class Clock {
         if (elapsed > 200) {
           elapsed = 1;
         }
-        
+
         // tick the mainloop and run scheduled callbacks
         this._elapsed = overrideUpdateMs || elapsed;
         this._totalElapsed += this._elapsed;
@@ -140,7 +140,7 @@ export abstract class Clock {
         this.tick(overrideUpdateMs || elapsed);
 
         if (fpsInterval !== 0) {
-          this._lastTime = now - leftover; 
+          this._lastTime = now - leftover;
         } else {
           this._lastTime = now;
         }

--- a/src/spec/ClockSpec.ts
+++ b/src/spec/ClockSpec.ts
@@ -96,6 +96,23 @@ describe('Clocks', () => {
       await testClock.step(500);
       expect(scheduledCb2).toHaveBeenCalledTimes(1);
     });
+
+    it('can limit fps', () => {
+      const tickSpy = jasmine.createSpy('tick');
+      const clock = new ex.TestClock({
+        tick: tickSpy,
+        maxFps: 15,
+        defaultUpdateMs: null
+      });
+
+      clock.start();
+      clock.step(1000 / 15);
+      clock.step(1000 / 15);
+      clock.step(1000 / 15);
+      expect(clock.fpsSampler.fps).toBeCloseTo(15, -1);
+      expect(tickSpy).toHaveBeenCalledWith(1000 / 15);
+      clock.stop();
+    });
   });
 
   describe('A StandardClock', () => {
@@ -129,7 +146,8 @@ describe('Clocks', () => {
       clock.start();
       setTimeout(() => {
         expect(clock.fpsSampler.fps).toBeCloseTo(15, -1);
-        stop();
+        expect(tickSpy).toHaveBeenCalledWith(1000 / 15);
+        clock.stop();
         done();
       }, 300);
     });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR fixes an unreleased issue where sometimes when constraining fps with the clock, the update loop would get out of phase and the `elapsed` time passed to the mainloop could be nearly double the fps. Ironically the clock loops were running correctly, the elapsed time passed to the simulation was wrong.

## Changes:

- Refactored the update to be a little easier to read
- Shifts the update elapsed time to be in-phase with the fps, the loop still counts updates correctly to match fps
