### PR TITLE
fix: [#2192] Actor.center returns global position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue [#2192] where Actor.center was not correct in child actors
 - Fixed issue where `ex.CircleCollider`s did not respect rotation/scale when offset
 - Fixed issue [#2157] when compiling in TS strict mode complaining about `ex.Poolable`
 - Fixed issue where scaled graphics were not calculating the correct bounds

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -1007,10 +1007,22 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
   }
 
   /**
-   * Get the center point of an actor
+   * Get the center point of an actor (global position)
    */
   public get center(): Vector {
-    return new Vector(this.pos.x + this.width / 2 - this.anchor.x * this.width, this.pos.y + this.height / 2 - this.anchor.y * this.height);
+    const globalPos = this.getGlobalPos();
+    return new Vector(
+      globalPos.x + this.width / 2 - this.anchor.x * this.width,
+      globalPos.y + this.height / 2 - this.anchor.y * this.height);
+  }
+
+  /**
+   * Get the local center point of an actor
+   */
+  public get localCenter(): Vector {
+    return new Vector(
+      this.pos.x + this.width / 2 - this.anchor.x * this.width,
+      this.pos.y + this.height / 2 - this.anchor.y * this.height);
   }
 
   public get width() {

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -314,7 +314,7 @@ describe('A game actor', () => {
 
     expect(grandChild.center).toBeVector(ex.vec(175, 175));
     expect(grandChild.localCenter).toBeVector(ex.vec(25, 25));
-  })
+  });
 
   it('has a left, right, top, and bottom', () => {
     const actor = new ex.Actor({

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -287,6 +287,35 @@ describe('A game actor', () => {
     expect(center.y).toBe(150);
   });
 
+  it('can have a center when parented', () => {
+    const parent = new ex.Actor({
+      x: 100,
+      y: 100
+    });
+
+    const child = new ex.Actor({
+      x: 50,
+      y: 50
+    });
+
+    const grandChild = new ex.Actor({
+      x: 25,
+      y: 25
+    });
+
+    parent.addChild(child);
+    child.addChild(grandChild);
+
+    expect(parent.center).toBeVector(ex.vec(100, 100));
+    expect(parent.localCenter).toBeVector(ex.vec(100, 100));
+
+    expect(child.center).toBeVector(ex.vec(150, 150));
+    expect(child.localCenter).toBeVector(ex.vec(50, 50));
+
+    expect(grandChild.center).toBeVector(ex.vec(175, 175));
+    expect(grandChild.localCenter).toBeVector(ex.vec(25, 25));
+  })
+
   it('has a left, right, top, and bottom', () => {
     const actor = new ex.Actor({
       x: 0,


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2192

## Changes:

- Adds a new property `Actor.localCenter` to retrieve the center in local coordinates
- Updates the `Actor.center` property to use the global position from the `TransformComponent`
