### PR TITLE
refactor: Move math utils, deprecate old import site

### DIFF
--- a/src/engine/Actions/Action/RotateBy.ts
+++ b/src/engine/Actions/Action/RotateBy.ts
@@ -1,9 +1,9 @@
 import { Action } from '../Action';
 import { RotationType } from '../RotationType';
-import * as Util from '../../Util/Util';
 import { TransformComponent } from '../../EntityComponentSystem/Components/TransformComponent';
 import { MotionComponent } from '../../EntityComponentSystem/Components/MotionComponent';
 import { Entity } from '../../EntityComponentSystem/Entity';
+import { TwoPI } from '../../Math/util';
 
 export class RotateBy implements Action {
   private _tx: TransformComponent;
@@ -40,7 +40,7 @@ export class RotateBy implements Action {
       this._end = this._start + this._offset;
 
       const distance1 = Math.abs(this._end - this._start);
-      const distance2 = Util.TwoPI - distance1;
+      const distance2 = TwoPI - distance1;
       if (distance1 > distance2) {
         this._shortDistance = distance2;
         this._longDistance = distance1;
@@ -49,7 +49,7 @@ export class RotateBy implements Action {
         this._longDistance = distance2;
       }
 
-      this._shortestPathIsPositive = (this._start - this._end + Util.TwoPI) % Util.TwoPI >= Math.PI;
+      this._shortestPathIsPositive = (this._start - this._end + TwoPI) % TwoPI >= Math.PI;
 
       switch (this._rotationType) {
         case RotationType.ShortestPath:

--- a/src/engine/Actions/Action/RotateTo.ts
+++ b/src/engine/Actions/Action/RotateTo.ts
@@ -1,9 +1,9 @@
 import { Action } from '../Action';
 import { RotationType } from '../RotationType';
-import * as Util from '../../Util/Util';
 import { TransformComponent } from '../../EntityComponentSystem/Components/TransformComponent';
 import { MotionComponent } from '../../EntityComponentSystem/Components/MotionComponent';
 import { Entity } from '../../EntityComponentSystem/Entity';
+import { TwoPI } from '../../Math/util';
 
 export class RotateTo implements Action {
   private _tx: TransformComponent;
@@ -36,7 +36,7 @@ export class RotateTo implements Action {
       this._start = this._tx.rotation;
       this._currentNonCannonAngle = this._tx.rotation;
       const distance1 = Math.abs(this._end - this._start);
-      const distance2 = Util.TwoPI - distance1;
+      const distance2 = TwoPI - distance1;
       if (distance1 > distance2) {
         this._shortDistance = distance2;
         this._longDistance = distance1;
@@ -45,7 +45,7 @@ export class RotateTo implements Action {
         this._longDistance = distance2;
       }
 
-      this._shortestPathIsPositive = (this._start - this._end + Util.TwoPI) % Util.TwoPI >= Math.PI;
+      this._shortestPathIsPositive = (this._start - this._end + TwoPI) % TwoPI >= Math.PI;
 
       switch (this._rotationType) {
         case RotationType.ShortestPath:

--- a/src/engine/Collision/BodyComponent.ts
+++ b/src/engine/Collision/BodyComponent.ts
@@ -8,7 +8,7 @@ import { Component } from '../EntityComponentSystem/Component';
 import { CollisionGroup } from './Group/CollisionGroup';
 import { EventDispatcher } from '../EventDispatcher';
 import { createId, Id } from '../Id';
-import { clamp } from '../Util/Util';
+import { clamp } from '../Math/util';
 import { ColliderComponent } from './ColliderComponent';
 
 export interface BodyComponentOptions {

--- a/src/engine/Collision/Solver/RealisticSolver.ts
+++ b/src/engine/Collision/Solver/RealisticSolver.ts
@@ -1,5 +1,5 @@
 import { CollisionPostSolveEvent, CollisionPreSolveEvent, PostCollisionEvent, PreCollisionEvent } from '../../Events';
-import { clamp } from '../../Util/Util';
+import { clamp } from '../../Math/util';
 import { CollisionContact } from '../Detection/CollisionContact';
 import { CollisionType } from '../CollisionType';
 import { ContactConstraintPoint } from './ContactConstraintPoint';

--- a/src/engine/Debug/DebugSystem.ts
+++ b/src/engine/Debug/DebugSystem.ts
@@ -7,7 +7,8 @@ import { CoordPlane, Entity, TransformComponent } from '../EntityComponentSystem
 import { System, SystemType } from '../EntityComponentSystem/System';
 import { ExcaliburGraphicsContext } from '../Graphics/Context/ExcaliburGraphicsContext';
 import { vec, Vector } from '../Math/vector';
-import { BodyComponent, CollisionSystem, CompositeCollider, GraphicsComponent, Particle, Util } from '..';
+import { toDegrees } from '../Math/util';
+import { BodyComponent, CollisionSystem, CompositeCollider, GraphicsComponent, Particle } from '..';
 import { DebugGraphicsComponent } from '../Graphics/DebugGraphicsComponent';
 
 export class DebugSystem extends System<TransformComponent> {
@@ -117,7 +118,7 @@ export class DebugSystem extends System<TransformComponent> {
             txSettings.rotationColor,
             2
           );
-          this._graphicsContext.debug.drawText(`rot deg(${Util.toDegrees(tx.rotation).toFixed(2)})`, cursor);
+          this._graphicsContext.debug.drawText(`rot deg(${toDegrees(tx.rotation).toFixed(2)})`, cursor);
           cursor = cursor.add(lineHeight);
         }
 

--- a/src/engine/Drawing/Animation.ts
+++ b/src/engine/Drawing/Animation.ts
@@ -5,9 +5,9 @@ import { Color } from '../Color';
 import { Drawable, DrawOptions } from '../Interfaces/Drawable';
 import { Vector } from '../Math/vector';
 import { Engine } from '../Engine';
-import * as Util from '../Util/Util';
 import { Configurable } from '../Configurable';
 import { obsolete } from '../Util/Decorators';
+import { clamp } from '../Math/util';
 
 /**
  * @deprecated Use [[HasTick]]
@@ -333,7 +333,7 @@ export class AnimationImpl implements Drawable, HasTick {
     }
 
     if (this.freezeFrame !== -1 && this.currentFrame >= this.sprites.length) {
-      currSprite = this.sprites[Util.clamp(this.freezeFrame, 0, this.sprites.length - 1)];
+      currSprite = this.sprites[clamp(this.freezeFrame, 0, this.sprites.length - 1)];
       currSprite.draw(animOptions);
     }
 

--- a/src/engine/Drawing/Sprite.ts
+++ b/src/engine/Drawing/Sprite.ts
@@ -5,9 +5,9 @@ import { Drawable, DrawOptions } from '../Interfaces/Drawable';
 import { Texture } from './Texture';
 import { Vector } from '../Math/vector';
 import { Logger } from '../Util/Log';
-import { clamp } from '../Util/Util';
 import { Configurable } from '../Configurable';
 import { obsolete } from '../Util/Decorators';
+import { clamp } from '../Math/util';
 
 /**
  * @hidden

--- a/src/engine/Graphics/Animation.ts
+++ b/src/engine/Graphics/Animation.ts
@@ -1,11 +1,11 @@
 import { Graphic, GraphicOptions } from './Graphic';
-import { clamp } from '../Util/Util';
 import { ExcaliburGraphicsContext } from './Context/ExcaliburGraphicsContext';
 import { EventDispatcher } from '../EventDispatcher';
 import { SpriteSheet } from './SpriteSheet';
 import { Logger } from '../Util/Log';
 import { Engine, LegacyDrawing } from '..';
 import { Sprite } from '.';
+import { clamp } from '../Math/util';
 
 export interface HasTick {
   /**

--- a/src/engine/Loader.ts
+++ b/src/engine/Loader.ts
@@ -9,8 +9,9 @@ import logoImg from './Loader.logo.png';
 import loaderCss from './Loader.css';
 import { Canvas } from './Graphics/Canvas';
 import { Vector } from './Math/vector';
-import { clamp, delay } from './Util/Util';
+import { delay } from './Util/Util';
 import { ImageFiltering } from './Graphics/Filtering';
+import { clamp } from './Math/util';
 
 /**
  * Pre-loading assets

--- a/src/engine/Math/matrix.ts
+++ b/src/engine/Math/matrix.ts
@@ -1,6 +1,6 @@
 import { sign } from './util';
 import { Vector, vec } from './vector';
-import { canonicalizeAngle } from '../Util/Util';
+import { canonicalizeAngle } from './util';
 
 export enum MatrixLocations {
   X = 12,

--- a/src/engine/Math/util.ts
+++ b/src/engine/Math/util.ts
@@ -1,3 +1,10 @@
+import { Random } from './Random';
+
+/**
+ * Two PI constant
+ */
+export const TwoPI: number = Math.PI * 2;
+
 /**
  * Returns the fractional part of a number
  * @param x
@@ -19,3 +26,66 @@ export function sign(val: number): number {
   }
   return val < 0 ? -1 : 1;
 };
+
+/**
+ * Clamps a value between a min and max inclusive
+ */
+export function clamp(val: number, min: number, max: number) {
+  return Math.min(Math.max(min, val), max);
+}
+
+
+/**
+ * Convert an angle to be the equivalent in the range [0, 2PI]
+ */
+export function canonicalizeAngle(angle: number): number {
+  let tmpAngle = angle;
+  if (angle > TwoPI) {
+    while (tmpAngle > TwoPI) {
+      tmpAngle -= TwoPI;
+    }
+  }
+
+  if (angle < 0) {
+    while (tmpAngle < 0) {
+      tmpAngle += TwoPI;
+    }
+  }
+  return tmpAngle;
+}
+
+/**
+ * Convert radians to degrees
+ */
+export function toDegrees(radians: number): number {
+  return (180 / Math.PI) * radians;
+}
+
+/**
+ * Convert degrees to radians
+ */
+export function toRadians(degrees: number): number {
+  return (degrees / 180) * Math.PI;
+}
+
+/**
+ * Generate a range of numbers
+ * For example: range(0, 5) -> [0, 1, 2, 3, 4, 5]
+ * @param from inclusive
+ * @param to inclusive
+ */
+export const range = (from: number, to: number) => Array.from(new Array(to - from + 1), (_x, i) => i + from);
+
+/**
+ * Find a random floating point number in range
+ */
+export function randomInRange(min: number, max: number, random: Random = new Random()): number {
+  return random ? random.floating(min, max) : min + Math.random() * (max - min);
+}
+
+/**
+ * Find a random integer in a range
+ */
+export function randomIntInRange(min: number, max: number, random: Random = new Random()): number {
+  return random ? random.integer(min, max) : Math.round(randomInRange(min, max));
+}

--- a/src/engine/Particles.ts
+++ b/src/engine/Particles.ts
@@ -14,6 +14,7 @@ import { Entity } from './EntityComponentSystem/Entity';
 import { CanvasDrawComponent } from './Drawing/Index';
 import { Sprite } from './Graphics/Sprite';
 import { LegacyDrawing } from '.';
+import { clamp, randomInRange } from './Math/util';
 
 /**
  * An enum that represents the types of emitter nozzles
@@ -155,21 +156,21 @@ export class ParticleImpl extends Entity {
     }
 
     if (this.fadeFlag) {
-      this.opacity = Util.clamp(this._aRate * this.life, 0.0001, 1);
+      this.opacity = clamp(this._aRate * this.life, 0.0001, 1);
     }
 
     if (this.startSize > 0 && this.endSize > 0) {
-      this.particleSize = Util.clamp(
+      this.particleSize = clamp(
         this.sizeRate * delta + this.particleSize,
         Math.min(this.startSize, this.endSize),
         Math.max(this.startSize, this.endSize)
       );
     }
 
-    this._currentColor.r = Util.clamp(this._currentColor.r + this._rRate * delta, 0, 255);
-    this._currentColor.g = Util.clamp(this._currentColor.g + this._gRate * delta, 0, 255);
-    this._currentColor.b = Util.clamp(this._currentColor.b + this._bRate * delta, 0, 255);
-    this._currentColor.a = Util.clamp(this.opacity, 0.0001, 1);
+    this._currentColor.r = clamp(this._currentColor.r + this._rRate * delta, 0, 255);
+    this._currentColor.g = clamp(this._currentColor.g + this._gRate * delta, 0, 255);
+    this._currentColor.b = clamp(this._currentColor.b + this._bRate * delta, 0, 255);
+    this._currentColor.a = clamp(this.opacity, 0.0001, 1);
 
     if (this.focus) {
       const accel = this.focus
@@ -205,7 +206,7 @@ export class ParticleImpl extends Entity {
     }
 
     ctx.save();
-    this._currentColor.a = Util.clamp(this.opacity, 0.0001, 1);
+    this._currentColor.a = clamp(this.opacity, 0.0001, 1);
     ctx.fillStyle = this._currentColor.toString();
     ctx.beginPath();
     ctx.arc(0, 0, this.particleSize, 0, Math.PI * 2);
@@ -540,17 +541,17 @@ export class ParticleEmitter extends Actor {
     let ranX = 0;
     let ranY = 0;
 
-    const angle = Util.randomInRange(this.minAngle, this.maxAngle, this.random);
-    const vel = Util.randomInRange(this.minVel, this.maxVel, this.random);
-    const size = this.startSize || Util.randomInRange(this.minSize, this.maxSize, this.random);
+    const angle = randomInRange(this.minAngle, this.maxAngle, this.random);
+    const vel = randomInRange(this.minVel, this.maxVel, this.random);
+    const size = this.startSize || randomInRange(this.minSize, this.maxSize, this.random);
     const dx = vel * Math.cos(angle);
     const dy = vel * Math.sin(angle);
 
     if (this.emitterType === EmitterType.Rectangle) {
-      ranX = Util.randomInRange(0, this.width, this.random);
-      ranY = Util.randomInRange(0, this.height, this.random);
+      ranX = randomInRange(0, this.width, this.random);
+      ranY = randomInRange(0, this.height, this.random);
     } else if (this.emitterType === EmitterType.Circle) {
-      const radius = Util.randomInRange(0, this.radius, this.random);
+      const radius = randomInRange(0, this.radius, this.random);
       ranX = radius * Math.cos(angle);
       ranY = radius * Math.sin(angle);
     }
@@ -576,7 +577,7 @@ export class ParticleEmitter extends Actor {
     }
     p.particleRotationalVelocity = this.particleRotationalVelocity;
     if (this.randomRotation) {
-      p.currentRotation = Util.randomInRange(0, Math.PI * 2, this.random);
+      p.currentRotation = randomInRange(0, Math.PI * 2, this.random);
     }
     if (this.focus) {
       p.focus = this.focus.add(new Vector(this.pos.x, this.pos.y));

--- a/src/engine/Resources/Gif.ts
+++ b/src/engine/Resources/Gif.ts
@@ -7,7 +7,7 @@ import { Engine } from '../Engine';
 import { Loadable } from '../Interfaces/Index';
 import { ImageSource } from '../Graphics/ImageSource';
 import { LegacyDrawing } from '..';
-import { range } from '../Util/Util';
+import { range } from '../Math/util';
 /**
  * The [[Texture]] object allows games built in Excalibur to load image resources.
  * [[Texture]] is an [[Loadable]] which means it can be passed to a [[Loader]]

--- a/src/engine/Resources/Sound/WebAudioInstance.ts
+++ b/src/engine/Resources/Sound/WebAudioInstance.ts
@@ -1,5 +1,5 @@
 import { Audio } from '../../Interfaces/Audio';
-import * as Util from '../../Util/Util';
+import { clamp } from '../../Math/util';
 import { AudioContextFactory } from './AudioContext';
 
 /**
@@ -27,7 +27,7 @@ export class WebAudioInstance implements Audio {
   }
 
   public set volume(value: number) {
-    value = Util.clamp(value, 0, 1.0);
+    value = clamp(value, 0, 1.0);
 
     this._volume = value;
 

--- a/src/engine/Util/Util.ts
+++ b/src/engine/Util/Util.ts
@@ -1,113 +1,61 @@
 import { Vector } from '../Math/vector';
-import { Random } from '../Math/Random';
 import { Side } from '../Collision/Side';
-import { Clock } from '..';
+import { Clock } from './Clock';
+
+// TODO remove in v0.26.0
+// Re-export hack to deprecate import site gently
+import {
+  TwoPI as lTwoPI,
+  clamp as lclamp,
+  randomInRange as lrandomInRange,
+  randomIntInRange as lrandomIntInRange,
+  canonicalizeAngle as lcanonicalizeAngle,
+  toDegrees as ltoDegrees,
+  toRadians as ltoRadians,
+  range as lrange
+} from '../Math/util';
 
 /**
- * Two PI constant
+ * @deprecated ex.Util.TwoPI import site will be removed in v0.26.0, use ex.TwoPI
  */
-export const TwoPI: number = Math.PI * 2;
-
+export const TwoPI = lTwoPI;
 
 /**
- * Encode a string in base64
- * @deprecated This will be removed in v0.26.0
+ * @deprecated ex.Util.clamp import site will be removed in v0.26.0, use ex.clamp
  */
-export function base64Encode(inputStr: string) {
-  const b64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
-  let outputStr = '';
-  let i = 0;
-
-  while (i < inputStr.length) {
-    //all three "& 0xff" added below are there to fix a known bug
-    //with bytes returned by xhr.responseText
-    const byte1 = inputStr.charCodeAt(i++) & 0xff;
-    const byte2 = inputStr.charCodeAt(i++) & 0xff;
-    const byte3 = inputStr.charCodeAt(i++) & 0xff;
-
-    const enc1 = byte1 >> 2;
-    const enc2 = ((byte1 & 3) << 4) | (byte2 >> 4);
-
-    let enc3, enc4;
-    if (isNaN(byte2)) {
-      enc3 = enc4 = 64;
-    } else {
-      enc3 = ((byte2 & 15) << 2) | (byte3 >> 6);
-      if (isNaN(byte3)) {
-        enc4 = 64;
-      } else {
-        enc4 = byte3 & 63;
-      }
-    }
-
-    outputStr += b64.charAt(enc1) + b64.charAt(enc2) + b64.charAt(enc3) + b64.charAt(enc4);
-  }
-
-  return outputStr;
-}
+export const clamp = lclamp;
 
 /**
- * Sugar that will use `nullishVal` if it's not null or undefined. Simulates the `??` operator
- * @param nullishVal
- * @param defaultVal
+ * @deprecated ex.Util.randomInRange import site will be removed in v0.26.0, use ex.randomInRange
  */
-export function nullish<T>(nullishVal: T | undefined | null, defaultVal: T): T {
-  return nullishVal !== null && nullishVal !== undefined ? nullishVal : defaultVal;
-}
+export const randomInRange = lrandomInRange;
 
 /**
- * Clamps a value between a min and max inclusive
+ * @deprecated ex.Util.randomIntInRange import site will be removed in v0.26.0, use ex.randomIntInRange
  */
-export function clamp(val: number, min: number, max: number) {
-  return Math.min(Math.max(min, val), max);
-}
+export const randomIntInRange = lrandomIntInRange;
 
 /**
- * Find a random floating point number in range
+ * @deprecated ex.Util.canonicalizeAngle import site will be removed in v0.26.0, use ex.canonicalizeAngle
  */
-export function randomInRange(min: number, max: number, random: Random = new Random()): number {
-  return random ? random.floating(min, max) : min + Math.random() * (max - min);
-}
+export const canonicalizeAngle = lcanonicalizeAngle;
 
 /**
- * Find a random integer in a range
+ * @deprecated ex.Util.toDegrees import site will be removed in v0.26.0, use ex.toDegrees
  */
-export function randomIntInRange(min: number, max: number, random: Random = new Random()): number {
-  return random ? random.integer(min, max) : Math.round(randomInRange(min, max));
-}
+export const toDegrees = ltoDegrees;
 
 /**
- * Convert an angle to be the equivalent in the range [0, 2PI]
+ * @deprecated ex.Util.toRadians import site will be removed in v0.26.0, use ex.toRadians
  */
-export function canonicalizeAngle(angle: number): number {
-  let tmpAngle = angle;
-  if (angle > TwoPI) {
-    while (tmpAngle > TwoPI) {
-      tmpAngle -= TwoPI;
-    }
-  }
-
-  if (angle < 0) {
-    while (tmpAngle < 0) {
-      tmpAngle += TwoPI;
-    }
-  }
-  return tmpAngle;
-}
+export const toRadians = ltoRadians;
 
 /**
- * Convert radians to degrees
+ * @deprecated ex.Util.range import site will be removed in v0.26.0, use ex.range
  */
-export function toDegrees(radians: number): number {
-  return (180 / Math.PI) * radians;
-}
+export const range = lrange;
 
-/**
- * Convert degrees to radians
- */
-export function toRadians(degrees: number): number {
-  return (degrees / 180) * Math.PI;
-}
+// TODO END REMOVE in v0.26.0
 
 /**
  * Find the screen position of an HTML element
@@ -377,14 +325,6 @@ export class Collection<T> {
 export function fail(message: never): never {
   throw new Error(message);
 }
-
-/**
- * Generate a range of numbers
- * For example: range(0, 5) -> [0, 1, 2, 3, 4, 5]
- * @param from inclusive
- * @param to inclusive
- */
-export const range = (from: number, to: number) => Array.from(new Array(to - from + 1), (_x, i) => i + from);
 
 /**
  * Create a promise that resolves after a certain number of milliseconds

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -64,7 +64,6 @@ export { traits as Traits };
 // ex.Util namespaces
 import * as util from './Util/Index';
 export { util as Util };
-export { clamp, range, toDegrees, toRadians, randomInRange, randomIntInRange, canonicalizeAngle } from './Util/Index';
 
 export * from './Util/Browser';
 export * from './Util/Decorators';

--- a/src/spec/ActionSpec.ts
+++ b/src/spec/ActionSpec.ts
@@ -1,7 +1,6 @@
 import * as ex from '@excalibur';
 import { TestUtils } from './util/TestUtils';
 import { ExcaliburMatchers } from 'excalibur-jasmine';
-import { canonicalizeAngle } from '../engine/Util/Util';
 
 describe('Action', () => {
   let actor: ex.Actor;
@@ -570,13 +569,13 @@ describe('Action', () => {
 
       scene.update(engine, 1000);
       //rotation is currently incremented by rx delta ,so will be negative while moving counterclockwise
-      expect(actor.rotation).toBe(canonicalizeAngle((-1 * Math.PI) / 2));
+      expect(actor.rotation).toBe(ex.canonicalizeAngle((-1 * Math.PI) / 2));
 
       scene.update(engine, 2000);
-      expect(actor.rotation).toBe(canonicalizeAngle((-3 * Math.PI) / 2));
+      expect(actor.rotation).toBe(ex.canonicalizeAngle((-3 * Math.PI) / 2));
 
       scene.update(engine, 500);
-      expect(actor.rotation).toBe(canonicalizeAngle(Math.PI / 2));
+      expect(actor.rotation).toBe(ex.canonicalizeAngle(Math.PI / 2));
       expect(actor.angularVelocity).toBe(0);
     });
 
@@ -601,19 +600,19 @@ describe('Action', () => {
 
       actor.actions.rotateTo(Math.PI / 2, Math.PI / 2, ex.RotationType.CounterClockwise);
       scene.update(engine, 2000);
-      expect(actor.rotation).toBe(canonicalizeAngle(-Math.PI));
+      expect(actor.rotation).toBe(ex.canonicalizeAngle(-Math.PI));
 
       scene.update(engine, 1000);
-      expect(actor.rotation).toBe(canonicalizeAngle((-3 * Math.PI) / 2));
+      expect(actor.rotation).toBe(ex.canonicalizeAngle((-3 * Math.PI) / 2));
 
       scene.update(engine, 500);
-      expect(actor.rotation).toBe(canonicalizeAngle(Math.PI / 2));
+      expect(actor.rotation).toBe(ex.canonicalizeAngle(Math.PI / 2));
       expect(actor.angularVelocity).toBe(0);
 
       // rotating back to 0, starting at PI / 2
       actor.actions.rotateTo(0, Math.PI / 2, ex.RotationType.CounterClockwise);
       scene.update(engine, 1000);
-      expect(actor.rotation).toBe(canonicalizeAngle(0));
+      expect(actor.rotation).toBe(ex.canonicalizeAngle(0));
 
       scene.update(engine, 1);
       expect(actor.angularVelocity).toBe(0);
@@ -656,10 +655,10 @@ describe('Action', () => {
       actor.actions.rotateBy(Math.PI / 2, Math.PI / 2, ex.RotationType.LongestPath);
 
       scene.update(engine, 1000);
-      expect(actor.rotation).toBe(canonicalizeAngle((-1 * Math.PI) / 2));
+      expect(actor.rotation).toBe(ex.canonicalizeAngle((-1 * Math.PI) / 2));
 
       scene.update(engine, 2000);
-      expect(actor.rotation).toBe(canonicalizeAngle((-3 * Math.PI) / 2));
+      expect(actor.rotation).toBe(ex.canonicalizeAngle((-3 * Math.PI) / 2));
 
       scene.update(engine, 500);
       expect(actor.rotation).toBe(Math.PI / 2);
@@ -688,10 +687,10 @@ describe('Action', () => {
       actor.actions.rotateBy(Math.PI / 2, Math.PI / 2, ex.RotationType.LongestPath);
 
       scene.update(engine, 1000);
-      expect(actor.rotation).toBe(canonicalizeAngle((-1 * Math.PI) / 2));
+      expect(actor.rotation).toBe(ex.canonicalizeAngle((-1 * Math.PI) / 2));
 
       scene.update(engine, 2000);
-      expect(actor.rotation).toBe(canonicalizeAngle((-3 * Math.PI) / 2));
+      expect(actor.rotation).toBe(ex.canonicalizeAngle((-3 * Math.PI) / 2));
 
       scene.update(engine, 500);
       expect(actor.rotation).toBe(Math.PI / 2);

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -381,7 +381,7 @@ describe('A game actor', () => {
   });
 
   it('is rotated along with its parent', () => {
-    const rotation = ex.Util.toRadians(90);
+    const rotation = ex.toRadians(90);
 
     actor.pos = ex.vec(10, 10);
     actor.rotation = rotation;
@@ -396,7 +396,7 @@ describe('A game actor', () => {
   });
 
   it('is rotated along with its grandparent', () => {
-    const rotation = ex.Util.toRadians(90);
+    const rotation = ex.toRadians(90);
 
     actor.pos = ex.vec(10, 10);
     actor.rotation = rotation;
@@ -448,7 +448,7 @@ describe('A game actor', () => {
   });
 
   it('is rotated and scaled along with its parent', () => {
-    const rotation = ex.Util.toRadians(90);
+    const rotation = ex.toRadians(90);
 
     actor.pos = ex.vec(10, 10);
     actor.scale = ex.vec(2, 2);
@@ -464,7 +464,7 @@ describe('A game actor', () => {
   });
 
   it('is rotated and scaled along with its grandparent', () => {
-    const rotation = ex.Util.toRadians(90);
+    const rotation = ex.toRadians(90);
 
     actor.pos = ex.vec(10, 10);
     actor.scale = ex.vec(2, 2);

--- a/src/spec/MathSpec.ts
+++ b/src/spec/MathSpec.ts
@@ -3,41 +3,41 @@ import * as ex from '@excalibur';
 describe('Excalibur Math', () => {
   it('can convert radians to degrees', () => {
     const angleInRadians = Math.PI * 3;
-    expect(ex.Util.toDegrees(angleInRadians)).toBe(540);
+    expect(ex.toDegrees(angleInRadians)).toBe(540);
   });
 
   it('can convert degrees to radians', () => {
     const angleInDegrees = 540;
-    expect(ex.Util.toRadians(angleInDegrees)).toBe(Math.PI * 3);
+    expect(ex.toRadians(angleInDegrees)).toBe(Math.PI * 3);
   });
 
   it('can canonicalize angles larger than 2PI', () => {
     const angleLargerThan2Pi = Math.PI * 3 + Math.PI / 2;
-    expect(ex.Util.canonicalizeAngle(angleLargerThan2Pi)).toBe((3 / 2) * Math.PI);
+    expect(ex.canonicalizeAngle(angleLargerThan2Pi)).toBe((3 / 2) * Math.PI);
   });
 
   it('can canonicalize angles less than 2PI', () => {
     const angleLessThanZero = -Math.PI / 4;
-    expect(ex.Util.canonicalizeAngle(angleLessThanZero)).toBe((7 / 4) * Math.PI);
+    expect(ex.canonicalizeAngle(angleLessThanZero)).toBe((7 / 4) * Math.PI);
   });
 
   it('can clamp a value larger than a range', () => {
     const value = 20;
-    expect(ex.Util.clamp(value, 4, 10)).toBe(10);
+    expect(ex.clamp(value, 4, 10)).toBe(10);
   });
 
   it('can clamp a value smaller than a range', () => {
     const value = 2;
-    expect(ex.Util.clamp(value, 4, 10)).toBe(4);
+    expect(ex.clamp(value, 4, 10)).toBe(4);
   });
 
   it('can clamp a value in a range', () => {
     const value = 6;
-    expect(ex.Util.clamp(value, 4, 10)).toBe(6);
+    expect(ex.clamp(value, 4, 10)).toBe(6);
   });
 
   it('has a constant for 2 Pi', () => {
-    expect(ex.Util.TwoPI).toBe(2 * Math.PI);
+    expect(ex.TwoPI).toBe(2 * Math.PI);
   });
 
   it('can get the fractional portion of a number', () => {

--- a/src/spec/UtilSpec.ts
+++ b/src/spec/UtilSpec.ts
@@ -16,14 +16,14 @@ describe('Utility functions', () => {
   });
 
   it('can clamp a number to a maximum and minimum', () => {
-    expect(ex.Util.clamp(0, 10, 20)).toBe(10);
-    expect(ex.Util.clamp(15, 10, 20)).toBe(15);
-    expect(ex.Util.clamp(30, 10, 20)).toBe(20);
-    expect(ex.Util.clamp(-Infinity, 0, 1)).toBe(0);
-    expect(ex.Util.clamp(Infinity, 0, 1)).toBe(1);
-    expect(ex.Util.clamp(12, -Infinity, Infinity)).toBe(12);
-    expect(ex.Util.clamp(12, -Infinity, 100)).toBe(12);
-    expect(ex.Util.clamp(12, -100, Infinity)).toBe(12);
+    expect(ex.clamp(0, 10, 20)).toBe(10);
+    expect(ex.clamp(15, 10, 20)).toBe(15);
+    expect(ex.clamp(30, 10, 20)).toBe(20);
+    expect(ex.clamp(-Infinity, 0, 1)).toBe(0);
+    expect(ex.clamp(Infinity, 0, 1)).toBe(1);
+    expect(ex.clamp(12, -Infinity, Infinity)).toBe(12);
+    expect(ex.clamp(12, -Infinity, 100)).toBe(12);
+    expect(ex.clamp(12, -100, Infinity)).toBe(12);
   });
 
   describe('removeItemFromArray function', () => {
@@ -40,20 +40,6 @@ describe('Utility functions', () => {
     it('should return false when item to delete is not present', () => {
       const arrayToRemove = ['Godfrey', 'Crizzo', 'Fullstack'];
       expect(ex.Util.removeItemFromArray('Lannister', arrayToRemove)).toBe(false);
-    });
-  });
-
-  describe('nullish', () => {
-    it('should return the default if null or undefined', () => {
-      const defaultNull = ex.Util.nullish(null, 1);
-      const defaultUndefined = ex.Util.nullish(undefined, 2);
-      expect(defaultNull).toBe(1);
-      expect(defaultUndefined).toBe(2);
-    });
-
-    it('should return a value if not null or undefined', () => {
-      const value = ex.Util.nullish('value', 'otherValue');
-      expect(value).toBe('value');
     });
   });
 });


### PR DESCRIPTION

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

The PR consolidates the math utils out of the cursed old Util folder/file and import site.

It also promotes the useful math utility functions to hang off the UMD global 🎉 

<img width="285" alt="image" src="https://user-images.githubusercontent.com/612071/147624963-54386642-fbf4-4cfd-b916-ee14263e178d.png">

