### PR TITLE
feat(graphics): Add canvas 2d fallback mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 -
 
 ### Added
-
+- Added new performance fallback configuration to `ex.Engine` for developers to help players experiencing poor performance in non-standard browser configurations
+  * This will fallback to the Canvas2D rendering graphics context which usually performs better on non hardware accelerated browsers, currently postprocessing effects are unavailable in this fallback.
+  * By default if a game is running at 20fps or lower for 100 frames or more after the game has started it will be triggered, the developer can optionally show a player message that is off by default.
+  ```typescript
+    var game = new ex.Engine({
+      ...
+      configurePerformanceCanvas2DFallback: {
+        allow: true, // opt-out of the fallback
+        showPlayerMessage: true, // opt-in to a player pop-up message
+        threshold: { fps: 20, numberOfFrames: 100 } // configure the threshold to trigger the fallback
+      }
+    });
+  ```
 - Added new `ex.ParallaxComponent` for creating parallax effects on the graphics, entities with this component are drawn differently and a collider will not be where you expect. It is not recommended you use colliders with parallax entities.
   ```typescript
   const actor = new ex.Actor();

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -51,7 +51,16 @@ var game = new ex.Engine({
   displayMode: ex.DisplayMode.FitScreen,
   antialiasing: false,
   snapToPixel: true,
-  maxFps: 60
+  maxFps: 60,
+  configurePerformanceCanvas2DFallback: {
+    allow: true,
+    showPlayerMessage: true,
+    threshold: { fps: 20, numberOfFrames: 100 }
+  }
+});
+
+game.on('fallbackgraphicscontext', (ctx) => {
+  console.log('fallback triggered', ctx);
 });
 //@ts-ignore For some reason ts doesn't like the /// slash import
 const devtool = new ex.DevTools.DevTool(game);

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -42,6 +42,7 @@ import { PointerEventReceiver } from './Input/PointerEventReceiver';
 import { Clock, StandardClock } from './Util/Clock';
 import { ImageFiltering } from './Graphics/Filtering';
 import { GraphicsDiagnostics } from './Graphics/GraphicsDiagnostics';
+import { Toaster } from './Util/Toaster';
 
 /**
  * Enum representing the different mousewheel event bubble prevention
@@ -410,6 +411,8 @@ export class Engine extends Class implements CanInitialize, CanUpdate, CanDraw {
 
   private _logger: Logger;
 
+  private _toaster: Toaster = new Toaster();
+
   // this determines whether excalibur is compatible with your browser
   private _compatible: boolean;
 
@@ -635,6 +638,7 @@ O|===|* >________________>\n\
         'Ensure webgl.disabled = false, webgl.force-enabled = true, and layers.acceleration.force-enabled = true\n\n' +
         'Read more about this issue at https://excaliburjs.com/docs/webgl'
       );
+      
       useCanvasGraphicsContext = true;
     }
 
@@ -704,6 +708,11 @@ O|===|* >________________>\n\
       'If in Firefox, visit about:config. ' +
       'Ensure webgl.disabled = false, webgl.force-enabled = true, and layers.acceleration.force-enabled = true\n\n' +
       'Read more about this issue at https://excaliburjs.com/docs/webgl'
+    );
+
+    this._toaster.toast(
+      'Excalibur is encountering performance issues. It\'s possible that your browser doesn\'t have hardware acceleration enabled. Visit [LINK] for more information and potential solutions.',
+      'https://excaliburjs.com/docs/webgl'
     );
 
     const options = this._originalOptions;

--- a/src/engine/Flags.ts
+++ b/src/engine/Flags.ts
@@ -10,12 +10,13 @@ export class Flags {
   private static _FLAGS: Record<string, boolean> = {};
 
 
+  /**
+   * Force excalibur to load the Canvas 2D graphics context fallback
+   *
+   * @warning not all features of excalibur are supported in the Canvas 2D fallback
+   */
   public static useCanvasGraphicsContext() {
     Flags.enable('use-canvas-context');
-  }
-
-  public static isCanvasGraphicsContextEnabled() {
-    return Flags.isEnabled('use-canvas-context');
   }
 
   /**

--- a/src/engine/Flags.ts
+++ b/src/engine/Flags.ts
@@ -9,6 +9,15 @@ export class Flags {
   private static _FROZEN = false;
   private static _FLAGS: Record<string, boolean> = {};
 
+
+  public static useCanvasGraphicsContext() {
+    Flags.enable('use-canvas-context');
+  }
+
+  public static isCanvasGraphicsContextEnabled() {
+    return Flags.isEnabled('use-canvas-context');
+  }
+
   /**
    * Freeze all flag modifications making them readonly
    */

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContext2DCanvas.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContext2DCanvas.ts
@@ -281,15 +281,15 @@ export class ExcaliburGraphicsContext2DCanvas implements ExcaliburGraphicsContex
   }
 
   public addPostProcessor(_postprocessor: PostProcessor) {
-    throw Error('Not implemented');
+    // pass
   }
 
   public removePostProcessor(_postprocessor: PostProcessor) {
-    throw Error('Not implemented');
+    // pass
   }
 
   public clearPostProcessors() {
-    throw Error('Not implemented');
+    // pass
   }
 
   public beginDrawLifecycle() {

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
@@ -174,6 +174,9 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
       powerPreference: 'high-performance',
       failIfMajorPerformanceCaveat: true
     });
+    if (!this.__gl) {
+      throw Error("Failed to retrieve webgl context from browser")
+    }
     ExcaliburWebGLContextAccessor.register(this.__gl);
     TextureLoader.register(this.__gl);
     this.snapToPixel = snapToPixel ?? this.snapToPixel;

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
@@ -175,7 +175,7 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
       failIfMajorPerformanceCaveat: true
     });
     if (!this.__gl) {
-      throw Error("Failed to retrieve webgl context from browser")
+      throw Error('Failed to retrieve webgl context from browser');
     }
     ExcaliburWebGLContextAccessor.register(this.__gl);
     TextureLoader.register(this.__gl);

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
@@ -171,7 +171,8 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
       premultipliedAlpha: false,
       alpha: enableTransparency ?? true,
       depth: true,
-      powerPreference: 'high-performance'
+      powerPreference: 'high-performance',
+      failIfMajorPerformanceCaveat: true
     });
     ExcaliburWebGLContextAccessor.register(this.__gl);
     TextureLoader.register(this.__gl);

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -36,7 +36,7 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
   };
 
   public preupdate(): void {
-    // Graphics context could be switched to fallback
+    // Graphics context could be switched to fallback in a new frame
     this._graphicsContext = this._engine.graphicsContext;
     if (this._zHasChanged) {
       this._sortedTransforms.sort((a, b) => {

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -26,7 +26,6 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
   }
 
   public initialize(scene: Scene): void {
-    this._graphicsContext = scene.engine.graphicsContext;
     this._camera = scene.camera;
     this._engine = scene.engine;
   }
@@ -37,6 +36,8 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
   };
 
   public preupdate(): void {
+    // Graphics context could be switched to fallback
+    this._graphicsContext = this._engine.graphicsContext;
     if (this._zHasChanged) {
       this._sortedTransforms.sort((a, b) => {
         return a.z - b.z;

--- a/src/engine/Input/PointerEventReceiver.ts
+++ b/src/engine/Input/PointerEventReceiver.ts
@@ -58,6 +58,19 @@ export class PointerEventReceiver extends Class {
     super();
   }
 
+  /**
+   * Creates a new PointerEventReceiver with a new target and engine while preserving existing pointer event
+   * handlers.
+   * @param target
+   * @param engine
+   */
+  public recreate(target: GlobalEventHandlers & EventTarget, engine: Engine) {
+    const eventReceiver = new PointerEventReceiver(target, engine);
+    eventReceiver.primary = this.primary;
+    eventReceiver._pointers = this._pointers;
+    return eventReceiver;
+  }
+
   private _pointers: PointerAbstraction[] = [this.primary];
   /**
    * Locates a specific pointer by id, creates it if it doesn't exist

--- a/src/engine/Input/PointerSystem.ts
+++ b/src/engine/Input/PointerSystem.ts
@@ -45,7 +45,6 @@ export class PointerSystem extends System<TransformComponent | PointerComponent>
 
   public initialize(scene: Scene): void {
     this._engine = scene.engine;
-    this._receiver = this._engine.input.pointers;
   }
 
   private _sortedTransforms: TransformComponent[] = [];
@@ -57,6 +56,8 @@ export class PointerSystem extends System<TransformComponent | PointerComponent>
   };
 
   public preupdate(): void {
+    // event receiver might change per frame
+    this._receiver = this._engine.input.pointers;
     if (this._zHasChanged) {
       this._sortedTransforms.sort((a, b) => {
         return b.z - a.z;

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -6,6 +6,7 @@ import { BoundingBox } from './Collision/Index';
 import { ExcaliburGraphicsContext } from './Graphics/Context/ExcaliburGraphicsContext';
 import { getPosition } from './Util/Util';
 import { ExcaliburGraphicsContextWebGL } from './Graphics/Context/ExcaliburGraphicsContextWebGL';
+import { ExcaliburGraphicsContext2DCanvas } from './Graphics/Context/ExcaliburGraphicsContext2DCanvas';
 
 /**
  * Enum representing the different display modes available to Excalibur.
@@ -377,6 +378,9 @@ export class Screen {
     this.graphicsContext.updateViewport(this.resolution);
     this.graphicsContext.resetTransform();
     this.graphicsContext.smoothing = this._antialiasing;
+    if (this.graphicsContext instanceof ExcaliburGraphicsContext2DCanvas) {
+      this.graphicsContext.scale(this.pixelRatio, this.pixelRatio);
+    }
   }
 
   public get antialiasing() {

--- a/src/engine/Util/Toaster.css
+++ b/src/engine/Util/Toaster.css
@@ -1,0 +1,29 @@
+
+#ex-toast-container {
+  position: absolute;
+  height: 0;
+  width: 50%;
+  left: 50%;
+  top: 0;
+}
+
+.ex-toast-message {
+  left: -50%;
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+
+
+  padding: 10px;
+  margin-top: 5px;
+  font-size: 18px;
+  font-family: sans-serif;
+  border-radius: 6px;
+  border: 3px solid #b7b779;
+  background-color: rgb(253, 253, 192);
+}
+
+
+.ex-toast-message button {
+  align-self: flex-start;
+}

--- a/src/engine/Util/Toaster.css
+++ b/src/engine/Util/Toaster.css
@@ -2,7 +2,7 @@
 #ex-toast-container {
   position: absolute;
   height: 0;
-  width: 50%;
+  min-width: 50%;
   left: 50%;
   top: 0;
 }

--- a/src/engine/Util/Toaster.ts
+++ b/src/engine/Util/Toaster.ts
@@ -22,6 +22,14 @@ export class Toaster {
     }
   }
 
+  public dispose() {
+    this._container.parentElement.removeChild(this._container);
+
+    this._styleBlock.parentElement.removeChild(this._styleBlock);
+
+    this._isInitialized = false;
+  }
+
   private _createFragment(message: string) {
     const toastMessage = document.createElement('span');
     toastMessage.innerText = message;

--- a/src/engine/Util/Toaster.ts
+++ b/src/engine/Util/Toaster.ts
@@ -1,9 +1,12 @@
 import toasterCss from './Toaster.css';
+
+/**
+ * The Toaster is only meant to be called from inside Excalibur to display messages to players
+ */
 export class Toaster {
   private _styleBlock: HTMLStyleElement;
   private _container: HTMLDivElement;
   private _toasterCss: string = toasterCss.toString();
-  constructor() {}
 
   private _isInitialized = false;
   private _initialize() {
@@ -20,20 +23,26 @@ export class Toaster {
   }
 
   private _createFragment(message: string) {
-    let toastMessage = document.createElement('span');
+    const toastMessage = document.createElement('span');
     toastMessage.innerText = message;
     return toastMessage;
   }
 
+  /**
+   * Display a toast message to a player
+   * @param message Text of the message, messages may have a single "[LINK]" to influence placement
+   * @param linkTarget Optionally specify a link location
+   * @param linkName Optionally specify a name for that link location
+   */
   public toast(message: string, linkTarget?: string, linkName?: string) {
     this._initialize();
-    var toast = document.createElement('div');
+    const toast = document.createElement('div');
     toast.className = 'ex-toast-message';
 
-    let messageFragments: HTMLElement[] = message.split("[LINK]").map(message => this._createFragment(message));
+    const messageFragments: HTMLElement[] = message.split('[LINK]').map(message => this._createFragment(message));
 
     if (linkTarget) {
-      var link = document.createElement('a');
+      const link = document.createElement('a');
       link.href = linkTarget;
       if (linkName) {
         link.innerText = linkName;
@@ -42,33 +51,33 @@ export class Toaster {
       }
       messageFragments.splice(1, 0, link);
     }
-    
+
     // Assembly message
-    let finalMessage = document.createElement('div');
+    const finalMessage = document.createElement('div');
     messageFragments.forEach(message => {
       finalMessage.appendChild(message);
     });
     toast.appendChild(finalMessage);
 
     // Dismiss button
-    var dismissBtn = document.createElement('button');
-    dismissBtn.innerText = 'x'
+    const dismissBtn = document.createElement('button');
+    dismissBtn.innerText = 'x';
     dismissBtn.addEventListener('click', () => {
       this._container.removeChild(toast);
     });
     toast.appendChild(dismissBtn);
 
     // Escape to dismiss
-    let keydownHandler = (evt: KeyboardEvent) => {
-      if (evt.key === "Escape") {
-        this._container.removeChild(toast)
+    const keydownHandler = (evt: KeyboardEvent) => {
+      if (evt.key === 'Escape') {
+        this._container.removeChild(toast);
       }
       document.removeEventListener('keydown', keydownHandler);
-    }
+    };
     document.addEventListener('keydown', keydownHandler);
 
     // Insert into container
-    var first = this._container.firstChild;
+    const first = this._container.firstChild;
     this._container.insertBefore(toast, first);
   }
 }

--- a/src/engine/Util/Toaster.ts
+++ b/src/engine/Util/Toaster.ts
@@ -1,0 +1,74 @@
+import toasterCss from './Toaster.css';
+export class Toaster {
+  private _styleBlock: HTMLStyleElement;
+  private _container: HTMLDivElement;
+  private _toasterCss: string = toasterCss.toString();
+  constructor() {}
+
+  private _isInitialized = false;
+  private _initialize() {
+    if (!this._isInitialized) {
+      this._container = document.createElement('div');
+      this._container.id = 'ex-toast-container';
+      document.body.appendChild(this._container);
+      this._isInitialized = true;
+
+      this._styleBlock = document.createElement('style');
+      this._styleBlock.textContent = this._toasterCss;
+      document.head.appendChild(this._styleBlock);
+    }
+  }
+
+  private _createFragment(message: string) {
+    let toastMessage = document.createElement('span');
+    toastMessage.innerText = message;
+    return toastMessage;
+  }
+
+  public toast(message: string, linkTarget?: string, linkName?: string) {
+    this._initialize();
+    var toast = document.createElement('div');
+    toast.className = 'ex-toast-message';
+
+    let messageFragments: HTMLElement[] = message.split("[LINK]").map(message => this._createFragment(message));
+
+    if (linkTarget) {
+      var link = document.createElement('a');
+      link.href = linkTarget;
+      if (linkName) {
+        link.innerText = linkName;
+      } else {
+        link.innerText = linkTarget;
+      }
+      messageFragments.splice(1, 0, link);
+    }
+    
+    // Assembly message
+    let finalMessage = document.createElement('div');
+    messageFragments.forEach(message => {
+      finalMessage.appendChild(message);
+    });
+    toast.appendChild(finalMessage);
+
+    // Dismiss button
+    var dismissBtn = document.createElement('button');
+    dismissBtn.innerText = 'x'
+    dismissBtn.addEventListener('click', () => {
+      this._container.removeChild(toast);
+    });
+    toast.appendChild(dismissBtn);
+
+    // Escape to dismiss
+    let keydownHandler = (evt: KeyboardEvent) => {
+      if (evt.key === "Escape") {
+        this._container.removeChild(toast)
+      }
+      document.removeEventListener('keydown', keydownHandler);
+    }
+    document.addEventListener('keydown', keydownHandler);
+
+    // Insert into container
+    var first = this._container.firstChild;
+    this._container.insertBefore(toast, first);
+  }
+}

--- a/src/engine/Util/Toaster.ts
+++ b/src/engine/Util/Toaster.ts
@@ -78,7 +78,11 @@ export class Toaster {
     // Escape to dismiss
     const keydownHandler = (evt: KeyboardEvent) => {
       if (evt.key === 'Escape') {
-        this._container.removeChild(toast);
+        try {
+          this._container.removeChild(toast);
+        } catch {
+          // pass
+        }
       }
       document.removeEventListener('keydown', keydownHandler);
     };

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -70,6 +70,7 @@ export * from './Util/Pool';
 export * from './Util/Fps';
 export * from './Util/Clock';
 export * from './Util/WebAudio';
+export * from './Util/Toaster';
 
 // ex.Deprecated
 // import * as deprecated from './Deprecated';

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -145,6 +145,15 @@ describe('The engine', () => {
     expect(engine.useCanvas2DFallback).toHaveBeenCalled();
   });
 
+  it('can flag on to the canvas fallback', async () => {
+    engine = TestUtils.engine({
+      suppressPlayButton: false
+    }, ['use-canvas-context']);
+    await TestUtils.runToReady(engine);
+
+    expect(engine.graphicsContext).toBeInstanceOf(ex.ExcaliburGraphicsContext2DCanvas);
+  });
+
   it('should update the frame stats every tick', () => {
     engine = TestUtils.engine();
     const testClock = engine.clock as ex.TestClock;

--- a/src/spec/ToasterSpec.ts
+++ b/src/spec/ToasterSpec.ts
@@ -85,5 +85,5 @@ describe('A Toaster', () => {
 
     sut.dispose();
   });
-  
+
 });

--- a/src/spec/ToasterSpec.ts
+++ b/src/spec/ToasterSpec.ts
@@ -73,7 +73,7 @@ describe('A Toaster', () => {
 
     expect(toastContainer.textContent).toContain('Dismiss');
 
-    const toastButton = document.getElementsByTagName('button')[0];
+    const toastButton = toastContainer.getElementsByTagName('button')[0];
 
     expect(toastButton.textContent).toContain('x');
 

--- a/src/spec/ToasterSpec.ts
+++ b/src/spec/ToasterSpec.ts
@@ -1,0 +1,89 @@
+import * as ex from '@excalibur';
+
+describe('A Toaster', () => {
+  it('exists', () => {
+    expect(ex.Toaster).toBeDefined();
+  });
+
+  it('can be constructed', () => {
+    const sut = new ex.Toaster();
+    expect(sut).toBeDefined();
+  });
+
+  it('can pop a toast to a user', () => {
+    const sut = new ex.Toaster();
+
+    sut.toast('Some Toast Message');
+
+    const toastContainer = document.getElementById('ex-toast-container');
+
+    expect(toastContainer.textContent).toContain('Some Toast Message');
+    sut.dispose();
+  });
+
+  it('can pop a toast with a link and name', () => {
+    const sut = new ex.Toaster();
+
+    sut.toast('Link [LINK]', 'https://excaliburjs.com', 'excalibur-link');
+
+    const toastContainer = document.getElementById('ex-toast-container');
+
+    expect(toastContainer.textContent).toContain('Link');
+
+    expect(toastContainer.textContent).toContain('excalibur-link');
+
+    sut.dispose();
+  });
+
+  it('can pop a toast with just a link', () => {
+    const sut = new ex.Toaster();
+
+    sut.toast('Link [LINK]', 'https://excaliburjs.com');
+
+    const toastContainer = document.getElementById('ex-toast-container');
+
+    expect(toastContainer.textContent).toContain('Link');
+
+    expect(toastContainer.textContent).toContain('https://excaliburjs.com');
+
+    sut.dispose();
+  });
+
+  it('can pop a toast and be dismissed with escape', () => {
+    const sut = new ex.Toaster();
+
+    sut.toast('Dismiss');
+
+    const toastContainer = document.getElementById('ex-toast-container');
+
+    expect(toastContainer.textContent).toContain('Dismiss');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {'key': 'Escape'}));
+
+    expect(toastContainer.textContent).not.toContain('Dismiss');
+
+    sut.dispose();
+  });
+
+  it('can pop a toast and be dismissed with click', () => {
+    const sut = new ex.Toaster();
+
+    sut.toast('Dismiss');
+    const toastContainer = document.getElementById('ex-toast-container');
+
+    expect(toastContainer.textContent).toContain('Dismiss');
+
+    const toastButton = document.getElementsByTagName('button')[0];
+
+    expect(toastButton.textContent).toContain('x');
+
+    toastButton.click();
+
+    const toastMessageGone = document.getElementById('ex-toast-container');
+
+    expect(toastMessageGone.textContent).not.toContain('Dismiss');
+
+    sut.dispose();
+  });
+  
+});


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

See discussion #2304 

This PR adds the 2D canvas rendering context as a fallback if webgl fails for any reason. Also returns the ability to flag on the 2D canvas context as well.
