### PR TITLE
feat: Add pixelRatio override for Text rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-
+- `ex.Engine` now support setting the pixel ratio in the constructor `new ex.Engine({pixelRatio: 2})`, this is useful for smooth `ex.Text` rendering when `antialiasing: false` and rendering pixel art type graphics
 - `ex.TileMap` now supports per Tile custom colliders!
   ```typescript
   const tileMap = new ex.TileMap(...);

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -46,7 +46,7 @@ var game = new ex.Engine({
   height: 600 / 2,
   viewport: { width: 800, height: 600 },
   canvasElementId: 'game',
-  suppressHiDPIScaling: false,
+  pixelRatio: 4,
   suppressPlayButton: true,
   pointerScope: ex.Input.PointerScope.Canvas,
   displayMode: ex.DisplayMode.FitScreen,

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -102,6 +102,17 @@ export interface EngineOptions {
   antialiasing?: boolean;
 
   /**
+   * Optionally upscale the number of pixels in the canvas. Normally only useful if you need a smoother look to your assets, especially
+   * [[Text]].
+   *
+   * **WARNING** It is recommended you try using `antialiasing: true` before adjusting pixel ratio. Pixel ratio will consume more memory
+   * and on mobile may break if the internal size of the canvas exceeds 4k pixels in width or height.
+   *
+   * Default is based the display's pixel ratio, for example a HiDPI screen might have the value 2;
+   */
+  pixelRatio?: number;
+
+  /**
    * Optionally configure the native canvas transparent backdrop
    */
   enableCanvasTransparency?: boolean;
@@ -657,9 +668,10 @@ O|===|* >________________>\n\
       resolution: options.resolution,
       displayMode,
       position: options.position,
-      pixelRatio: options.suppressHiDPIScaling ? 1 : null
+      pixelRatio: options.suppressHiDPIScaling ? 1 : (options.pixelRatio ?? null)
     });
 
+    // Set default filtering based on antialiasing
     TextureLoader.filtering = options.antialiasing ? ImageFiltering.Blended : ImageFiltering.Pixel;
 
     if (options.backgroundColor) {

--- a/src/engine/Graphics/Font.ts
+++ b/src/engine/Graphics/Font.ts
@@ -277,14 +277,21 @@ export class Font extends Graphic implements FontRenderer {
       this.clearCache();
     }
     this.checkAndClearCache();
+    // Get bitmap for rastering text, this is cached by raster properties
     const bitmap = this._getTextBitmap(text, colorOverride);
     const isNewBitmap = !this._bitmapUsage.get(bitmap);
+
+    // Bounds of the text
     this._textBounds = this.measureText(text);
 
+    // TODO if the text is bigger than 4k we need to split it somehow
+
     if (isNewBitmap) {
+      // Setting dimension is expensive because it invalidates the bitmap
       this._setDimension(this._textBounds, bitmap);
     }
 
+    // Apply affine transformations
     this._preDraw(ex, x, y);
 
     const lines = text.split('\n');
@@ -301,6 +308,7 @@ export class Font extends Graphic implements FontRenderer {
       TextureLoader.load(bitmap.canvas, this.filtering, true);
     }
 
+    // Send draw cal to the ex graphics context
     ex.drawImage(
       bitmap.canvas,
       0,

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -384,8 +384,8 @@ export class Screen {
       if (!supported && !this._alreadyWarned) {
         this._alreadyWarned = true; // warn once
         this._logger.warn(
-          `The currently configured resolution (${this.resolution.width}x${this.resolution.height})` +
-          ' is too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly.' +
+          `The currently configured resolution (${this.resolution.width}x${this.resolution.height}) and pixel ratio (${this.pixelRatio})` +
+          ' are too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly.' +
           ' Try reducing the resolution or disabling Hi DPI scaling to avoid this' +
           ' (read more here https://excaliburjs.com/docs/screens#understanding-viewport--resolution).');
       }

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -153,6 +153,14 @@ describe('The engine', () => {
     expect(engine.graphicsContext.snapToPixel).toBeTrue();
   });
 
+  it('can set pixelRatio', () => {
+    engine = TestUtils.engine({width: 100, height: 100, pixelRatio: 5, suppressHiDPIScaling: false});
+    expect(engine.pixelRatio).toBe(5);
+    expect(engine.screen.pixelRatio).toBe(5);
+    expect(engine.screen.scaledWidth).toBe(500);
+    expect(engine.screen.scaledHeight).toBe(500);
+  });
+
   it('should emit a preframe event', () => {
     const fired = jasmine.createSpy('fired');
     engine.on('preframe', fired);

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -610,8 +610,8 @@ describe('A Screen', () => {
     sut.applyResolutionAndViewport();
     expect(context.checkIfResolutionSupported).toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledOnceWith(
-      `The currently configured resolution (${sut.resolution.width}x${sut.resolution.height})` +
-          ' is too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly.' +
+      `The currently configured resolution (${sut.resolution.width}x${sut.resolution.height}) and pixel ratio (${sut.pixelRatio})` +
+          ' are too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly.' +
           ' Try reducing the resolution or disabling Hi DPI scaling to avoid this' +
           ' (read more here https://excaliburjs.com/docs/screens#understanding-viewport--resolution).'
     );


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2291

This PR assists in pixelated Text rendering by increasing the number of internal pixels available on the canvas, to do this I added a `pixelRatio` that can be set at `Engine` constructor time.

Before antialiasing is off (pixel art mode), default `pixelRatio`

<img width="230" alt="image" src="https://user-images.githubusercontent.com/612071/162589397-59466303-1cd7-4b5e-926b-6033bd4af9c7.png">


After antialiasing is off (pixel art mode) but `pixelRatio` is set to 4

<img width="227" alt="image" src="https://user-images.githubusercontent.com/612071/162589388-fe9c9a81-5863-4630-80e8-92aa6d22308d.png">


## Changes:

- Added `pixelRatio` option to `Engine` constructor
- Added/updated tests
- Commented Font renderer
