### PR TITLE
fix: Pixel 6 devices crash when MAX_TEXTURE_IMAGE_UNITS used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where only Pixel 6 devices crash when using their MAX_TEXTURE_IMAGE_UNITS, artificially cap Excalibur to 125 textures max
 - Fixed issue [#2203] where `engine.screenshot()` did not work in the WebGL implementation
 - Fixed issue [#1528] where screenshots didn't match the displayed game's size in HiDPI displays, images are now consistent with the game. If you want the full scaled image pass `engine.screenshot(true)` to preserve HiDPI Resolution.
 - Fixed issue [#2206] error and warning logs for large images to help developers identify error situations in the webgl implementation

--- a/src/engine/Graphics/Context/image-renderer/image-renderer.ts
+++ b/src/engine/Graphics/Context/image-renderer/image-renderer.ts
@@ -34,7 +34,8 @@ export class ImageRenderer implements RendererPlugin {
     this._gl = gl;
     this._context = context;
     // Transform shader source
-    this._maxTextures = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
+    // FIXME: PIXEL 6 complains `ERROR: Expression too complex.` if we use it's reported max texture units, 125 seems to work for now...
+    this._maxTextures = Math.min(gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS), 125);
     const transformedFrag = this._transformFragmentSource(frag, this._maxTextures);
     // Compile shader
     this._shader = new Shader({


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Fixes an issue in Pixel 6 when using MAX_TEXTURE_IMAGE_UNITS, in the interest of supporting the device we're artificially capping the max textures to 125
