### PR TITLE
fix: polygon colliders have inaccurate collision normals when offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where collision normals are inaccurate on polygon colliders that offset from their origin
 - Fixed issue [#2224] where pointer events sometimes didn't work in mobile platforms due to `touch-action` not being set to `none`
 - Fixed issue [#2203] where `engine.screenshot()` did not work in the WebGL implementation
 - Fixed issue [#1528] where screenshots didn't match the displayed game's size in HiDPI displays, images are now consistent with the game. If you want the full scaled image pass `engine.screenshot(true)` to preserve HiDPI Resolution.

--- a/src/engine/Collision/Colliders/CollisionJumpTable.ts
+++ b/src/engine/Collision/Colliders/CollisionJumpTable.ts
@@ -258,7 +258,7 @@ export const CollisionJumpTable = {
       let normal = separation.axis;
       let tangent = normal.perpendicular();
       // Point Contact A -> B
-      if (polyB.worldPos.sub(polyA.worldPos).dot(normal) < 0) {
+      if (polyB.center.sub(polyA.center).dot(normal) < 0) {
         normal = normal.negate();
         tangent = normal.perpendicular();
       }

--- a/src/spec/CollisionShapeSpec.ts
+++ b/src/spec/CollisionShapeSpec.ts
@@ -1011,7 +1011,7 @@ describe('Collision Shape', () => {
       const contact = rect.collide(edge)[0];
       expect(contact.normal)
         .withContext('Rect/Edge normal point away from edge')
-        .toBeVector(ex.Vector.Up);
+        .toBeVector(ex.Vector.Down);
       expect(contact.points[0]).toBeVector(ex.vec(20, 10));
       expect(contact.points[1]).toBeVector(ex.vec(-20, 10));
 
@@ -1025,7 +1025,7 @@ describe('Collision Shape', () => {
       const contact = rect.collide(edge)[0];
       expect(contact.normal)
         .withContext('Rect/Edge normal point away from edge')
-        .toBeVector(ex.Vector.Up);
+        .toBeVector(ex.Vector.Down);
       expect(contact.points[0]).toBeVector(ex.vec(20, 10));
       expect(contact.points[1]).toBeVector(ex.vec(10, 10));
 
@@ -1039,7 +1039,7 @@ describe('Collision Shape', () => {
       const contact = rect.collide(edge)[0];
       expect(contact.normal)
         .withContext('Rect/Edge normal point away from edge')
-        .toBeVector(ex.Vector.Up);
+        .toBeVector(ex.Vector.Down);
       expect(contact.points[0]).toBeVector(ex.vec(-20, 10));
       expect(contact.points[1]).toBeVector(ex.vec(0, 10));
 


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

This PR corrects collisions when offset, the reason this was a problem was there were inaccurate collision normal

