### PR TITLE
perf: Add `zIndexChanged$` + Improve pointer system perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added faster `ex.BoundingBox.transform(...)` implementation.
 - Added faster `ex.BoundingBox.overlap(...)` implementation.
 - Added `ex.Vector.min(...)` and `ex.Vector.max(...)` to find the min/max of each vector component between 2 vectors.
+- Added `ex.TransformComponent.zIndexChange$` observable to watch when z index changes.
 
 ### Fixed
 

--- a/src/engine/EntityComponentSystem/Components/TransformComponent.ts
+++ b/src/engine/EntityComponentSystem/Components/TransformComponent.ts
@@ -2,6 +2,7 @@ import { Matrix, MatrixLocations } from '../../Math/matrix';
 import { VectorView } from '../../Math/vector-view';
 import { Vector, vec } from '../../Math/vector';
 import { Component } from '../Component';
+import { Observable } from '../../Util/Observable';
 
 export interface Transform {
   /**
@@ -192,10 +193,26 @@ export class TransformComponent extends Component<'ex.transform'> implements Tra
   }
 
   /**
+   * Observable that emits when the z index changes on this component
+   */
+  public zIndexChanged$ = new Observable<number>();
+  private _z = 0;
+
+  /**
    * The z-index ordering of the entity, a higher values are drawn on top of lower values.
    * For example z=99 would be drawn on top of z=0.
    */
-  public z: number = 0;
+  public get z(): number {
+    return this._z;
+  }
+
+  public set z(val: number) {
+    const oldz = this._z;
+    this._z = val;
+    if (oldz !== val) {
+      this.zIndexChanged$.notifyAll(val);
+    }
+  }
 
   /**
    * The rotation of the entity in radians. For example `Math.PI` radians is the same as 180 degrees.

--- a/src/spec/TransformComponentSpec.ts
+++ b/src/spec/TransformComponentSpec.ts
@@ -145,4 +145,15 @@ describe('A TransformComponent', () => {
     expect(childTx.getGlobalTransform().rotation).toBe(Math.PI);
     expect(childTx.getGlobalTransform().scale).toBeVector(ex.vec(2, 3));
   });
+
+  it('can observe a z index change', () => {
+    const tx = new ex.TransformComponent();
+    const zSpy = jasmine.createSpy('zSpy');
+    tx.zIndexChanged$.subscribe(zSpy);
+
+    tx.z = 19;
+
+    expect(zSpy).toHaveBeenCalledWith(19);
+    expect(tx.z).toBe(19);
+  });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR adds `zIndexChanged$` to the `ex.TransformComponent` in order to know when the z index changes. This allows the `ex.PointerSystem` to maintain a sorted list which is much faster than using the ECS Query.
