### PR TITLE
perf: Various performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed unreleased bug where CompositeCollider components would not collide appropriately because contacts did not have unique ids
 - Fixed issue where CompositeColliders treat separate constituents as separate collisionstart/collisionend which is unexpected
 - Fixed issue where resources that failed to load would silently fail making debugging challenging
 - Fixed issue where large pieces of Text were rendered as black rectangles on mobile, excalibur now internally breaks these into smaller chunks in order to render them.
@@ -116,6 +117,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Updates
 
+- Performance improvement to the `ex.Loader` screen keeping frame rates higher by only updating the backing `ex.Canvas` when there are changes
+- Improved collision broadphase by swapping to a more efficient `ex.BoundingBox.overlaps` check
+- Improved collision narrowphase by improving `ex.PolygonCollider` calculations for localBounds, bounds, and transformed point geometry
+- Improved Text/Font performance by internally caching expensive native `measureText()` calls
 - Performance improvement to GraphicsSystem
 - Performance improvement to the transform capture of the previous frame transform and motion
 

--- a/sandbox/tests/triangulation/index.ts
+++ b/sandbox/tests/triangulation/index.ts
@@ -35,6 +35,7 @@ game.add(actor);
 var actor2 = new ex.Actor({x: 400, y: 200, collisionType: ex.CollisionType.Active});
 actor2.collider.set(ex.Shape.Box(100, 100).tessellate());
 actor2.graphics.use(new ex.Rectangle({ width: 100, height: 100, color: ex.Color.Black}));
+actor2.rotation = (Math.PI / 2) * 3;
 game.add(actor2);
 
 

--- a/src/engine/Collision/Colliders/PolygonCollider.ts
+++ b/src/engine/Collision/Colliders/PolygonCollider.ts
@@ -65,6 +65,7 @@ export class PolygonCollider extends Collider {
   constructor(options: PolygonColliderOptions) {
     super();
     this.offset = options.offset ?? Vector.Zero;
+    this._globalMatrix.translate(this.offset.x, this.offset.y);
     this.points = options.points ?? [];
     const counterClockwise = this._isCounterClockwiseWinding(this.points);
     if (!counterClockwise) {
@@ -385,16 +386,22 @@ export class PolygonCollider extends Collider {
     return this._axes;
   }
 
+  /**
+   * Updates the transform for the collision geometry
+   *
+   * Collision geometry (points/bounds) will not change until this is called.
+   * @param transform
+   */
   public update(transform: Transform): void {
     this._transform = transform;
     this._sides.length = 0;
     this._localSides.length = 0;
     this._axes.length = 0;
     const tx = this._transform as TransformComponent;
+    // This change means an update must be performed in order for geometry to update
     const globalMat = tx?.getGlobalMatrix() ?? this._globalMatrix;
     globalMat.clone(this._globalMatrix);
     this._globalMatrix.translate(this.offset.x, this.offset.y);
-    // this._transformedPoints.length = 0;
     this.getTransformedPoints();
     this.getSides();
     this.getLocalSides();

--- a/src/engine/Collision/Colliders/PolygonCollider.ts
+++ b/src/engine/Collision/Colliders/PolygonCollider.ts
@@ -282,11 +282,11 @@ export class PolygonCollider extends Collider {
    */
   private _calculateTransformation() {
 
-      const len = this.points.length;
-      this._transformedPoints.length = 0; // clear out old transform
-      for (let i = 0; i < len; i++) {
-        this._transformedPoints[i] = this._globalMatrix.multiply(this.points[i].clone());
-      }
+    const len = this.points.length;
+    this._transformedPoints.length = 0; // clear out old transform
+    for (let i = 0; i < len; i++) {
+      this._transformedPoints[i] = this._globalMatrix.multiply(this.points[i].clone());
+    }
   }
 
   /**

--- a/src/engine/Collision/Colliders/PolygonCollider.ts
+++ b/src/engine/Collision/Colliders/PolygonCollider.ts
@@ -7,6 +7,7 @@ import { CollisionContact } from '../Detection/CollisionContact';
 import { Projection } from '../../Math/projection';
 import { Line } from '../../Math/line';
 import { Vector } from '../../Math/vector';
+import { Matrix } from '../../Math/matrix';
 import { Ray } from '../../Math/ray';
 import { ClosestLineJumpTable } from './ClosestLineJumpTable';
 import { Transform, TransformComponent } from '../../EntityComponentSystem';
@@ -36,11 +37,23 @@ export class PolygonCollider extends Collider {
    */
   public offset: Vector;
 
+  private _points: Vector[];
   /**
    * Points in the polygon in order around the perimeter in local coordinates. These are relative from the body transform position.
-   * Excalibur stores these in clockwise order
+   * Excalibur stores these in counter-clockwise order
    */
-  public points: Vector[];
+  public set points(points: Vector[]) {
+    this._localBoundsDirty = true;
+    this._points = points;
+  }
+
+  /**
+   * Points in the polygon in order around the perimeter in local coordinates. These are relative from the body transform position.
+   * Excalibur stores these in counter-clockwise order
+   */
+  public get points(): Vector[] {
+    return this._points;
+  }
 
   private _transform: Transform;
 
@@ -53,8 +66,8 @@ export class PolygonCollider extends Collider {
     super();
     this.offset = options.offset ?? Vector.Zero;
     this.points = options.points ?? [];
-    const clockwise = this._isClockwiseWinding(this.points);
-    if (!clockwise) {
+    const counterClockwise = this._isCounterClockwiseWinding(this.points);
+    if (!counterClockwise) {
       this.points.reverse();
     }
     if (!this.isConvex()) {
@@ -67,7 +80,7 @@ export class PolygonCollider extends Collider {
     this._calculateTransformation();
   }
 
-  private _isClockwiseWinding(points: Vector[]): boolean {
+  private _isCounterClockwiseWinding(points: Vector[]): boolean {
     // https://stackoverflow.com/a/1165943
     let sum = 0;
     for (let i = 0; i < points.length; i++) {
@@ -262,21 +275,18 @@ export class PolygonCollider extends Collider {
     return this.bounds.center;
   }
 
+  private _globalMatrix: Matrix = Matrix.identity();
+
   /**
    * Calculates the underlying transformation from the body relative space to world space
    */
   private _calculateTransformation() {
-    const transform = this._transform as TransformComponent;
 
-    const pos = transform ? transform.globalPos.add(this.offset) : this.offset;
-    const angle = transform ? transform.globalRotation : 0;
-    const scale = transform ? transform.globalScale : Vector.One;
-
-    const len = this.points.length;
-    this._transformedPoints.length = 0; // clear out old transform
-    for (let i = 0; i < len; i++) {
-      this._transformedPoints[i] = this.points[i].scale(scale).rotate(angle).add(pos);
-    }
+      const len = this.points.length;
+      this._transformedPoints.length = 0; // clear out old transform
+      for (let i = 0; i < len; i++) {
+        this._transformedPoints[i] = this._globalMatrix.multiply(this.points[i].clone());
+      }
   }
 
   /**
@@ -380,7 +390,11 @@ export class PolygonCollider extends Collider {
     this._sides.length = 0;
     this._localSides.length = 0;
     this._axes.length = 0;
-    this._transformedPoints.length = 0;
+    const tx = this._transform as TransformComponent;
+    const globalMat = tx?.getGlobalMatrix() ?? this._globalMatrix;
+    globalMat.clone(this._globalMatrix);
+    this._globalMatrix.translate(this.offset.x, this.offset.y);
+    // this._transformedPoints.length = 0;
     this.getTransformedPoints();
     this.getSides();
     this.getLocalSides();
@@ -502,18 +516,21 @@ export class PolygonCollider extends Collider {
    * Get the axis aligned bounding box for the polygon collider in world coordinates
    */
   public get bounds(): BoundingBox {
-    const tx = this._transform as TransformComponent;
-    const scale = tx?.globalScale ?? Vector.One;
-    const rotation = tx?.globalRotation ?? 0;
-    const pos = (tx?.globalPos ?? Vector.Zero).add(this.offset);
-    return this.localBounds.scale(scale).rotate(rotation).translate(pos);
+    return this.localBounds.transform(this._globalMatrix);
   }
 
+  private _localBoundsDirty = true;
+  private _localBounds: BoundingBox;
   /**
    * Get the axis aligned bounding box for the polygon collider in local coordinates
    */
   public get localBounds(): BoundingBox {
-    return BoundingBox.fromPoints(this.points);
+    if (this._localBoundsDirty) {
+      this._localBounds = BoundingBox.fromPoints(this.points);
+      this._localBoundsDirty = false;
+    }
+
+    return this._localBounds;
   }
 
   /**

--- a/src/engine/Collision/CollisionSystem.ts
+++ b/src/engine/Collision/CollisionSystem.ts
@@ -90,14 +90,14 @@ export class CollisionSystem extends System<TransformComponent | MotionComponent
     contacts = solver.solve(contacts);
 
     // Record contacts for start/end
-    for (let contact of contacts) {
+    for (const contact of contacts) {
       // Process composite ids, things with the same composite id are treated as the same collider for start/end
-      var index = contact.id.indexOf('|');
+      const index = contact.id.indexOf('|');
       if (index > 0) {
         const compositeId = contact.id.substring(index + 1);
         this._currentFrameContacts.set(compositeId, contact);
       } else {
-        this._currentFrameContacts.set(contact.id, contact)
+        this._currentFrameContacts.set(contact.id, contact);
       }
     }
 

--- a/src/engine/Collision/CollisionSystem.ts
+++ b/src/engine/Collision/CollisionSystem.ts
@@ -89,8 +89,17 @@ export class CollisionSystem extends System<TransformComponent | MotionComponent
     // Solve, this resolves the position/velocity so entities aren't overlapping
     contacts = solver.solve(contacts);
 
-    // Record contacts
-    contacts.forEach((c) => this._currentFrameContacts.set(c.id, c));
+    // Record contacts for start/end
+    for (let contact of contacts) {
+      // Process composite ids, things with the same composite id are treated as the same collider for start/end
+      var index = contact.id.indexOf('|');
+      if (index > 0) {
+        const compositeId = contact.id.substring(index + 1);
+        this._currentFrameContacts.set(compositeId, contact);
+      } else {
+        this._currentFrameContacts.set(contact.id, contact)
+      }
+    }
 
     // Emit contact start/end events
     this.runContactStartEnd();

--- a/src/engine/Collision/Detection/CollisionContact.ts
+++ b/src/engine/Collision/Detection/CollisionContact.ts
@@ -78,8 +78,8 @@ export class CollisionContact {
     this.info = info;
     this.id = Pair.calculatePairHash(colliderA.id, colliderB.id);
     if (colliderA.__compositeColliderId || colliderB.__compositeColliderId) {
-      // Potential problem id's are no longer unique
-      this.id = Pair.calculatePairHash(colliderA.__compositeColliderId ?? colliderA.id, colliderB.__compositeColliderId ?? colliderB.id);
+      // Add on the parent composite pair for start/end contact
+      this.id += '|' + Pair.calculatePairHash(colliderA.__compositeColliderId ?? colliderA.id, colliderB.__compositeColliderId ?? colliderB.id);
     }
   }
 

--- a/src/engine/Collision/Detection/CollisionContact.ts
+++ b/src/engine/Collision/Detection/CollisionContact.ts
@@ -79,7 +79,9 @@ export class CollisionContact {
     this.id = Pair.calculatePairHash(colliderA.id, colliderB.id);
     if (colliderA.__compositeColliderId || colliderB.__compositeColliderId) {
       // Add on the parent composite pair for start/end contact
-      this.id += '|' + Pair.calculatePairHash(colliderA.__compositeColliderId ?? colliderA.id, colliderB.__compositeColliderId ?? colliderB.id);
+      this.id += '|' + Pair.calculatePairHash(
+        colliderA.__compositeColliderId ?? colliderA.id,
+        colliderB.__compositeColliderId ?? colliderB.id);
     }
   }
 

--- a/src/engine/Collision/Detection/DynamicTree.ts
+++ b/src/engine/Collision/Detection/DynamicTree.ts
@@ -424,7 +424,7 @@ export class DynamicTree<T extends ColliderProxy<Entity>> {
   public query(collider: T, callback: (other: T) => boolean): void {
     const bounds = collider.bounds;
     const helper = (currentNode: TreeNode<T>): boolean => {
-      if (currentNode && currentNode.bounds.intersect(bounds)) {
+      if (currentNode && currentNode.bounds.overlaps(bounds)) {
         if (currentNode.isLeaf() && currentNode.data !== collider) {
           if (callback.call(collider, currentNode.data)) {
             return true;

--- a/src/engine/Collision/Solver/ArcadeSolver.ts
+++ b/src/engine/Collision/Solver/ArcadeSolver.ts
@@ -52,7 +52,7 @@ export class ArcadeSolver extends CollisionSolver {
     for (const contact of contacts) {
       // if bounds no longer interesect skip to the next
       // this removes jitter from overlapping/stacked solid tiles or a wall of solid tiles
-      if (!contact.colliderA.bounds.intersect(contact.colliderB.bounds)) {
+      if (!contact.colliderA.bounds.overlaps(contact.colliderB.bounds)) {
         continue;
       }
       let mtv = contact.mtv;

--- a/src/engine/Collision/Solver/ArcadeSolver.ts
+++ b/src/engine/Collision/Solver/ArcadeSolver.ts
@@ -74,11 +74,13 @@ export class ArcadeSolver extends CollisionSolver {
         if (bodyA.collisionType === CollisionType.Active) {
           bodyA.pos.x -= mtv.x;
           bodyA.pos.y -= mtv.y;
+          colliderA.update(bodyA.transform);
         }
 
         if (bodyB.collisionType === CollisionType.Active) {
           bodyB.pos.x += mtv.x;
           bodyB.pos.y += mtv.y;
+          colliderB.update(bodyB.transform);
         }
       }
     }

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
@@ -111,7 +111,7 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
    * Meant for internal use only. Access the internal context at your own risk and no guarantees this will exist in the future.
    * @internal
    */
-  public __gl: WebGLRenderingContext;
+  public __gl: WebGL2RenderingContext;
 
   private _transform = new TransformStack();
   private _state = new StateStack();
@@ -166,7 +166,7 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
 
   constructor(options: ExcaliburGraphicsContextOptions) {
     const { canvasElement, enableTransparency, smoothing, snapToPixel, backgroundColor, useDrawSorting } = options;
-    this.__gl = canvasElement.getContext('webgl', {
+    this.__gl = canvasElement.getContext('webgl2', {
       antialias: smoothing ?? this.smoothing,
       premultipliedAlpha: false,
       alpha: enableTransparency ?? true,

--- a/src/engine/Graphics/Context/circle-renderer/circle-renderer.frag.glsl
+++ b/src/engine/Graphics/Context/circle-renderer/circle-renderer.frag.glsl
@@ -1,22 +1,22 @@
-#ifdef GL_OES_standard_derivatives
-#extension GL_OES_standard_derivatives : enable
-#endif
+#version 300 es
 precision highp float;
 
 // UV coord
-varying vec2 v_uv;
+in vec2 v_uv;
 
 // Color coord to blend with image
-varying lowp vec4 v_color;
+in lowp vec4 v_color;
 
 // Stroke color if used
-varying lowp vec4 v_strokeColor;
+in lowp vec4 v_strokeColor;
 
 // Stroke thickness if used
-varying lowp float v_strokeThickness;
+in lowp float v_strokeThickness;
 
 // Opacity
-varying float v_opacity;
+in float v_opacity;
+
+out vec4 fragColor;
 
 void main() {
   // make (0, 0) the center the uv 
@@ -49,5 +49,5 @@ void main() {
   vec4 finalColor = mix(vec4(0.0), (color + strokeColor), fill);
   finalColor.rgb = finalColor.rgb * v_opacity;
   finalColor.a = finalColor.a * v_opacity;
-  gl_FragColor = finalColor;
+  fragColor = finalColor;
 }

--- a/src/engine/Graphics/Context/circle-renderer/circle-renderer.ts
+++ b/src/engine/Graphics/Context/circle-renderer/circle-renderer.ts
@@ -30,7 +30,6 @@ export class CircleRenderer implements RendererPlugin {
   initialize(gl: WebGLRenderingContext, context: ExcaliburGraphicsContextWebGL): void {
     this._gl = gl;
     this._context = context;
-    gl.getExtension('OES_standard_derivatives');
     this._shader = new Shader({
       fragmentSource: frag,
       vertexSource: vert

--- a/src/engine/Graphics/Context/circle-renderer/circle-renderer.vert.glsl
+++ b/src/engine/Graphics/Context/circle-renderer/circle-renderer.vert.glsl
@@ -1,21 +1,22 @@
-attribute vec2 a_position;
+#version 300 es
+in vec2 a_position;
 
 // UV coordinate
-attribute vec2 a_uv;
-varying vec2 v_uv;
+in vec2 a_uv;
+out vec2 v_uv;
 
 // Opacity 
-attribute float a_opacity;
-varying float v_opacity;
+in float a_opacity;
+out float v_opacity;
 
-attribute vec4 a_color;
-varying vec4 v_color;
+in vec4 a_color;
+out vec4 v_color;
 
-attribute vec4 a_strokeColor;
-varying vec4 v_strokeColor;
+in vec4 a_strokeColor;
+out vec4 v_strokeColor;
 
-attribute float a_strokeThickness;
-varying float v_strokeThickness;
+in float a_strokeThickness;
+out float v_strokeThickness;
 
 uniform mat4 u_matrix;
 

--- a/src/engine/Graphics/Context/image-renderer/image-renderer.frag.glsl
+++ b/src/engine/Graphics/Context/image-renderer/image-renderer.frag.glsl
@@ -1,16 +1,19 @@
+#version 300 es
 precision mediump float;
 
 // UV coord
-varying vec2 v_texcoord;
+in vec2 v_texcoord;
 
 // Texture index
-varying lowp float v_textureIndex;
+in lowp float v_textureIndex;
 
 // Textures in the current draw
 uniform sampler2D u_textures[%%count%%];
 
 // Opacity
-varying float v_opacity;
+in float v_opacity;
+
+out vec4 fragColor;
 
 void main() {
    // In order to support the most efficient sprite batching, we have multiple
@@ -24,5 +27,5 @@ void main() {
 
    color.rgb = color.rgb * v_opacity;
    color.a = color.a * v_opacity;
-   gl_FragColor = color;
+   fragColor = color;
 }

--- a/src/engine/Graphics/Context/image-renderer/image-renderer.ts
+++ b/src/engine/Graphics/Context/image-renderer/image-renderer.ts
@@ -83,7 +83,7 @@ export class ImageRenderer implements RendererPlugin {
       } else {
         texturePickerBuilder += `   else if (v_textureIndex <= ${i}.5) {\n`;
       }
-      texturePickerBuilder += `      color = texture2D(u_textures[${i}], v_texcoord);\n`;
+      texturePickerBuilder += `      color = texture(u_textures[${i}], v_texcoord);\n`;
       texturePickerBuilder += `   }\n`;
     }
     newSource = newSource.replace('%%texture_picker%%', texturePickerBuilder);
@@ -247,7 +247,7 @@ export class ImageRenderer implements RendererPlugin {
     this._shader.use();
 
     // Bind the memory layout and upload data
-    this._layout.use(true);
+    this._layout.use(true, 4 * 6 * this._imageCount);
 
     // Update ortho matrix uniform
     this._shader.setUniformMatrix('u_matrix', this._context.ortho);

--- a/src/engine/Graphics/Context/image-renderer/image-renderer.vert.glsl
+++ b/src/engine/Graphics/Context/image-renderer/image-renderer.vert.glsl
@@ -1,19 +1,19 @@
-attribute vec2 a_position;
+#version 300 es
+in vec2 a_position;
 
 // Opacity 
-attribute float a_opacity;
-varying float v_opacity;
+in float a_opacity;
+out float v_opacity;
 
 // UV coordinate
-attribute vec2 a_texcoord;
-varying vec2 v_texcoord;
+in vec2 a_texcoord;
+out vec2 v_texcoord;
 
 // Texture number
-attribute lowp float a_textureIndex;
-varying lowp float v_textureIndex;
+in lowp float a_textureIndex;
+out lowp float v_textureIndex;
 
 uniform mat4 u_matrix;
-
 
 void main() {
    // Set the vertex position using the ortho transform matrix

--- a/src/engine/Graphics/Context/line-renderer/line-fragment.glsl
+++ b/src/engine/Graphics/Context/line-renderer/line-fragment.glsl
@@ -1,9 +1,11 @@
+#version 300 es
 precision mediump float;
 
 // Color
-varying lowp vec4 v_color;
+in lowp vec4 v_color;
 
+out vec4 fragColor;
 
 void main() {
-  gl_FragColor = v_color;
+  fragColor = v_color;
 }

--- a/src/engine/Graphics/Context/line-renderer/line-vertex.glsl
+++ b/src/engine/Graphics/Context/line-renderer/line-vertex.glsl
@@ -1,10 +1,10 @@
-attribute vec2 a_position;
-attribute vec4 a_color;
+#version 300 es
+in vec2 a_position;
+in vec4 a_color;
 
-varying lowp vec4 v_color;
+out lowp vec4 v_color;
 
 uniform mat4 u_matrix;
-
 
 void main() {
    // Set the vertex position using the ortho transform matrix

--- a/src/engine/Graphics/Context/point-renderer/point-fragment.glsl
+++ b/src/engine/Graphics/Context/point-renderer/point-fragment.glsl
@@ -1,26 +1,20 @@
-#ifdef GL_OES_standard_derivatives
-#extension GL_OES_standard_derivatives : enable
-#endif
+#version 300 es
 
 precision mediump float;
-varying lowp vec4 v_color;
+in lowp vec4 v_color;
+
+out vec4 fragColor;
 
 void main() {
   float r = 0.0, delta = 0.0, alpha = 1.0;
   vec2 cxy = 2.0 * gl_PointCoord - 1.0;
   r = dot(cxy, cxy);
 
-#ifdef GL_OES_standard_derivatives
   delta = fwidth(r);
   alpha = 1.0 - smoothstep(1.0 - delta, 1.0 + delta, r);
-#else
-  if (r > 1.0) {
-    discard;
-  }
-#endif
   // "premultiply" the color by alpha
   vec4 color = v_color;
   color.a = color.a * alpha;
   color.rgb = color.rgb * color.a;
-  gl_FragColor = color;
+  fragColor = color;
 }

--- a/src/engine/Graphics/Context/point-renderer/point-vertex.glsl
+++ b/src/engine/Graphics/Context/point-renderer/point-vertex.glsl
@@ -1,7 +1,8 @@
-attribute vec2 a_position;
-attribute vec4 a_color;
-attribute float a_size;
-varying lowp vec4 v_color;
+#version 300 es
+in vec2 a_position;
+in vec4 a_color;
+in float a_size;
+out lowp vec4 v_color;
 uniform mat4 u_matrix;
 
 void main() {

--- a/src/engine/Graphics/Context/quad-index-buffer.ts
+++ b/src/engine/Graphics/Context/quad-index-buffer.ts
@@ -8,7 +8,7 @@ import { ExcaliburWebGLContextAccessor } from './webgl-adapter';
  * it is almost always worth it in terms of performance to use an index buffer.
  */
 export class QuadIndexBuffer {
-  private _gl: WebGLRenderingContext = ExcaliburWebGLContextAccessor.gl;
+  private _gl: WebGL2RenderingContext = ExcaliburWebGLContextAccessor.gl;
   private _logger: Logger = Logger.getInstance();
   /**
    * Access to the webgl buffer handle

--- a/src/engine/Graphics/Context/quad-index-buffer.ts
+++ b/src/engine/Graphics/Context/quad-index-buffer.ts
@@ -34,8 +34,7 @@ export class QuadIndexBuffer {
 
     const totalVertices = numberOfQuads * 6;
 
-    const ext = gl.getExtension('OES_element_index_uint');
-    if (ext && !useUint16) {
+    if (!useUint16) {
       this.bufferData = new Uint32Array(totalVertices);
     } else {
       // fall back to using gl.UNSIGNED_SHORT or tell the user they are out of luck

--- a/src/engine/Graphics/Context/rectangle-renderer/rectangle-renderer.frag.glsl
+++ b/src/engine/Graphics/Context/rectangle-renderer/rectangle-renderer.frag.glsl
@@ -1,24 +1,25 @@
-#ifdef GL_OES_standard_derivatives
-#extension GL_OES_standard_derivatives : enable
-#endif
+#version 300 es
+
 precision mediump float;
 
 // UV coord
-varying vec2 v_uv;
+in vec2 v_uv;
 
-varying vec2 v_size; // in pixels
+in vec2 v_size; // in pixels
 
 // Color coord to blend with image
-varying lowp vec4 v_color;
+in lowp vec4 v_color;
 
 // Stroke color if used
-varying lowp vec4 v_strokeColor;
+in lowp vec4 v_strokeColor;
 
 // Stroke thickness if used
-varying lowp float v_strokeThickness; // in pixels
+in lowp float v_strokeThickness; // in pixels
 
 // Opacity
-varying float v_opacity;
+in float v_opacity;
+
+out vec4 fragColor;
 
 void main() {
     // modified from https://stackoverflow.com/questions/59197671/glsl-rounded-rectangle-with-variable-border
@@ -31,12 +32,12 @@ void main() {
 
     if (fragCoord.x < maxX && fragCoord.x > minX &&
         fragCoord.y < maxY && fragCoord.y > minY) {
-      gl_FragColor = v_color;
+      fragColor = v_color;
     } else {
-      gl_FragColor = v_strokeColor;
+      fragColor = v_strokeColor;
     }
-    gl_FragColor.a *= v_opacity;
-    gl_FragColor.rgb *= gl_FragColor.a;
+    fragColor.a *= v_opacity;
+    fragColor.rgb *= fragColor.a;
 
     // vec2 v2CenteredPos     = abs(fragCoord - v_size.xy / 2.0);
     // vec2 v2HalfShapeSizePx = v_size.xy/2.0 - v_strokeThickness/2.0;

--- a/src/engine/Graphics/Context/rectangle-renderer/rectangle-renderer.ts
+++ b/src/engine/Graphics/Context/rectangle-renderer/rectangle-renderer.ts
@@ -30,7 +30,6 @@ export class RectangleRenderer implements RendererPlugin {
   initialize(gl: WebGLRenderingContext, context: ExcaliburGraphicsContextWebGL): void {
     this._gl = gl;
     this._context = context;
-    gl.getExtension('OES_standard_derivatives');
     // https://stackoverflow.com/questions/59197671/glsl-rounded-rectangle-with-variable-border
     this._shader = new Shader({
       fragmentSource: frag,

--- a/src/engine/Graphics/Context/rectangle-renderer/rectangle-renderer.vert.glsl
+++ b/src/engine/Graphics/Context/rectangle-renderer/rectangle-renderer.vert.glsl
@@ -1,24 +1,25 @@
-attribute vec2 a_position;
+#version 300 es
+in vec2 a_position;
 
 // UV coordinate
-attribute vec2 a_uv;
-varying vec2 v_uv;
+in vec2 a_uv;
+out vec2 v_uv;
 
-attribute vec2 a_size;
-varying vec2 v_size;
+in vec2 a_size;
+out vec2 v_size;
 
 // Opacity 
-attribute float a_opacity;
-varying float v_opacity;
+in float a_opacity;
+out float v_opacity;
 
-attribute vec4 a_color;
-varying vec4 v_color;
+in vec4 a_color;
+out vec4 v_color;
 
-attribute vec4 a_strokeColor;
-varying vec4 v_strokeColor;
+in vec4 a_strokeColor;
+out vec4 v_strokeColor;
 
-attribute float a_strokeThickness;
-varying float v_strokeThickness;
+in float a_strokeThickness;
+out float v_strokeThickness;
 
 uniform mat4 u_matrix;
 

--- a/src/engine/Graphics/Context/screen-pass-painter/screen-fragment.glsl
+++ b/src/engine/Graphics/Context/screen-pass-painter/screen-fragment.glsl
@@ -1,11 +1,14 @@
+#version 300 es
 precision mediump float;
 
 // Passed in from the vertex shader.
-varying vec2 v_texcoord;
+in vec2 v_texcoord;
 
 // The texture.
 uniform sampler2D u_texture;
 
+out vec4 fragColor;
+
 void main() {
-   gl_FragColor = texture2D(u_texture, v_texcoord);
+   fragColor = texture(u_texture, v_texcoord);
 }

--- a/src/engine/Graphics/Context/screen-pass-painter/screen-vertex.glsl
+++ b/src/engine/Graphics/Context/screen-pass-painter/screen-vertex.glsl
@@ -1,7 +1,8 @@
-attribute vec2 a_position;
+#version 300 es
+in vec2 a_position;
 
-attribute vec2 a_texcoord;
-varying vec2 v_texcoord;
+in vec2 a_texcoord;
+out vec2 v_texcoord;
 
 void main() {
   gl_Position = vec4(a_position, 0.0, 1.0);

--- a/src/engine/Graphics/Context/vertex-buffer.ts
+++ b/src/engine/Graphics/Context/vertex-buffer.ts
@@ -26,7 +26,7 @@ export interface VertexBufferOptions {
  * Under the hood uses Float32Array
  */
 export class VertexBuffer {
-  private _gl: WebGLRenderingContext = ExcaliburWebGLContextAccessor.gl;
+  private _gl: WebGL2RenderingContext = ExcaliburWebGLContextAccessor.gl;
 
   /**
    * Access to the webgl buffer handle
@@ -57,6 +57,10 @@ export class VertexBuffer {
       this.bufferData = data;
     }
     this.type = type ?? this.type;
+    // Allocate buffer
+    const gl = this._gl;
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, this.bufferData, this.type === 'static' ? gl.STATIC_DRAW : gl.DYNAMIC_DRAW);
   }
 
   /**
@@ -65,14 +69,20 @@ export class VertexBuffer {
   bind() {
     const gl = this._gl;
     gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
+
   }
 
   /**
    * Upload vertex buffer geometry to the GPU
    */
-  upload() {
+  upload(count?: number) {
     const gl = this._gl;
     gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
-    gl.bufferData(gl.ARRAY_BUFFER, this.bufferData, this.type === 'static' ? gl.STATIC_DRAW : gl.DYNAMIC_DRAW);
+    if (count) {
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, this.bufferData, 0, count);
+    } else {
+      // TODO always use bufferSubData? need to perf test it
+      gl.bufferData(gl.ARRAY_BUFFER, this.bufferData, this.type === 'static' ? gl.STATIC_DRAW : gl.DYNAMIC_DRAW);
+    }
   }
 }

--- a/src/engine/Graphics/Context/vertex-layout.ts
+++ b/src/engine/Graphics/Context/vertex-layout.ts
@@ -102,14 +102,14 @@ export class VertexLayout {
    *
    * @param uploadBuffer Optionally indicate you wish to upload the buffer to the GPU associated with this layout
    */
-  use(uploadBuffer = false) {
+  use(uploadBuffer = false, count?: number) {
     const gl = this._gl;
     if (!this._shader.isCurrentlyBound()) {
       throw Error('Shader associated with this vertex layout is not active! Call shader.use() before layout.use()');
     }
     this._vertexBuffer.bind();
     if (uploadBuffer) {
-      this._vertexBuffer.upload();
+      this._vertexBuffer.upload(count);
     }
     let offset = 0;
     // TODO switch to VAOs if the extension is

--- a/src/engine/Graphics/Context/webgl-adapter.ts
+++ b/src/engine/Graphics/Context/webgl-adapter.ts
@@ -3,15 +3,15 @@
  * Must be accessed after Engine construction time to ensure the context has been created
  */
 export class ExcaliburWebGLContextAccessor {
-  private static _GL: WebGLRenderingContext;
+  private static _GL: WebGL2RenderingContext;
   public static clear() {
     ExcaliburWebGLContextAccessor._GL = null;
   }
-  public static register(gl: WebGLRenderingContext) {
+  public static register(gl: WebGL2RenderingContext) {
     ExcaliburWebGLContextAccessor._GL = gl;
   }
   // current webgl context
-  public static get gl(): WebGLRenderingContext {
+  public static get gl(): WebGL2RenderingContext {
     if (!ExcaliburWebGLContextAccessor._GL) {
       throw Error('Attempted gl access before init');
     }

--- a/src/engine/Graphics/Font.ts
+++ b/src/engine/Graphics/Font.ts
@@ -157,13 +157,11 @@ export class Font extends Graphic implements FontRenderer {
     let cached = this._catchedTextMeasurement.get(text);
     if (!cached) {
       measurementDirty = true;
-      console.log('text unknown');
     }
 
-    let rasterProps = this._getRasterPropertiesHash();
+    const rasterProps = this._getRasterPropertiesHash();
     if (!cached || rasterProps !== cached.rasterProps) {
       measurementDirty = true;
-      console.log('raster props different');
     }
 
     if (measurementDirty) {
@@ -196,7 +194,7 @@ export class Font extends Graphic implements FontRenderer {
         text,
         rasterProps,
         measurement
-      }
+      };
       this._catchedTextMeasurement.set(text, cached);
       return cached.measurement;
     } else {

--- a/src/engine/Graphics/Font.ts
+++ b/src/engine/Graphics/Font.ts
@@ -139,7 +139,7 @@ export class Font extends Graphic implements FontRenderer {
   }
 
 
-  private _catchedTextMeasurement = new Map<string, {text: string, measurement: BoundingBox, rasterProps: string}>();
+  private _cachedTextMeasurement = new Map<string, {text: string, measurement: BoundingBox, rasterProps: string}>();
   private _bitmapToTextMeasurement = new Map<CanvasRenderingContext2D, {text: string, measurement: BoundingBox, rasterProps: string}>();
   /**
    * Returns a BoundingBox that is the total size of the text including multiple lines
@@ -150,7 +150,7 @@ export class Font extends Graphic implements FontRenderer {
    */
   public measureText(text: string): BoundingBox {
     let measurementDirty = false;
-    let cached = this._catchedTextMeasurement.get(text);
+    let cached = this._cachedTextMeasurement.get(text);
     if (!cached) {
       measurementDirty = true;
     }
@@ -191,7 +191,7 @@ export class Font extends Graphic implements FontRenderer {
         rasterProps,
         measurement
       };
-      this._catchedTextMeasurement.set(text, cached);
+      this._cachedTextMeasurement.set(text, cached);
       this._bitmapToTextMeasurement.set(ctx, cached);
       return cached.measurement;
     } else {
@@ -415,8 +415,10 @@ export class Font extends Graphic implements FontRenderer {
         this._bitmapUsage.delete(bitmap);
         // Cleanup measurements
         const measurement = this._bitmapToTextMeasurement.get(bitmap);
-        this._catchedTextMeasurement.delete(measurement.text);
-        this._bitmapToTextMeasurement.delete(bitmap);
+        if (measurement) {
+          this._cachedTextMeasurement.delete(measurement.text);
+          this._bitmapToTextMeasurement.delete(bitmap);
+        }
         TextureLoader.delete(bitmap.canvas);
       }
     }

--- a/src/engine/Graphics/Font.ts
+++ b/src/engine/Graphics/Font.ts
@@ -139,12 +139,8 @@ export class Font extends Graphic implements FontRenderer {
   }
 
 
-  // private _measurementDirty = true;
-  // private _cachedMeasurement: BoundingBox;
-  // private _cachedText: string;
-  // private _cachedRasterProps: string;
-
   private _catchedTextMeasurement = new Map<string, {text: string, measurement: BoundingBox, rasterProps: string}>();
+  private _bitmapToTextMeasurement = new Map<CanvasRenderingContext2D, {text: string, measurement: BoundingBox, rasterProps: string}>();
   /**
    * Returns a BoundingBox that is the total size of the text including multiple lines
    *
@@ -196,6 +192,7 @@ export class Font extends Graphic implements FontRenderer {
         measurement
       };
       this._catchedTextMeasurement.set(text, cached);
+      this._bitmapToTextMeasurement.set(ctx, cached);
       return cached.measurement;
     } else {
       return cached.measurement;
@@ -416,9 +413,10 @@ export class Font extends Graphic implements FontRenderer {
       // if bitmap hasn't been used in 1 second clear it
       if (time + 1000 < performance.now()) {
         this._bitmapUsage.delete(bitmap);
-        // TODO clean up cached measurements
-        // const text = this._textToBitmap.get(bitmap);
-        // this._catchedTextMeasurement.delete(text);
+        // Cleanup measurements
+        const measurement = this._bitmapToTextMeasurement.get(bitmap);
+        this._catchedTextMeasurement.delete(measurement.text);
+        this._bitmapToTextMeasurement.delete(bitmap);
         TextureLoader.delete(bitmap.canvas);
       }
     }

--- a/src/engine/Graphics/PostProcessor/ScreenShader.ts
+++ b/src/engine/Graphics/PostProcessor/ScreenShader.ts
@@ -14,10 +14,10 @@ export class ScreenShader {
   private _layout: VertexLayout;
   constructor(fragmentSource: string) {
     this._shader = new Shader({
-      vertexSource: `
-      attribute vec2 a_position;
-      attribute vec2 a_texcoord;
-      varying vec2 v_texcoord;
+      vertexSource: `#version 300 es
+      in vec2 a_position;
+      in vec2 a_texcoord;
+      out vec2 v_texcoord;
 
       void main() {
         gl_Position = vec4(a_position, 0.0, 1.0);

--- a/src/engine/Graphics/PostProcessor/color-blind-fragment.glsl
+++ b/src/engine/Graphics/PostProcessor/color-blind-fragment.glsl
@@ -1,8 +1,9 @@
+#version 300 es
 precision mediump float;
 // our texture
 uniform sampler2D u_image;
 // the texCoords passed in from the vertex shader.
-varying vec2 v_texcoord;
+in vec2 v_texcoord;
 
 // color blind type
 uniform int u_type;
@@ -10,8 +11,10 @@ uniform int u_type;
 // simulation?
 uniform bool u_simulate;
 
+out vec4 fragColor;
+
 void main() {
-  vec4 o =  texture2D(u_image, v_texcoord);
+  vec4 o =  texture(u_image, v_texcoord);
   // RGB to LMS matrix conversion
   float L = (17.8824 * o.r) + (43.5161 * o.g) + (4.11935 * o.b);
   float M = (3.45565 * o.r) + (27.1554 * o.g) + (3.86714 * o.b);
@@ -55,8 +58,8 @@ void main() {
 
   // sim 
   if (u_simulate) {
-    gl_FragColor = error.rgba;
+    fragColor = error.rgba;
   } else {
-    gl_FragColor = correction.rgba;
+    fragColor = correction.rgba;
   }
 }

--- a/src/engine/Loader.ts
+++ b/src/engine/Loader.ts
@@ -82,6 +82,7 @@ export class Loader extends Class implements Loadable<Loadable<any>[]> {
   public canvas: Canvas = new Canvas({
     filtering: ImageFiltering.Blended,
     smoothing: true,
+    cache: true,
     draw: this.draw.bind(this)
   });
   private _resourceList: Loadable<any>[] = [];
@@ -328,6 +329,7 @@ export class Loader extends Class implements Loadable<Loadable<any>[]> {
         r.load().finally(() => {
           // capture progress
           this._numLoaded++;
+          this.canvas.flagDirty();
         })
       )
     );
@@ -335,6 +337,7 @@ export class Loader extends Class implements Loadable<Loadable<any>[]> {
 
     // short delay in showing the button for aesthetics
     await delay(200, this._engine?.clock);
+    this.canvas.flagDirty();
 
     await this.showPlayButton();
     // Unlock browser AudioContext in after user gesture

--- a/src/engine/Util/Observable.ts
+++ b/src/engine/Util/Observable.ts
@@ -70,8 +70,14 @@ export class Observable<T> {
    * @param message
    */
   notifyAll(message: T) {
-    this.observers.forEach((o) => o.notify(message));
-    this.subscriptions.forEach(cb => cb(message));
+    const observersLength = this.observers.length;
+    for (let i = 0; i < observersLength; i++) {
+      this.observers[i].notify(message);
+    }
+    const subscriptionsLength = this.subscriptions.length;
+    for (let i = 0; i < subscriptionsLength; i++) {
+      this.subscriptions[i](message);
+    }
   }
 
   /**

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -348,24 +348,32 @@ describe('A game actor', () => {
     // move other actor into collision range from the right side
     other.pos.x = 9;
     other.pos.y = 0;
+    actor.collider.update();
+    other.collider.update();
     expect(actor.collider.bounds.intersectWithSide(other.collider.bounds)).toBe(ex.Side.Right);
     expect(other.collider.bounds.intersectWithSide(actor.collider.bounds)).toBe(ex.Side.Left);
 
     // move other actor into collision range from the left side
     other.pos.x = -9;
     other.pos.y = 0;
+    actor.collider.update();
+    other.collider.update();
     expect(actor.collider.bounds.intersectWithSide(other.collider.bounds)).toBe(ex.Side.Left);
     expect(other.collider.bounds.intersectWithSide(actor.collider.bounds)).toBe(ex.Side.Right);
 
     // move other actor into collision range from the top
     other.pos.x = 0;
     other.pos.y = -9;
+    actor.collider.update();
+    other.collider.update();
     expect(actor.collider.bounds.intersectWithSide(other.collider.bounds)).toBe(ex.Side.Top);
     expect(other.collider.bounds.intersectWithSide(actor.collider.bounds)).toBe(ex.Side.Bottom);
 
     // move other actor into collision range from the bottom
     other.pos.x = 0;
     other.pos.y = 9;
+    actor.collider.update();
+    other.collider.update();
     expect(actor.collider.bounds.intersectWithSide(other.collider.bounds)).toBe(ex.Side.Bottom);
     expect(other.collider.bounds.intersectWithSide(actor.collider.bounds)).toBe(ex.Side.Top);
   });

--- a/src/spec/CompositeColliderSpec.ts
+++ b/src/spec/CompositeColliderSpec.ts
@@ -144,7 +144,11 @@ describe('A CompositeCollider', () => {
     circle.update(xf);
 
     const contactBoxCircle = compCollider.collide(circle);
-    expect(contactBoxCircle[0].id).toBe(ex.Pair.calculatePairHash(compCollider.id, circle.id));
+    // Composite collisions have a special id that appends the "parent" id to the id to accurately track start/end
+    expect(contactBoxCircle[0].id).toBe(
+      ex.Pair.calculatePairHash(compCollider.getColliders()[1].id, circle.id) +
+      '|' +
+      ex.Pair.calculatePairHash(compCollider.id, circle.id));
   });
 
   it('can collide with other composite colliders', () => {

--- a/src/spec/QuadIndexBufferSpec.ts
+++ b/src/spec/QuadIndexBufferSpec.ts
@@ -39,7 +39,7 @@ describe('A QuadIndexBuffer', () => {
 
     sut.upload();
     expect(gl.bindBuffer).toHaveBeenCalledWith(gl.ELEMENT_ARRAY_BUFFER, sut.buffer);
-    expect(gl.bufferData).toHaveBeenCalledWith(gl.ELEMENT_ARRAY_BUFFER, sut.bufferData, gl.STATIC_DRAW);
+    expect(gl.bufferData as any).toHaveBeenCalledWith(gl.ELEMENT_ARRAY_BUFFER, sut.bufferData, gl.STATIC_DRAW);
   });
 
   it('can return the size of the buffer', () => {


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR takes a look at the slow areas in Excalibur and does some optimizations to improve their speed.
* Improve framerate during the loader screen
* Improve collision broadphase by swapping to use more efficient `overlaps` method
* Improve collision narrowphase by improving polygon collider calcuations for localBounds, bounds, and transformed points
* Improve Text/Fonts by caching the internal `measureText` calls 
* Fix bug with composite colliders having non-unique ids

TODO
* [x] Benchmarks
* [x] Tests

The 2000 actor benchmark stayed the same near 60 

Chrome 4000 actor benchmark 37 -> 39
![image](https://user-images.githubusercontent.com/612071/166168139-2b14efef-3cb4-43c7-ad23-f4e3fe8d9842.png)

I'll be including FF benchmarks from now on, in general the FF benchmarks are much worse than their chrome counterparts

FF 1000

![image](https://user-images.githubusercontent.com/612071/166168334-76029c88-6043-474c-a209-02094de6c978.png)

FF 2000

![image](https://user-images.githubusercontent.com/612071/166850041-68aa9606-4c28-449c-bf44-c73bf9447eba.png)


FF 4000

![image](https://user-images.githubusercontent.com/612071/166850055-0a0df024-caea-43c8-8dbc-cbc62efa9b89.png)

