### PR TITLE
feat(graphics): [#2288] Implement SpriteSheet builder with custom sourceViews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added feature to build `SpriteSheet`s from a list of different sized source views using `ex.SpriteSheet.fromImageSourceWithSourceViews(...)`
+  ```typescript
+    const ss = ex.SpriteSheet.fromImageSourceWithSourceViews({
+      image,
+      sourceViews: [
+        {x: 0, y: 0, width: 20, height: 30},
+        {x: 20, y: 0, width: 40, height: 50},
+      ]
+    });
+  ```
 - Added draw call sorting `new ex.Engine({useDrawSorting: true})` to efficiently draw render plugins in batches to avoid expensive renderer switching as much as possible. By default this is turned on, but can be opted out of.
 - Added the ability to clone into a target `Matrix` this is useful to save allocations and in turn garbage collection pauses.
 - `ex.Engine` now support setting the pixel ratio in the constructor `new ex.Engine({pixelRatio: 2})`, this is useful for smooth `ex.Text` rendering when `antialiasing: false` and rendering pixel art type graphics

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -173,6 +173,19 @@ cardSpriteSheet.sprites.forEach(s => s.scale = ex.vec(2, 2));
 
 var cardAnimation = ex.Animation.fromSpriteSheet(cardSpriteSheet, ex.range(0, 14 * 4), 200);
 
+var multiCardSheet = ex.SpriteSheet.fromImageSourceWithSourceViews({
+  image: cards,
+  sourceViews: [
+    { x: 11, y: 2, width: 42*2 + 23, height: 60*2 + 5 }
+  ]
+});
+
+var multiCardActor = new ex.Actor({
+  pos: ex.vec(400, 100),
+});
+multiCardActor.graphics.use(multiCardSheet.sprites[0]);
+game.add(multiCardActor);
+
 var spriteFontSheet = ex.SpriteSheet.fromImageSource({
   image: spriteFontImage,
   grid: {

--- a/src/engine/Graphics/SpriteSheet.ts
+++ b/src/engine/Graphics/SpriteSheet.ts
@@ -130,8 +130,8 @@ export class SpriteSheet {
       return new Sprite({
         image: options.image,
         sourceView
-      })
-    })
+      });
+    });
     return new SpriteSheet({sprites});
   }
 

--- a/src/engine/Graphics/SpriteSheet.ts
+++ b/src/engine/Graphics/SpriteSheet.ts
@@ -1,5 +1,5 @@
 import { ImageSource } from './ImageSource';
-import { Sprite } from './Sprite';
+import { SourceView, Sprite } from './Sprite';
 import { Logger } from '../Util/Log';
 
 /**
@@ -55,6 +55,17 @@ export interface SpriteSheetGridOptions {
   spacing?: SpriteSheetSpacingDimensions;
 }
 
+export interface SpriteSheetSparseOptions {
+  /**
+   * Source image to use for each sprite
+   */
+  image: ImageSource;
+  /**
+   * List of source view rectangles to create a sprite sheet from
+   */
+  sourceViews: SourceView[];
+}
+
 export interface SpriteSheetOptions {
   /**
    * Source sprites for the sprite sheet
@@ -108,6 +119,20 @@ export class SpriteSheet {
     }
     const spriteIndex = x + y * this.columns;
     return this.sprites[spriteIndex];
+  }
+
+  /**
+   * Create a sprite sheet from a sparse set of [[SourceView]] rectangles
+   * @param options
+   */
+  public static fromSparseImageSource(options: SpriteSheetSparseOptions): SpriteSheet {
+    const sprites: Sprite[] = options.sourceViews.map(sourceView => {
+      return new Sprite({
+        image: options.image,
+        sourceView
+      })
+    })
+    return new SpriteSheet({sprites});
   }
 
   /**

--- a/src/engine/Graphics/SpriteSheet.ts
+++ b/src/engine/Graphics/SpriteSheet.ts
@@ -125,7 +125,7 @@ export class SpriteSheet {
    * Create a sprite sheet from a sparse set of [[SourceView]] rectangles
    * @param options
    */
-  public static fromSparseImageSource(options: SpriteSheetSparseOptions): SpriteSheet {
+  public static fromImageSourceWithSourceViews(options: SpriteSheetSparseOptions): SpriteSheet {
     const sprites: Sprite[] = options.sourceViews.map(sourceView => {
       return new Sprite({
         image: options.image,

--- a/src/spec/SpriteSheetSpec.ts
+++ b/src/spec/SpriteSheetSpec.ts
@@ -39,7 +39,7 @@ describe('A SpriteSheet for Graphics', () => {
       image,
       sourceViews: [
         {x: 0, y: 0, width: 20, height: 30},
-        {x: 20, y: 0, width: 40, height: 50},
+        {x: 20, y: 0, width: 40, height: 50}
       ]
     });
 

--- a/src/spec/SpriteSheetSpec.ts
+++ b/src/spec/SpriteSheetSpec.ts
@@ -31,6 +31,25 @@ describe('A SpriteSheet for Graphics', () => {
     expect(ss.sprites[0].height).toBe(53);
   });
 
+  it('can be created from a list of source views', async () => {
+    const image = new ex.ImageSource('src/spec/images/GraphicsTextSpec/spritefont.png');
+    await image.load();
+
+    const ss = ex.SpriteSheet.fromImageSourceWithSourceViews({
+      image,
+      sourceViews: [
+        {x: 0, y: 0, width: 20, height: 30},
+        {x: 20, y: 0, width: 40, height: 50},
+      ]
+    });
+
+    expect(ss.sprites.length).toBe(2);
+    expect(ss.sprites[0].width).toBe(20);
+    expect(ss.sprites[0].height).toBe(30);
+    expect(ss.sprites[1].width).toBe(40);
+    expect(ss.sprites[1].height).toBe(50);
+  });
+
   it('can be created from a grid', async () => {
     const image = new ex.ImageSource('src/spec/images/GraphicsTextSpec/spritefont.png');
 


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2288

Adds a new builder for producing sprite sheets with custom slices of source view for non-uniform SpriteSheets
