### PR TITLE
fix: [#2224] Disable touch action on pointer target for mobile platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue [#2224] where pointer events sometimes didn't work in mobile platforms due to `touch-action` not being set to `none`
 - Fixed issue [#2203] where `engine.screenshot()` did not work in the WebGL implementation
 - Fixed issue [#1528] where screenshots didn't match the displayed game's size in HiDPI displays, images are now consistent with the game. If you want the full scaled image pass `engine.screenshot(true)` to preserve HiDPI Resolution.
 - Fixed issue [#2206] error and warning logs for large images to help developers identify error situations in the webgl implementation

--- a/src/engine/Input/PointerEventReceiver.ts
+++ b/src/engine/Input/PointerEventReceiver.ts
@@ -211,7 +211,13 @@ export class PointerEventReceiver extends Class {
    */
   public init() {
     // Disabling the touch action avoids browser/platform gestures from firing on the canvas
-    this.engine.canvas.style.touchAction = 'none';
+    // It is important on mobile to have touch action 'none'
+    // https://stackoverflow.com/questions/48124372/pointermove-event-not-working-with-touch-why-not
+    if (this.target === this.engine.canvas) {
+      this.engine.canvas.style.touchAction = 'none';
+    } else {
+      document.body.style.touchAction = 'none';
+    }
     // Preferred pointer events
     if (window.PointerEvent) {
       this.target.addEventListener('pointerdown', this._boundHandle);


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2224

Touch action must be set on the event listener target

