### PR TITLE
fix: [#2300] CompositeColliders count as a whole for collisionstart/collisionend events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where CompositeColliders treat separate constituents as separate collisionstart/collisionend which is unexpected
 - Fixed issue where large pieces of Text were rendered as black rectangles on mobile, excalibur now internally breaks these into smaller chunks in order to render them.
 - Fixed issue #2263 where keyboard input `wasPressed` was not working in the `onPostUpdate` lifecycle
 - Fixed issue #2263 where there were some keys missing from the `ex.Input.Keys` enum, including `Enter`

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -454,6 +454,13 @@ follower.actions
 // follow player
 
 player.rotation = 0;
+player.on('collisionstart', () => {
+  console.log('collision start');
+});
+
+player.on('collisionend', () => {
+  console.log('collision end');
+});
 
 // Health bar example
 var healthbar = new ex.Actor({

--- a/src/engine/Collision/Colliders/Collider.ts
+++ b/src/engine/Collision/Colliders/Collider.ts
@@ -18,6 +18,12 @@ import { ExcaliburGraphicsContext } from '../../Graphics/Context/ExcaliburGraphi
 export abstract class Collider implements Clonable<Collider> {
   private static _ID = 0;
   public readonly id: Id<'collider'> = createId('collider', Collider._ID++);
+  /**
+   * Excalibur uses this to signal to the [[CollisionSystem]] this is part of a composite collider
+   * @internal
+   * @hidden
+   */
+  public __compositeColliderId: Id<'collider'> | null = null;
   public events: EventDispatcher<Collider> = new EventDispatcher<Collider>();
 
   /**

--- a/src/engine/Collision/Colliders/CompositeCollider.ts
+++ b/src/engine/Collision/Colliders/CompositeCollider.ts
@@ -32,6 +32,7 @@ export class CompositeCollider extends Collider {
 
   addCollider(collider: Collider) {
     this.events.wire(collider.events);
+    collider.__compositeColliderId = this.id;
     this._colliders.push(collider);
     this._collisionProcessor.track(collider);
     this._dynamicAABBTree.trackCollider(collider);
@@ -39,6 +40,7 @@ export class CompositeCollider extends Collider {
 
   removeCollider(collider: Collider) {
     this.events.unwire(collider.events);
+    collider.__compositeColliderId = null;
     Util.removeItemFromArray(collider, this._colliders);
     this._collisionProcessor.untrack(collider);
     this._dynamicAABBTree.untrackCollider(collider);

--- a/src/engine/Collision/CollisionSystem.ts
+++ b/src/engine/Collision/CollisionSystem.ts
@@ -111,6 +111,7 @@ export class CollisionSystem extends System<TransformComponent | MotionComponent
   }
 
   public runContactStartEnd() {
+    // Composite collider collisions may have a duplicate id because we want to treat those as a singular start/end
     for (const [id, c] of this._currentFrameContacts) {
       // find all new contacts
       if (!this._lastFrameContacts.has(id)) {
@@ -123,7 +124,7 @@ export class CollisionSystem extends System<TransformComponent | MotionComponent
       }
     }
 
-    // find all contacts taht have ceased
+    // find all contacts that have ceased
     for (const [id, c] of this._lastFrameContacts) {
       if (!this._currentFrameContacts.has(id)) {
         const colliderA = c.colliderA;

--- a/src/engine/Collision/Detection/CollisionContact.ts
+++ b/src/engine/Collision/Detection/CollisionContact.ts
@@ -77,6 +77,10 @@ export class CollisionContact {
     this.localPoints = localPoints;
     this.info = info;
     this.id = Pair.calculatePairHash(colliderA.id, colliderB.id);
+    if (colliderA.__compositeColliderId || colliderB.__compositeColliderId) {
+      // Potential problem id's are no longer unique
+      this.id = Pair.calculatePairHash(colliderA.__compositeColliderId ?? colliderA.id, colliderB.__compositeColliderId ?? colliderB.id);
+    }
   }
 
   /**

--- a/src/spec/CompositeColliderSpec.ts
+++ b/src/spec/CompositeColliderSpec.ts
@@ -135,6 +135,18 @@ describe('A CompositeCollider', () => {
     expect(contactCircleCircle[0].points[0]).withContext('Top of the circle in comp').toEqual(vec(0, -50));
   });
 
+  it('creates contacts that have the composite collider id', () => {
+    const compCollider = new ex.CompositeCollider([ex.Shape.Circle(50), ex.Shape.Box(200, 10, Vector.Half)]);
+
+    const circle = ex.Shape.Circle(50);
+    const xf = new TransformComponent();
+    xf.pos = vec(149, 0);
+    circle.update(xf);
+
+    const contactBoxCircle = compCollider.collide(circle);
+    expect(contactBoxCircle[0].id).toBe(ex.Pair.calculatePairHash(compCollider.id, circle.id));
+  });
+
   it('can collide with other composite colliders', () => {
     const compCollider1 = new ex.CompositeCollider([ex.Shape.Circle(50), ex.Shape.Box(200, 10, Vector.Half)]);
 


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2300 

This PR solves the issue of duplicate `collisionstart`/`collisionend` events by keeping track of the `CompositeCollider` in the contact id (which makes it no longer unique) but allows the dispatch logic for start/end to work unchanged in the `CollisionSystem`. This is done with a slightly gross hack to decorate colliders with a composite id if they are part of a composite collider.

