### PR TITLE
feat: Add arbitrary non-convex polygon support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
--
+ Added arbitrary non-convex polygon support (only non-self intersecting) with `ex.PolygonCollider(...).triangulate()` which builds a new `ex.CompositeCollider` composed of triangles.
 
 ### Fixed
 

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -9,6 +9,7 @@
 
     <ul>
       <li><a href="html/index.html">Sandbox Platformer</a></li>
+      <li><a href="tests/triangulation/index.html">Triangulation</a></li>
       <li><a href="tests/drawcalls/index.html">Draw Calls</a></li>
       <li><a href="tests/imageloading/index.html">Large Image Loading</a></li>
       <li><a href="tests/gif/animatedGif.html">Animated Gif</a></li>

--- a/sandbox/tests/triangulation/index.html
+++ b/sandbox/tests/triangulation/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Triangulation</title>
+</head>
+<body>
+  <script src="../../lib/excalibur.js"></script>
+  <script src="./index.js"></script>
+</body>
+</html>

--- a/sandbox/tests/triangulation/index.ts
+++ b/sandbox/tests/triangulation/index.ts
@@ -1,0 +1,45 @@
+
+var game = new ex.Engine({
+  width: 800,
+  height: 600
+});
+game.toggleDebug();
+game.debug.transform.showPosition = true;
+game.debug.transform.positionColor = ex.Color.Black;
+ex.Physics.useRealisticPhysics();
+ex.Physics.gravity = ex.vec(0, 100);
+
+// star points
+var star: ex.Vector[] = [];
+var rotation = -Math.PI / 2;
+for (var i = 0; i < 5; i++) {
+  // outer
+  star.push(ex.vec(100 * Math.cos((2 * Math.PI * i)/5 + rotation), 100 * Math.sin((2 * Math.PI * i)/5 + rotation) ));
+  // inner
+  star.push(ex.vec(40 * Math.cos((2 * Math.PI * i)/5 + rotation + 2 * Math.PI / 10), 40 * Math.sin((2 * Math.PI * i)/5 + rotation + 2 * Math.PI / 10) ));
+}
+star.reverse();
+var starCollider = new ex.PolygonCollider({points: star});
+console.log("Collider Bounds", starCollider.localBounds);
+var starGraphic = new ex.Polygon({points: star, color: ex.Color.Yellow});
+console.log("Graphic Bounds", starGraphic.localBounds);
+
+var actor = new ex.Actor({x: 200, y: 200, collisionType: ex.CollisionType.Active});
+// This is an odd quirk but because we center graphics by default, and the star is asymmetric
+actor.graphics.use(starGraphic, { offset: ex.vec(0, -10)});
+actor.collider.set(starCollider.triangulate());
+actor.angularVelocity = 3;
+game.add(actor);
+
+
+var actor2 = new ex.Actor({x: 400, y: 200, collisionType: ex.CollisionType.Active});
+actor2.collider.set(ex.Shape.Box(100, 100).tessellate());
+actor2.graphics.use(new ex.Rectangle({ width: 100, height: 100, color: ex.Color.Black}));
+game.add(actor2);
+
+
+var ground = new ex.Actor({anchor: ex.Vector.Zero, x: 0, y: 500, width: 800, height: 10, color: ex.Color.Black, collisionType: ex.CollisionType.Fixed});
+game.add(ground);
+
+
+game.start();

--- a/src/engine/Collision/ColliderComponent.ts
+++ b/src/engine/Collision/ColliderComponent.ts
@@ -192,7 +192,7 @@ export class ColliderComponent extends Component<'ex.collider'> {
    * By default, the box is center is at (0, 0) which means it is centered around the actors anchor.
    */
   usePolygonCollider(points: Vector[], center: Vector = Vector.Zero): PolygonCollider {
-    const poly = Shape.Polygon(points, false, center);
+    const poly = Shape.Polygon(points, center);
     return (this.set(poly));
   }
 

--- a/src/engine/Collision/Colliders/Shape.ts
+++ b/src/engine/Collision/Colliders/Shape.ts
@@ -29,14 +29,12 @@ export class Shape {
    *
    * PolygonColliders are useful for creating convex polygon shapes
    * @param points Points specified in counter clockwise
-   * @param clockwiseWinding Optionally changed the winding of points, by default false meaning counter-clockwise winding.
    * @param offset Optional offset relative to the collider in local coordinates
    */
-  static Polygon(points: Vector[], clockwiseWinding: boolean = false, offset: Vector = Vector.Zero): PolygonCollider {
+  static Polygon(points: Vector[], offset: Vector = Vector.Zero): PolygonCollider {
     return new PolygonCollider({
       points: points,
-      offset: offset,
-      clockwiseWinding: clockwiseWinding
+      offset: offset
     });
   }
 

--- a/src/spec/CollisionShapeSpec.ts
+++ b/src/spec/CollisionShapeSpec.ts
@@ -481,6 +481,53 @@ describe('Collision Shape', () => {
       expect(poly).not.toBe(null);
     });
 
+    it('will adjust winding to clockwise', () => {
+      const points = [ex.vec(0, 0), ex.vec(10, 10), ex.vec(10, 0)];
+      const winding = new ex.PolygonCollider({ points: [...points] });
+
+      expect(winding.points).toEqual([ex.vec(0, 0), ex.vec(10, 10), ex.vec(10, 0)].reverse());
+    });
+
+    it('can be checked for convexity', () => {
+      const convex = new ex.PolygonCollider({
+        points: [ex.vec(0, 0), ex.vec(10, 10), ex.vec(10, 0)]
+      });
+      expect(convex.isConvex()).withContext('Triangles are always convex').toBe(true);
+
+      const concave = new ex.PolygonCollider({
+        points: [ex.vec(0, 0), ex.vec(5, 5), ex.vec(0, 10), ex.vec(10, 10), ex.vec(10, 0)]
+      });
+
+      expect(concave.isConvex()).withContext('Should be concave').toBe(false);
+    });
+
+    it('can triangulate', () => {
+      const concave = new ex.PolygonCollider({
+        points: [ex.vec(0, 0), ex.vec(5, 5), ex.vec(0, 10), ex.vec(10, 10), ex.vec(10, 0)]
+      });
+
+      const composite = concave.triangulate();
+
+      const colliders = composite.getColliders() as ex.PolygonCollider[];
+      expect(colliders.length).toBe(3);
+      expect(colliders[0].points).toEqual([ex.vec(0, 0), ex.vec(10, 0), ex.vec(10, 10)]);
+      expect(colliders[1].points).toEqual([ex.vec(0, 0), ex.vec(10, 10), ex.vec(0, 10)]);
+      expect(colliders[2].points).toEqual([ex.vec(0, 0), ex.vec(5, 5), ex.vec(0, 10)]);
+
+      expect(concave.isConvex()).withContext('Should be concave').toBe(false);
+    });
+
+    it('can tesselate', () => {
+      const box = ex.Shape.Box(10, 10);
+
+      const composite = box.tessellate();
+
+      const colliders = composite.getColliders() as ex.PolygonCollider[];
+      expect(colliders.length).toBe(2);
+      expect(colliders[0].points).toEqual([ex.vec(-5, -5), ex.vec(5, 5), ex.vec(-5, 5)]);
+      expect(colliders[1].points).toEqual([ex.vec(-5, -5), ex.vec(5, -5), ex.vec(5, 5)]);
+    });
+
     it('can have be constructed with position', () => {
       const poly = new ex.PolygonCollider({
         offset: new ex.Vector(10, 0),


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR adds arbitrary non-convex polygon support using the `ex.PolygonCollider(...).triangulate()` method which produces a new `ex.CompositeCollider` composed of triangles.

![triangulation](https://user-images.githubusercontent.com/612071/153693435-932e6f86-c531-46c6-8b0c-0f89ec5b794c.gif)

This PR also adds a `tessellate()` which will produce a triangle fan `ex.CompositeCollider`


