### PR TITLE
fix: Prevent SpriteFonts from logging excessive warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed unreleased issue where SpriteFonts log every frame they detect a misconfigured font.
 - Fixed unreleased issue where clock when constraining fps would pass larger than expected elapsed times to the simulation causing things to "speed up" bizarrely
 - Fixed unreleased issue where games with no resources would crash
 - Fixed issue [#2152] where shared state in `ex.Font` and `ex.SpriteFont` prevented text from aligning properly when re-used

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -266,7 +266,7 @@ var spriteFont = new ex.SpriteFont({
 });
 
 var spriteText = new ex.Text({
-  text: 'Sprite Text',
+  text: 'Sprite Text 💖',
   font: spriteFont
 });
 

--- a/src/engine/Graphics/SpriteFont.ts
+++ b/src/engine/Graphics/SpriteFont.ts
@@ -65,6 +65,8 @@ export class SpriteFont extends Graphic implements FontRenderer {
     this.shadow = shadow ?? this.shadow;
   }
 
+  private _alreadyWarnedAlphabet = false;
+  private _alreadyWarnedSpriteSheet = false;
   private _getCharacterSprites(text: string): Sprite[] {
     const results: Sprite[] = [];
     // handle case insenstive
@@ -78,14 +80,22 @@ export class SpriteFont extends Graphic implements FontRenderer {
       let spriteIndex = alphabet.indexOf(letter);
       if (spriteIndex === -1) {
         spriteIndex = 0;
-        this._logger.warn(`SpriteFont - Cannot find letter '${letter}' in configured alphabet '${alphabet}'`);
+        if (!this._alreadyWarnedAlphabet) {
+          this._logger.warn(`SpriteFont - Cannot find letter '${letter}' in configured alphabet '${alphabet}'.`);
+          this._logger.warn('There maybe be more issues in the SpriteFont configuration. No additional warnings will be logged.');
+          this._alreadyWarnedAlphabet = true;
+        }
       }
 
       const letterSprite = this.spriteSheet.sprites[spriteIndex];
       if (letterSprite) {
         results.push(letterSprite);
       } else {
-        this._logger.warn(`SpriteFont - Cannot find sprite for '${letter}' at index '${spriteIndex}' in configured SpriteSheet`);
+        if (!this._alreadyWarnedSpriteSheet) {
+          this._logger.warn(`SpriteFont - Cannot find sprite for '${letter}' at index '${spriteIndex}' in configured SpriteSheet`);
+          this._logger.warn('There maybe be more issues in the SpriteFont configuration. No additional warnings will be logged.');
+          this._alreadyWarnedSpriteSheet = true;
+        }
       }
     }
     return results;

--- a/src/spec/GraphicsTextSpec.ts
+++ b/src/spec/GraphicsTextSpec.ts
@@ -720,13 +720,21 @@ describe('A Text Graphic', () => {
 
     sut.text = '~';
     sut.draw(ctx, 0, 0);
-    expect(logger.warn).toHaveBeenCalledWith(
-      'SpriteFont - Cannot find letter \'~\' in configured alphabet \'0123456789abcdefghijklmnopqrstuvwxyz,!\'&."?- \''
-    );
-
-    sut.text = '?';
     sut.draw(ctx, 0, 0);
-    expect(logger.warn).toHaveBeenCalledWith('SpriteFont - Cannot find sprite for \'?\' at index \'42\' in configured SpriteSheet');
+    const warnSpy = logger.warn as jasmine.Spy;
+    expect(warnSpy.calls.argsFor(0)).toEqual([
+      'SpriteFont - Cannot find letter \'~\' in configured alphabet \'0123456789abcdefghijklmnopqrstuvwxyz,!\'&."?- \'.']);
+    expect(warnSpy.calls.argsFor(1)).toEqual([
+      'There maybe be more issues in the SpriteFont configuration. No additional warnings will be logged.']);
+    expect(warnSpy.calls.argsFor(2)).toEqual([]); // warn only once
+      sut.text = '?';
+    sut.draw(ctx, 0, 0);
+    sut.draw(ctx, 0, 0);
+    expect(warnSpy.calls.argsFor(2)).toEqual([
+      'SpriteFont - Cannot find sprite for \'?\' at index \'42\' in configured SpriteSheet']);
+    expect(warnSpy.calls.argsFor(3)).toEqual([
+      'There maybe be more issues in the SpriteFont configuration. No additional warnings will be logged.']);
+    expect(warnSpy.calls.argsFor(4)).toEqual([]); // warn only once
   });
 
   it('can do some simple shadowing', async () => {

--- a/src/spec/GraphicsTextSpec.ts
+++ b/src/spec/GraphicsTextSpec.ts
@@ -727,7 +727,7 @@ describe('A Text Graphic', () => {
     expect(warnSpy.calls.argsFor(1)).toEqual([
       'There maybe be more issues in the SpriteFont configuration. No additional warnings will be logged.']);
     expect(warnSpy.calls.argsFor(2)).toEqual([]); // warn only once
-      sut.text = '?';
+    sut.text = '?';
     sut.draw(ctx, 0, 0);
     sut.draw(ctx, 0, 0);
     expect(warnSpy.calls.argsFor(2)).toEqual([


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR changes SpriteFonts to log once per detected issue.

## Changes:

- Update SpriteFont warning tests
