### PR TITLE
feat: Support image filtering modes on ImageSource & Raster Graphics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added support for different webgl texture blending modes as `ex.ImageFiltering` :
+  * `ex.ImageFiltering.Blended` -  Blended is useful when you have high resolution artwork and would like it blended and smoothed
+  * `ex.ImageFiltering.Pixel` - Pixel is useful when you do not want smoothing aka antialiasing applied to your graphics.
+- Excalibur will set a "default" blend mode based on the `ex.EngineOption` antialiasing property, but can be overridden per graphic
+  - `antialiasing: true`, then the blend mode defaults to  `ex.ImageFiltering.Blended`
+  - `antialiasing: false`, then the blend mode defaults to `ex.ImageFiltering.Pixel`
+- `ex.Text/ex.Font` defaults to blended which improves the default look of text rendering dramatically!
+- `ex.Circle` and `ex.Polygon` also default to blended which improves the default look dramatically!
+- `ex.ImageSource` can now specify a blend mode before the Image is loaded, otherwise
 - Added new `measureText` method to the `ex.SpriteFont` and `ex.Font` to return the bounds of any particular text
 - Added new `Clock` api to manage the core main loop. Clocks hide the implementation detail of how the mainloop runs, users just knows that it ticks somehow. Clocks additionally encapsulate any related browser timing, like `performance.now()`
   1. `StandardClock` encapsulates the existing `requestAnimationFrame` api logic

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -147,10 +147,10 @@ bootstrap(game);
 
 var heartTex = new ex.ImageSource('../images/heart.png');
 var heartImageSource = new ex.ImageSource('../images/heart.png');
-var imageRun = new ex.ImageSource('../images/PlayerRun.png');
+var imageRun = new ex.ImageSource('../images/PlayerRun.png', false, ex.ImageFiltering.Blended);
 var imageJump = new ex.ImageSource('../images/PlayerJump.png');
 var imageRun2 = new ex.ImageSource('../images/PlayerRun.png');
-var imageBlocks = new ex.ImageSource('../images/BlockA0.png');
+var imageBlocks = new ex.ImageSource('../images/BlockA0.png', false, ex.ImageFiltering.Blended);
 var imageBlocksLegacy = new ex.LegacyDrawing.Texture('../images/BlockA0.png');
 var spriteFontImage = new ex.ImageSource('../images/SpriteFont.png');
 var jump = new ex.Sound('../sounds/jump.wav', '../sounds/jump.mp3');
@@ -189,7 +189,8 @@ newSprite.scale = ex.vec(2, 2);
 
 var circle = new ex.Circle({
   radius: 10,
-  color: ex.Color.Red
+  color: ex.Color.Red,
+  filtering: ex.ImageFiltering.Blended
 });
 
 var rect = new ex.Rectangle({
@@ -384,6 +385,8 @@ var blockSprite = new ex.Sprite({
     height: 49
   }
 });
+otherPointer.get(ex.TransformComponent).z = 100;
+otherPointer.graphics.use(blockSprite);
 // Create spritesheet
 //var spriteSheetRun = new ex.SpriteSheet(imageRun, 21, 1, 96, 96);
 var spriteSheetRun = ex.SpriteSheet.fromImageSource({
@@ -477,7 +480,7 @@ for (var i = 0; i < 36; i++) {
   //var block = new ex.Actor(currentX, 350 + Math.random() * 100, tileBlockWidth, tileBlockHeight, color);
   //block.collisionType = ex.CollisionType.Fixed;
   block.body.group = blockGroup;
-  block.graphics.add(blockAnimation);
+  block.graphics.add(blockSprite);
 
   game.add(block);
 }

--- a/sandbox/tests/gif/animatedGif.ts
+++ b/sandbox/tests/gif/animatedGif.ts
@@ -1,11 +1,11 @@
 /// <reference path="../../lib/excalibur.d.ts" />
 
-// ex.Flags.enable(ex.Legacy.LegacyDrawing)
 var game = new ex.Engine({
   canvasElementId: 'game',
   width: 600,
   height: 400,
-  displayMode: ex.DisplayMode.FitScreen
+  displayMode: ex.DisplayMode.FitScreen,
+  antialiasing: false
 });
 
 game.currentScene.camera.zoom = 2;
@@ -13,7 +13,7 @@ game.currentScene.camera.zoom = 2;
 var gif: ex.Gif = new ex.Gif('./sword.gif', ex.Color.Black);
 var loader = new ex.Loader([gif]);
 game.start(loader).then(() => {
-  var actor = new ex.Actor({x: game.drawWidth / 2, y: game.drawHeight / 2, width: gif.width, height: gif.height});
+  var actor = new ex.Actor({x: game.currentScene.camera.x, y: game.currentScene.camera.y, width: gif.width, height: gif.height});
   actor.graphics.add(gif.toAnimation(500));
   game.add(actor);
 });

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -43,6 +43,7 @@ import { ExcaliburGraphicsContext, ExcaliburGraphicsContext2DCanvas, ExcaliburGr
 import { PointerEventReceiver } from './Input/PointerEventReceiver';
 import { FpsSampler } from './Util/Fps';
 import { Clock, StandardClock } from './Util/Clock';
+import { ImageFiltering } from './Graphics/Filtering';
 
 /**
  * Enum representing the different mousewheel event bubble prevention
@@ -90,6 +91,12 @@ export interface EngineOptions {
 
   /**
    * Optionally specify antialiasing (smoothing), by default true (smooth pixels)
+   * 
+   *  * `true` - useful for high resolution art work you would like smoothed, this also hints excalibur to load images 
+   * with [[ImageFiltering.Blended]]
+   *
+   *  * `false` - useful for pixel art style art work you would like sharp, this also hints excalibur to load images 
+   * with [[ImageFiltering.Pixel]]
    */
   antialiasing?: boolean;
 
@@ -652,7 +659,7 @@ O|===|* >________________>\n\
       pixelRatio: options.suppressHiDPIScaling ? 1 : null
     });
 
-    TextureLoader.imageFiltering = options.antialiasing ? "Linear" : "Pixel"
+    TextureLoader.filtering = options.antialiasing ? ImageFiltering.Blended : ImageFiltering.Pixel
 
     if (options.backgroundColor) {
       this.backgroundColor = options.backgroundColor.clone();

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -91,11 +91,11 @@ export interface EngineOptions {
 
   /**
    * Optionally specify antialiasing (smoothing), by default true (smooth pixels)
-   * 
-   *  * `true` - useful for high resolution art work you would like smoothed, this also hints excalibur to load images 
+   *
+   *  * `true` - useful for high resolution art work you would like smoothed, this also hints excalibur to load images
    * with [[ImageFiltering.Blended]]
    *
-   *  * `false` - useful for pixel art style art work you would like sharp, this also hints excalibur to load images 
+   *  * `false` - useful for pixel art style art work you would like sharp, this also hints excalibur to load images
    * with [[ImageFiltering.Pixel]]
    */
   antialiasing?: boolean;
@@ -659,7 +659,7 @@ O|===|* >________________>\n\
       pixelRatio: options.suppressHiDPIScaling ? 1 : null
     });
 
-    TextureLoader.filtering = options.antialiasing ? ImageFiltering.Blended : ImageFiltering.Pixel
+    TextureLoader.filtering = options.antialiasing ? ImageFiltering.Blended : ImageFiltering.Pixel;
 
     if (options.backgroundColor) {
       this.backgroundColor = options.backgroundColor.clone();

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -39,7 +39,7 @@ import * as Input from './Input/Index';
 import * as Events from './Events';
 import { BrowserEvents } from './Util/Browser';
 import { obsolete } from './Util/Decorators';
-import { ExcaliburGraphicsContext, ExcaliburGraphicsContext2DCanvas, ExcaliburGraphicsContextWebGL } from './Graphics';
+import { ExcaliburGraphicsContext, ExcaliburGraphicsContext2DCanvas, ExcaliburGraphicsContextWebGL, TextureLoader } from './Graphics';
 import { PointerEventReceiver } from './Input/PointerEventReceiver';
 import { FpsSampler } from './Util/Fps';
 import { Clock, StandardClock } from './Util/Clock';
@@ -651,6 +651,8 @@ O|===|* >________________>\n\
       position: options.position,
       pixelRatio: options.suppressHiDPIScaling ? 1 : null
     });
+
+    TextureLoader.imageFiltering = options.antialiasing ? "Linear" : "Pixel"
 
     if (options.backgroundColor) {
       this.backgroundColor = options.backgroundColor.clone();

--- a/src/engine/Graphics/Circle.ts
+++ b/src/engine/Graphics/Circle.ts
@@ -7,7 +7,7 @@ export interface CircleOptions {
 
 /**
  * A circle [[Graphic]] for drawing circles to the [[ExcaliburGraphicsContext]]
- * 
+ *
  * Circles default to [[ImageFiltering.Blended]]
  */
 export class Circle extends Raster {

--- a/src/engine/Graphics/Circle.ts
+++ b/src/engine/Graphics/Circle.ts
@@ -1,3 +1,4 @@
+import { ImageFiltering } from '.';
 import { Raster, RasterOptions } from './Raster';
 
 export interface CircleOptions {
@@ -6,6 +7,8 @@ export interface CircleOptions {
 
 /**
  * A circle [[Graphic]] for drawing circles to the [[ExcaliburGraphicsContext]]
+ * 
+ * Circles default to [[ImageFiltering.Blended]]
  */
 export class Circle extends Raster {
   private _radius: number = 0;
@@ -22,6 +25,7 @@ export class Circle extends Raster {
     super(options);
     this.padding = options.padding ?? 2; // default 2 padding for circles looks nice
     this.radius = options.radius;
+    this.filtering = options.filtering ?? ImageFiltering.Blended;
     this.rasterize();
   }
 

--- a/src/engine/Graphics/Context/texture-loader.ts
+++ b/src/engine/Graphics/Context/texture-loader.ts
@@ -40,6 +40,7 @@ export class TextureLoader {
   /**
    * Loads a graphic into webgl and returns it's texture info, a webgl context must be previously registered
    * @param image Source graphic
+   * @param filtering {ImageFiltering} The ImageFiltering mode to apply to the loaded texture
    * @param forceUpdate Optionally force a texture to be reloaded, useful if the source graphic has changed
    */
   public static load(image: HTMLImageSource, filtering?: ImageFiltering, forceUpdate = false): WebGLTexture {
@@ -75,7 +76,7 @@ export class TextureLoader {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 
-    // NEAREST for pixel art, LINEAR for hi-res 
+    // NEAREST for pixel art, LINEAR for hi-res
     const filterMode = filtering ?? TextureLoader.filtering;
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filterMode === ImageFiltering.Pixel ? gl.NEAREST : gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filterMode === ImageFiltering.Pixel ? gl.NEAREST : gl.LINEAR);

--- a/src/engine/Graphics/Context/texture-loader.ts
+++ b/src/engine/Graphics/Context/texture-loader.ts
@@ -1,3 +1,4 @@
+import { ImageFiltering } from '../Filtering';
 import { HTMLImageSource } from './ExcaliburGraphicsContext';
 import { ensurePowerOfTwo, isPowerOfTwo } from './webgl-util';
 
@@ -5,7 +6,10 @@ import { ensurePowerOfTwo, isPowerOfTwo } from './webgl-util';
  * Manages loading image sources into webgl textures, a unique id is associated with all sources
  */
 export class TextureLoader {
-  public static imageFiltering: "Pixel" | "Linear" = "Pixel";
+  /**
+   * Sets the default filtering for the Excalibur texture loader, default [[ImageFiltering.Blended]]
+   */
+  public static filtering: ImageFiltering = ImageFiltering.Blended;
   private static _POT_CANVAS = document.createElement('canvas');
   private static _POT_CTX = TextureLoader._POT_CANVAS.getContext('2d');
 
@@ -38,7 +42,7 @@ export class TextureLoader {
    * @param image Source graphic
    * @param forceUpdate Optionally force a texture to be reloaded, useful if the source graphic has changed
    */
-  public static load(image: HTMLImageSource, filtering?: "Linear" | "Pixel", forceUpdate = false): WebGLTexture {
+  public static load(image: HTMLImageSource, filtering?: ImageFiltering, forceUpdate = false): WebGLTexture {
     // Ignore loading if webgl is not registered
     const gl = TextureLoader._GL;
     if (!gl) {
@@ -72,9 +76,9 @@ export class TextureLoader {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 
     // NEAREST for pixel art, LINEAR for hi-res 
-    const filterMode = filtering ?? TextureLoader.imageFiltering;
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filterMode === "Pixel" ? gl.NEAREST : gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filterMode === "Pixel" ? gl.NEAREST : gl.LINEAR);
+    const filterMode = filtering ?? TextureLoader.filtering;
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filterMode === ImageFiltering.Pixel ? gl.NEAREST : gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filterMode === ImageFiltering.Pixel ? gl.NEAREST : gl.LINEAR);
 
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source);
 

--- a/src/engine/Graphics/Context/texture-loader.ts
+++ b/src/engine/Graphics/Context/texture-loader.ts
@@ -5,6 +5,7 @@ import { ensurePowerOfTwo, isPowerOfTwo } from './webgl-util';
  * Manages loading image sources into webgl textures, a unique id is associated with all sources
  */
 export class TextureLoader {
+  public static imageFiltering: "Pixel" | "Linear" = "Pixel";
   private static _POT_CANVAS = document.createElement('canvas');
   private static _POT_CTX = TextureLoader._POT_CANVAS.getContext('2d');
 
@@ -37,7 +38,7 @@ export class TextureLoader {
    * @param image Source graphic
    * @param forceUpdate Optionally force a texture to be reloaded, useful if the source graphic has changed
    */
-  public static load(image: HTMLImageSource, forceUpdate = false): WebGLTexture {
+  public static load(image: HTMLImageSource, filtering?: "Linear" | "Pixel", forceUpdate = false): WebGLTexture {
     // Ignore loading if webgl is not registered
     const gl = TextureLoader._GL;
     if (!gl) {
@@ -70,10 +71,10 @@ export class TextureLoader {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 
-    // TODO support different sampler filter?
-    // NEAREST for pixel art
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    // NEAREST for pixel art, LINEAR for hi-res 
+    const filterMode = filtering ?? TextureLoader.imageFiltering;
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filterMode === "Pixel" ? gl.NEAREST : gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filterMode === "Pixel" ? gl.NEAREST : gl.LINEAR);
 
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source);
 

--- a/src/engine/Graphics/Filtering.ts
+++ b/src/engine/Graphics/Filtering.ts
@@ -6,13 +6,13 @@ export enum ImageFiltering {
 
   /**
    * Pixel is useful when you do not want smoothing aka antialiasing applied to your graphics.
-   * 
+   *
    * Useful for Pixel art aesthetics.
    */
-  Pixel = "Pixel",
+  Pixel = 'Pixel',
 
   /**
    * Blended is useful when you have high resolution artwork and would like it blended and smoothed
    */
-  Blended = "Blended"
+  Blended = 'Blended'
 }

--- a/src/engine/Graphics/Filtering.ts
+++ b/src/engine/Graphics/Filtering.ts
@@ -1,0 +1,18 @@
+
+/**
+ * Describes the different image filtering modes
+ */
+export enum ImageFiltering {
+
+  /**
+   * Pixel is useful when you do not want smoothing aka antialiasing applied to your graphics.
+   * 
+   * Useful for Pixel art aesthetics.
+   */
+  Pixel = "Pixel",
+
+  /**
+   * Blended is useful when you have high resolution artwork and would like it blended and smoothed
+   */
+  Blended = "Blended"
+}

--- a/src/engine/Graphics/Font.ts
+++ b/src/engine/Graphics/Font.ts
@@ -85,7 +85,7 @@ export class Font extends Graphic implements FontRenderer {
   public quality = 2;
 
   // Raster properties for fonts
-  public padding = 0;
+  public padding = 2;
   public smoothing = false;
   public lineWidth = 1;
   public lineDash: number[] = [];

--- a/src/engine/Graphics/Font.ts
+++ b/src/engine/Graphics/Font.ts
@@ -19,7 +19,7 @@ import { ImageFiltering } from './Filtering';
 export class Font extends Graphic implements FontRenderer {
   /**
    * Set the font filtering mode, by default set to [[ImageFiltering.Blended]] regardles of the engine default smoothing
-   * 
+   *
    * If you have a pixel style font that may be a reason to switch this to [[ImageFiltering.Pixel]]
    */
   public filtering: ImageFiltering = ImageFiltering.Blended;

--- a/src/engine/Graphics/Font.ts
+++ b/src/engine/Graphics/Font.ts
@@ -7,6 +7,7 @@ import { BaseAlign, Direction, FontOptions, FontStyle, FontUnit, TextAlign, Font
 import { Graphic, GraphicOptions } from './Graphic';
 import { RasterOptions } from './Raster';
 import { TextureLoader } from '.';
+import { ImageFiltering } from './Filtering';
 
 /**
  * Represents a system or web font in Excalibur
@@ -16,6 +17,12 @@ import { TextureLoader } from '.';
  * If loading a custom web font be sure to have the font loaded before you use it https://erikonarheim.com/posts/dont-test-fonts/
  */
 export class Font extends Graphic implements FontRenderer {
+  /**
+   * Set the font filtering mode, by default set to [[ImageFiltering.Blended]] regardles of the engine default smoothing
+   * 
+   * If you have a pixel style font that may be a reason to switch this to [[ImageFiltering.Pixel]]
+   */
+  public filtering: ImageFiltering = ImageFiltering.Blended;
   constructor(options: FontOptions & GraphicOptions & RasterOptions = {}) {
     super(options); // <- Graphics properties
 
@@ -26,6 +33,7 @@ export class Font extends Graphic implements FontRenderer {
     this.strokeColor = options?.strokeColor ?? this.strokeColor;
     this.lineDash = options?.lineDash ?? this.lineDash;
     this.lineWidth = options?.lineWidth ?? this.lineWidth;
+    this.filtering = options?.filtering ?? this.filtering;
 
     // Font specific properts
     this.family = options?.family ?? this.family;
@@ -293,7 +301,7 @@ export class Font extends Graphic implements FontRenderer {
     const rasterHeight = bitmap.canvas.height;
 
     // draws the bitmap to excalibur graphics context
-    TextureLoader.load(bitmap.canvas, this.filterMode, true);
+    TextureLoader.load(bitmap.canvas, this.filtering, true);
     ex.drawImage(
       bitmap.canvas,
       0,

--- a/src/engine/Graphics/Font.ts
+++ b/src/engine/Graphics/Font.ts
@@ -6,6 +6,7 @@ import { ExcaliburGraphicsContext } from './Context/ExcaliburGraphicsContext';
 import { BaseAlign, Direction, FontOptions, FontStyle, FontUnit, TextAlign, FontRenderer } from './FontCommon';
 import { Graphic, GraphicOptions } from './Graphic';
 import { RasterOptions } from './Raster';
+import { TextureLoader } from '.';
 
 /**
  * Represents a system or web font in Excalibur
@@ -292,6 +293,7 @@ export class Font extends Graphic implements FontRenderer {
     const rasterHeight = bitmap.canvas.height;
 
     // draws the bitmap to excalibur graphics context
+    TextureLoader.load(bitmap.canvas, this.filterMode, true);
     ex.drawImage(
       bitmap.canvas,
       0,

--- a/src/engine/Graphics/Graphic.ts
+++ b/src/engine/Graphics/Graphic.ts
@@ -35,10 +35,6 @@ export interface GraphicOptions {
    * The origin of the drawing in pixels to use when applying transforms, by default it will be the center of the image
    */
   origin?: Vector;
-  /**
-   * Optionally specify what image filtering mode should be used, Pixel for pixel art, Linear for hi-res art
-   */
-  filtering?: "Pixel" | "Linear";
 }
 
 /**
@@ -53,7 +49,6 @@ export abstract class Graphic {
   private static _ID: number = 0;
   readonly id = Graphic._ID++;
 
-  public filterMode: "Pixel" | "Linear" = null;
 
   /**
    * Gets or sets wether to show debug information about the graphic
@@ -98,7 +93,6 @@ export abstract class Graphic {
       this.rotation = options.rotation ?? this.rotation;
       this.opacity = options.opacity ?? this.opacity;
       this.scale = options.scale ?? this.scale;
-      this.filterMode = options.filtering ?? this.filterMode;
     }
   }
 
@@ -110,7 +104,6 @@ export abstract class Graphic {
       rotation: this.rotation,
       opacity: this.opacity,
       scale: this.scale ? this.scale.clone() : null,
-      filtering: this.filterMode
     };
   }
 

--- a/src/engine/Graphics/Graphic.ts
+++ b/src/engine/Graphics/Graphic.ts
@@ -35,6 +35,10 @@ export interface GraphicOptions {
    * The origin of the drawing in pixels to use when applying transforms, by default it will be the center of the image
    */
   origin?: Vector;
+  /**
+   * Optionally specify what image filtering mode should be used, Pixel for pixel art, Linear for hi-res art
+   */
+  filtering?: "Pixel" | "Linear";
 }
 
 /**
@@ -48,6 +52,8 @@ export interface GraphicOptions {
 export abstract class Graphic {
   private static _ID: number = 0;
   readonly id = Graphic._ID++;
+
+  public filterMode: "Pixel" | "Linear" = null;
 
   /**
    * Gets or sets wether to show debug information about the graphic
@@ -92,6 +98,7 @@ export abstract class Graphic {
       this.rotation = options.rotation ?? this.rotation;
       this.opacity = options.opacity ?? this.opacity;
       this.scale = options.scale ?? this.scale;
+      this.filterMode = options.filtering ?? this.filterMode;
     }
   }
 
@@ -102,7 +109,8 @@ export abstract class Graphic {
       flipVertical: this.flipVertical,
       rotation: this.rotation,
       opacity: this.opacity,
-      scale: this.scale ? this.scale.clone() : null
+      scale: this.scale ? this.scale.clone() : null,
+      filtering: this.filterMode
     };
   }
 

--- a/src/engine/Graphics/Graphic.ts
+++ b/src/engine/Graphics/Graphic.ts
@@ -103,7 +103,7 @@ export abstract class Graphic {
       flipVertical: this.flipVertical,
       rotation: this.rotation,
       opacity: this.opacity,
-      scale: this.scale ? this.scale.clone() : null,
+      scale: this.scale ? this.scale.clone() : null
     };
   }
 

--- a/src/engine/Graphics/ImageSource.ts
+++ b/src/engine/Graphics/ImageSource.ts
@@ -55,7 +55,7 @@ export class ImageSource implements Loadable<HTMLImageElement> {
    */
   constructor(public readonly path: string, bustCache: boolean = false, filtering?: ImageFiltering) {
     this._resource = new Resource(path, 'blob', bustCache);
-    this._filtering = filtering
+    this._filtering = filtering;
     if (path.endsWith('.svg') || path.endsWith('.gif')) {
       this._logger.warn(`Image type is not fully supported, you may have mixed results ${path}. Fully supported: jpg, bmp, and png`);
     }

--- a/src/engine/Graphics/ImageSource.ts
+++ b/src/engine/Graphics/ImageSource.ts
@@ -3,10 +3,13 @@ import { Texture } from '../Drawing/Texture';
 import { Sprite } from './Sprite';
 import { Loadable } from '../Interfaces/Index';
 import { Logger } from '../Util/Log';
+import { TextureLoader } from '.';
+import { ImageFiltering } from './Filtering';
 
 export class ImageSource implements Loadable<HTMLImageElement> {
   private _logger = Logger.getInstance();
   private _resource: Resource<Blob>;
+  private _filtering: ImageFiltering;
 
   /**
    * The original size of the source image in pixels
@@ -46,10 +49,13 @@ export class ImageSource implements Loadable<HTMLImageElement> {
 
   /**
    * The path to the image, can also be a data url like 'data:image/'
-   * @param path
+   * @param path {string} Path to the image resource relative from the HTML document hosting the game, or absolute
+   * @param bustCache {boolean} Should excalibur add a cache busting querystring?
+   * @param filtering {ImageFiltering} Optionally override the image filtering set by [[EngineOptions.antialiasing]]
    */
-  constructor(public readonly path: string, bustCache: boolean = false) {
+  constructor(public readonly path: string, bustCache: boolean = false, filtering?: ImageFiltering) {
     this._resource = new Resource(path, 'blob', bustCache);
+    this._filtering = filtering
     if (path.endsWith('.svg') || path.endsWith('.gif')) {
       this._logger.warn(`Image type is not fully supported, you may have mixed results ${path}. Fully supported: jpg, bmp, and png`);
     }
@@ -85,6 +91,7 @@ export class ImageSource implements Loadable<HTMLImageElement> {
     } catch (error) {
       throw `Error loading ImageSource from path '${this.path}' with error [${error.message}]`;
     }
+    TextureLoader.load(this.data, this._filtering);
     // todo emit complete
     this._loadedResolve(this.data);
     return this.data;

--- a/src/engine/Graphics/Polygon.ts
+++ b/src/engine/Graphics/Polygon.ts
@@ -8,7 +8,7 @@ export interface PolygonOptions {
 
 /**
  * A polygon [[Graphic]] for drawing arbitrary polygons to the [[ExcaliburGraphicsContext]]
- * 
+ *
  * Polygons default to [[ImageFiltering.Blended]]
  */
 export class Polygon extends Raster {

--- a/src/engine/Graphics/Polygon.ts
+++ b/src/engine/Graphics/Polygon.ts
@@ -1,3 +1,4 @@
+import { ImageFiltering } from '.';
 import { Vector, vec } from '../Math/vector';
 import { Raster, RasterOptions } from './Raster';
 
@@ -7,6 +8,8 @@ export interface PolygonOptions {
 
 /**
  * A polygon [[Graphic]] for drawing arbitrary polygons to the [[ExcaliburGraphicsContext]]
+ * 
+ * Polygons default to [[ImageFiltering.Blended]]
  */
 export class Polygon extends Raster {
   private _points: Vector[];
@@ -30,6 +33,7 @@ export class Polygon extends Raster {
   constructor(options: RasterOptions & PolygonOptions) {
     super(options);
     this.points = options.points;
+    this.filtering = ImageFiltering.Blended;
     this.rasterize();
   }
 

--- a/src/engine/Graphics/Raster.ts
+++ b/src/engine/Graphics/Raster.ts
@@ -41,8 +41,9 @@ export interface RasterOptions {
   padding?: number;
 
   /**
-   * Optionally specify what image filtering mode should be used, [[ImageFiltering.Pixel]] for pixel art, [[ImageFiltering.Blended]] for hi-res art
-   * 
+   * Optionally specify what image filtering mode should be used, [[ImageFiltering.Pixel]] for pixel art,
+   * [[ImageFiltering.Blended]] for hi-res art
+   *
    * By default unset, rasters defer to the engine antialiasing setting
    */
   filtering?: ImageFiltering;

--- a/src/engine/Graphics/Raster.ts
+++ b/src/engine/Graphics/Raster.ts
@@ -6,14 +6,46 @@ import { Vector } from '../Math/vector';
 import { BoundingBox } from '../Collision/BoundingBox';
 import { watch } from '../Util/Watch';
 import { TextureLoader } from './Context/texture-loader';
+import { ImageFiltering } from './Filtering';
+
 
 export interface RasterOptions {
+  /**
+   * Optionally specify "smoothing" if you want antialiasing to apply to the raster's bitmap context, by default `false`
+   */
   smoothing?: boolean;
+
+  /**
+   * Optionally specify the color of the raster's bitmap context, by default [[Color.Black]]
+   */
   color?: Color;
+
+  /**
+   * Optionally specify the stroke color of the raster's bitmap context, by default undefined
+   */
   strokeColor?: Color;
+
+  /**
+   * Optionally specify the line width of the raster's bitmap, by default 1 pixel
+   */
   lineWidth?: number;
+
+  /**
+   * Optionally specify the line dash of the raster's bitmap, by default `[]` which means none
+   */
   lineDash?: number[];
+
+  /**
+   * Optionally specify the padding to apply to the bitmap
+   */
   padding?: number;
+
+  /**
+   * Optionally specify what image filtering mode should be used, [[ImageFiltering.Pixel]] for pixel art, [[ImageFiltering.Blended]] for hi-res art
+   * 
+   * By default unset, rasters defer to the engine antialiasing setting
+   */
+  filtering?: ImageFiltering;
 }
 
 /**
@@ -23,6 +55,7 @@ export interface RasterOptions {
  * Implementors must implemenet the [[Raster.execute]] method to rasterize their drawing.
  */
 export abstract class Raster extends Graphic {
+  public filtering: ImageFiltering = null;
   public _bitmap: HTMLCanvasElement;
   protected _ctx: CanvasRenderingContext2D;
   private _dirty: boolean = true;
@@ -36,6 +69,7 @@ export abstract class Raster extends Graphic {
       this.lineWidth = options.lineWidth ?? this.lineWidth;
       this.lineDash = options.lineDash ?? this.lineDash;
       this.padding = options.padding ?? this.padding;
+      this.filtering = options.filtering ?? this.filtering;
     }
     this._bitmap = document.createElement('canvas');
     // get the default canvas width/height as a fallback
@@ -215,7 +249,7 @@ export abstract class Raster extends Graphic {
     this.execute(this._ctx);
     this._ctx.restore();
     // The webgl texture needs to be updated if it exists after a raster cycle
-    TextureLoader.load(this._bitmap, this.filterMode, true);
+    TextureLoader.load(this._bitmap, this.filtering, true);
   }
 
   protected _applyRasterProperites(ctx: CanvasRenderingContext2D) {

--- a/src/engine/Graphics/Raster.ts
+++ b/src/engine/Graphics/Raster.ts
@@ -37,7 +37,6 @@ export abstract class Raster extends Graphic {
       this.lineDash = options.lineDash ?? this.lineDash;
       this.padding = options.padding ?? this.padding;
     }
-
     this._bitmap = document.createElement('canvas');
     // get the default canvas width/height as a fallback
     const bitmapWidth = options?.width ?? this._bitmap.width;
@@ -216,7 +215,7 @@ export abstract class Raster extends Graphic {
     this.execute(this._ctx);
     this._ctx.restore();
     // The webgl texture needs to be updated if it exists after a raster cycle
-    TextureLoader.load(this._bitmap, true);
+    TextureLoader.load(this._bitmap, this.filterMode, true);
   }
 
   protected _applyRasterProperites(ctx: CanvasRenderingContext2D) {

--- a/src/engine/Graphics/Text.ts
+++ b/src/engine/Graphics/Text.ts
@@ -35,6 +35,7 @@ export class Text extends Graphic {
     this.font = options.font ?? new Font();
     this.color = options.color ?? this.color;
     this.text = options.text;
+    this.filterMode = "Linear";
   }
 
   public clone(): Text {
@@ -113,6 +114,7 @@ export class Text extends Graphic {
     this.font.rotation = this.rotation;
     this.font.origin = this.origin;
     this.font.opacity = this.opacity;
+    this.font.filterMode = this.filterMode;
 
     const { width, height } = this.font.measureText(this._text);
     this._textWidth = width;

--- a/src/engine/Graphics/Text.ts
+++ b/src/engine/Graphics/Text.ts
@@ -35,7 +35,6 @@ export class Text extends Graphic {
     this.font = options.font ?? new Font();
     this.color = options.color ?? this.color;
     this.text = options.text;
-    this.filterMode = "Linear";
   }
 
   public clone(): Text {
@@ -114,7 +113,6 @@ export class Text extends Graphic {
     this.font.rotation = this.rotation;
     this.font.origin = this.origin;
     this.font.opacity = this.opacity;
-    this.font.filterMode = this.filterMode;
 
     const { width, height } = this.font.measureText(this._text);
     this._textWidth = width;

--- a/src/engine/Graphics/index.ts
+++ b/src/engine/Graphics/index.ts
@@ -31,3 +31,5 @@ export * from './Context/debug-text';
 export * from './PostProcessor/PostProcessor';
 export * from './PostProcessor/ColorBlindnessMode';
 export * from './PostProcessor/ColorBlindnessPostProcessor';
+
+export * from './Context/texture-loader';

--- a/src/engine/Graphics/index.ts
+++ b/src/engine/Graphics/index.ts
@@ -33,3 +33,4 @@ export * from './PostProcessor/ColorBlindnessMode';
 export * from './PostProcessor/ColorBlindnessPostProcessor';
 
 export * from './Context/texture-loader';
+export * from './Filtering';

--- a/src/engine/Label.ts
+++ b/src/engine/Label.ts
@@ -41,7 +41,7 @@ export interface LabelOptions {
  */
 export class Label extends Actor {
   public font: Font = new Font();
-  private _text: Text = new Text({ text: '', font: this.font });
+  private _text: Text = new Text({ text: '', font: this.font});
 
   /**
    * The text to draw.

--- a/src/engine/Loader.ts
+++ b/src/engine/Loader.ts
@@ -78,6 +78,7 @@ import { clamp, delay } from './Util/Util';
  */
 export class Loader extends Class implements Loadable<Loadable<any>[]> {
   public canvas: Canvas = new Canvas({
+    filtering: "Linear",
     smoothing: true,
     draw: this.draw.bind(this)
   });

--- a/src/engine/Loader.ts
+++ b/src/engine/Loader.ts
@@ -10,6 +10,7 @@ import loaderCss from './Loader.css';
 import { Canvas } from './Graphics/Canvas';
 import { Vector } from './Math/vector';
 import { clamp, delay } from './Util/Util';
+import { ImageFiltering } from './Graphics/Filtering';
 
 /**
  * Pre-loading assets
@@ -78,7 +79,7 @@ import { clamp, delay } from './Util/Util';
  */
 export class Loader extends Class implements Loadable<Loadable<any>[]> {
   public canvas: Canvas = new Canvas({
-    filtering: "Linear",
+    filtering: ImageFiltering.Blended,
     smoothing: true,
     draw: this.draw.bind(this)
   });

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -80,6 +80,20 @@ describe('The engine', () => {
     expect(engine.screen.resolution.height).toBe(600);
   });
 
+  it('should hint the texture loader image filter to Blended when aa=true', () => {
+    engine = TestUtils.engine({
+      antialiasing: true
+    });
+    expect(ex.TextureLoader.filtering).toBe(ex.ImageFiltering.Blended);
+  });
+
+  it('should hint the texture loader image filter to Pixel when aa=false', () => {
+    engine = TestUtils.engine({
+      antialiasing: false
+    });
+    expect(ex.TextureLoader.filtering).toBe(ex.ImageFiltering.Pixel);
+  });
+
   it('should not show the play button when suppressPlayButton is turned on', (done) => {
     reset();
     engine = TestUtils.engine({

--- a/src/spec/GraphicsCircleSpec.ts
+++ b/src/spec/GraphicsCircleSpec.ts
@@ -20,6 +20,13 @@ describe('A Circle Graphic', () => {
     expect(sut.height).toBe(24);
   });
 
+  it('has default filtering', () => {
+    const sut = new ex.Circle({
+      radius: 10
+    });
+    expect(sut.filtering).toBe(ex.ImageFiltering.Blended);
+  });
+
   it('can have a radius', () => {
     const sut = new ex.Circle({
       padding: 0,

--- a/src/spec/GraphicsImageSourceSpec.ts
+++ b/src/spec/GraphicsImageSourceSpec.ts
@@ -29,6 +29,30 @@ describe('A ImageSource', () => {
     expect(whenLoaded).toHaveBeenCalledTimes(1);
   });
 
+  it('can load images with an image filtering Blended', async () => {
+    spyOn(ex.TextureLoader, 'load').and.callThrough();
+    const spriteFontImage = new ex.ImageSource('src/spec/images/GraphicsTextSpec/spritefont.png', false, ex.ImageFiltering.Blended);
+    const whenLoaded = jasmine.createSpy('whenLoaded');
+    const image = await spriteFontImage.load();
+    await spriteFontImage.ready.then(whenLoaded);
+
+    expect(image.src).not.toBeNull();
+    expect(whenLoaded).toHaveBeenCalledTimes(1);
+    expect(ex.TextureLoader.load).toHaveBeenCalledWith(image, ex.ImageFiltering.Blended);
+  });
+
+  it('can load images with an image filtering Pixel', async () => {
+    spyOn(ex.TextureLoader, 'load').and.callThrough();
+    const spriteFontImage = new ex.ImageSource('src/spec/images/GraphicsTextSpec/spritefont.png', false, ex.ImageFiltering.Pixel);
+    const whenLoaded = jasmine.createSpy('whenLoaded');
+    const image = await spriteFontImage.load();
+    await spriteFontImage.ready.then(whenLoaded);
+
+    expect(image.src).not.toBeNull();
+    expect(whenLoaded).toHaveBeenCalledTimes(1);
+    expect(ex.TextureLoader.load).toHaveBeenCalledWith(image, ex.ImageFiltering.Pixel);
+  });
+
   it('can convert to a Sprite', async () => {
     const spriteFontImage = new ex.ImageSource('src/spec/images/GraphicsTextSpec/spritefont.png');
     const sprite = spriteFontImage.toSprite();

--- a/src/spec/GraphicsPolygonSpec.ts
+++ b/src/spec/GraphicsPolygonSpec.ts
@@ -26,6 +26,14 @@ describe('A Polygon Graphic', () => {
     expect(poly).toBeDefined();
   });
 
+  it('has default filtering', () => {
+    const sut = new ex.Polygon({
+      points: [ex.vec(10 * 5, 0), ex.vec(0, 20 * 5), ex.vec(20 * 5, 20 * 5)],
+      color: ex.Color.Green
+    });
+    expect(sut.filtering).toBe(ex.ImageFiltering.Blended);
+  });
+
   it('can be cloned', () => {
     const poly = new ex.Polygon({
       points: [ex.vec(10 * 5, 0), ex.vec(0, 20 * 5), ex.vec(20 * 5, 20 * 5)],

--- a/src/spec/GraphicsTextSpec.ts
+++ b/src/spec/GraphicsTextSpec.ts
@@ -115,7 +115,8 @@ describe('A Text Graphic', () => {
       font: new ex.Font({
         family: 'Open Sans',
         size: 18,
-        quality: 1
+        quality: 1,
+        padding: 0
       })
     });
 
@@ -143,7 +144,8 @@ describe('A Text Graphic', () => {
       font: new ex.Font({
         family: 'Open Sans',
         size: 18,
-        quality: 1
+        quality: 1,
+        padding: 0
       })
     });
 
@@ -174,7 +176,8 @@ describe('A Text Graphic', () => {
       font: new ex.Font({
         family: 'Open Sans',
         size: 18,
-        quality: 1
+        quality: 1,
+        padding: 0
       })
     });
 
@@ -188,7 +191,8 @@ describe('A Text Graphic', () => {
     const sut = new ex.Font({
       family: 'Open Sans',
       size: 18,
-      quality: 1
+      quality: 1,
+      padding: 0
     });
 
     const bounds = sut.measureText('some extra long text that we want to measure');
@@ -203,7 +207,8 @@ describe('A Text Graphic', () => {
       font: new ex.Font({
         family: 'Open Sans',
         size: 18,
-        quality: 1
+        quality: 1,
+        padding: 0
       })
     });
 
@@ -233,7 +238,8 @@ describe('A Text Graphic', () => {
       font: new ex.Font({
         family: 'Open Sans',
         size: 18,
-        quality: 1
+        quality: 1,
+        padding: 0
       })
     });
 
@@ -263,7 +269,8 @@ describe('A Text Graphic', () => {
       font: new ex.Font({
         family: 'Open Sans',
         size: 18,
-        quality: 1
+        quality: 1,
+        padding: 0
       })
     });
 
@@ -293,7 +300,8 @@ describe('A Text Graphic', () => {
       font: new ex.Font({
         family: 'Open Sans',
         size: 18,
-        quality: 1
+        quality: 1,
+        padding: 0
       })
     });
 
@@ -323,7 +331,8 @@ describe('A Text Graphic', () => {
       font: new ex.Font({
         family: 'Open Sans',
         size: 18,
-        quality: 1
+        quality: 1,
+        padding: 0
       })
     });
 
@@ -354,7 +363,8 @@ describe('A Text Graphic', () => {
         family: 'Open Sans',
         bold: true,
         size: 18,
-        quality: 1
+        quality: 1,
+        padding: 0
       })
     });
 
@@ -383,7 +393,8 @@ describe('A Text Graphic', () => {
         family: 'Open Sans',
         style: ex.FontStyle.Italic,
         size: 18,
-        quality: 1
+        quality: 1,
+        padding: 0
       })
     });
 
@@ -412,6 +423,7 @@ describe('A Text Graphic', () => {
         family: 'Open Sans',
         size: 18,
         quality: 1,
+        padding: 0,
         shadow: {
           blur: 5,
           offset: ex.vec(4, 4),

--- a/src/spec/GraphicsTextSpec.ts
+++ b/src/spec/GraphicsTextSpec.ts
@@ -94,6 +94,14 @@ describe('A Text Graphic', () => {
     expect(sut).toBeDefined();
   });
 
+  it('defaults to blended', () => {
+    const sut = new ex.Text({
+      text: 'yo'
+    });
+    const font = sut.font as ex.Font;
+    expect(font.filtering).toBe(ex.ImageFiltering.Blended);
+  });
+
   it('can be cloned', () => {
     const sut = new ex.Text({
       text: 'some text',


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Related to the roadmap for v0.26.0 #1161, this PR exposes different webgl texture blending modes to the user. I've attempted to give them names that are indicative of their function.

* `ex.ImageFiltering.Blended` -  Blended is useful when you have high resolution artwork and would like it blended and smoothed
* `ex.ImageFiltering.Pixel` - Pixel is useful when you do not want smoothing aka antialiasing applied to your graphics.

After the v0.25.0 and the switch to webgl, Excalibur really only catered to pixel art styles, now supports hi-res art styles as well!

## Changes:
- Excalibur will set a "default" blend mode based on the `ex.EngineOption` antialiasing property, but can be overridden per graphic
  - `antialiasing: true`, then the blend mode defaults to  `ex.ImageFiltering.Blended`
  - `antialiasing: false`, then the blend mode defaults to `ex.ImageFiltering.Pixel`
- `ex.Text/ex.Font` defaults to blended which improves the default look of text rendering dramatically!
- `ex.Circle` and `ex.Polygon` also default to blended which improves the default look dramatically!
- `ex.ImageSource` can now specify a blend mode before the Image is loaded, otherwise
