### PR TITLE
feat: [#2272] Add Fit Screen/Container and Zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `ex.TransformComponent.zIndexChange$` observable to watch when z index changes.
 - Added new display mode `ex.DisplayMode.FitContainerAndFill`.
 - Added new display mode `ex.DisplayMode.FitScreenAndFill`.
+- Added new display mode `ex.DisplayMode.FitContainerAndZoom`.
+- Added new display mode `ex.DisplayMode.FitScreenAndZoom`.
 
 ### Fixed
 

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -48,7 +48,7 @@ var game = new ex.Engine({
   pixelRatio: 1,
   suppressPlayButton: true,
   pointerScope: ex.Input.PointerScope.Canvas,
-  displayMode: ex.DisplayMode.FitScreenAndZoom,
+  displayMode: ex.DisplayMode.FitScreenAndFill,
   antialiasing: false,
   snapToPixel: true,
   maxFps: 60,

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -45,10 +45,10 @@ var game = new ex.Engine({
   height: 600 / 2,
   viewport: { width: 800, height: 600 },
   canvasElementId: 'game',
-  pixelRatio: 4,
+  pixelRatio: 1,
   suppressPlayButton: true,
   pointerScope: ex.Input.PointerScope.Canvas,
-  displayMode: ex.DisplayMode.FitScreen,
+  displayMode: ex.DisplayMode.FitScreenAndZoom,
   antialiasing: false,
   snapToPixel: true,
   maxFps: 60,
@@ -58,6 +58,27 @@ var game = new ex.Engine({
     threshold: { fps: 20, numberOfFrames: 100 }
   }
 });
+game.currentScene.onPreDraw = (ctx: ex.ExcaliburGraphicsContext) => {
+  ctx.save();
+  ctx.z = 99;
+  const red = ex.Color.fromHex('#F84541');
+  const green = ex.Color.fromHex('#3CCC2E');
+  const blue = ex.Color.fromHex('#3DDCFC');
+  const yellow = ex.Color.fromHex('#FDCF45');
+
+  const bb = game.screen.contentArea.clone();
+  bb.top++
+  bb.left++
+  bb.bottom--
+  bb.right--;
+  bb.draw(ctx, ex.Color.Yellow);
+
+  ctx.drawCircle(ex.vec(bb.left + 6, bb.top + 6), 10, green);
+  ctx.drawCircle(ex.vec(bb.right - 6, bb.top + 6), 10, blue);
+  ctx.drawCircle(ex.vec(bb.left + 6, bb.bottom - 6), 10, yellow);
+  ctx.drawCircle(ex.vec(bb.right - 6, bb.bottom - 6), 10, red);
+  ctx.restore();
+}
 
 game.on('fallbackgraphicscontext', (ctx) => {
   console.log('fallback triggered', ctx);

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -180,10 +180,6 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
     for (const ancestor of ancestors) {
       const transform = ancestor?.get(TransformComponent);
       if (transform) {
-        if (transform.coordPlane === CoordPlane.Screen) {
-          const safeArea = this._engine.screen.safeArea;
-          this._graphicsContext.translate(safeArea.left, safeArea.top);
-        }
         this._graphicsContext.z = transform.z;
         this._graphicsContext.translate(transform.pos.x, transform.pos.y);
         this._graphicsContext.scale(transform.scale.x, transform.scale.y);

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -180,6 +180,10 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
     for (const ancestor of ancestors) {
       const transform = ancestor?.get(TransformComponent);
       if (transform) {
+        if (transform.coordPlane === CoordPlane.Screen) {
+          const safeArea = this._engine.screen.safeArea;
+          this._graphicsContext.translate(safeArea.left, safeArea.top);
+        }
         this._graphicsContext.z = transform.z;
         this._graphicsContext.translate(transform.pos.x, transform.pos.y);
         this._graphicsContext.scale(transform.scale.x, transform.scale.y);

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -33,7 +33,7 @@ export enum DisplayMode {
 
   /**
    * Fit the viewport to the parent element maintaining aspect ratio given by the game resolution, but zooms in to avoid the black bars
-   * (letterbox) that would otherwise be present in [[FitContainer]]. 
+   * (letterbox) that would otherwise be present in [[FitContainer]].
    *
    * **warning** This will clip some drawable area from the user because of the zoom,
    * use [[Screen.contentArea]] to know the safe to draw area.
@@ -769,7 +769,7 @@ export class Screen {
       adjustedHeight = vh;
     }
 
-    const scaleX = vw / adjustedWidth
+    const scaleX = vw / adjustedWidth;
     const scaleY = vh / adjustedHeight;
 
     const maxScaleFactor = Math.max(scaleX, scaleY);
@@ -796,7 +796,7 @@ export class Screen {
     };
 
     const bounds = BoundingBox.fromDimension(this.viewport.width, this.viewport.height, Vector.Zero);
-      // return safe area
+    // return safe area
     if (this.viewport.width > vw) {
       const clip = (this.viewport.width - vw)/this.viewport.width * this.resolution.width;
       bounds.top = 0;

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -18,28 +18,36 @@ export enum DisplayMode {
   Fixed = 'Fixed',
 
   /**
-   * Fit an aspect ratio of the screen within the container at all times will fill the screen. This displayed area outside the aspect ratio
-   * is not guaranteed to be on the screen, only the [[Screen.contentArea]] is guaranteed to be on screen.
+   * Fit the aspect ratio given by the game resolution within the container at all times will fill any gaps with canvas.
+   * The displayed area outside the aspect ratio is not guaranteed to be on the screen, only the [[Screen.contentArea]]
+   * is guaranteed to be on screen.
    */
   FitContainerAndFill = 'FitContainerAndFill',
 
   /**
-   * Fit an aspect ratio within the screen at all times will fill the screen. This displayed area outside the aspect ratio is not
-   * guaranteed to be on the screen, only the [[Screen.contentArea]] is guaranteed to be on screen.
+   * Fit the aspect ratio given by the game resolution the screen at all times will fill the screen.
+   * This displayed area outside the aspect ratio is not guaranteed to be on the screen, only the [[Screen.contentArea]]
+   * is guaranteed to be on screen.
    */
   FitScreenAndFill = 'FitScreenAndFill',
 
-  /*
-   * Fit the viewport to the parent element maintaining aspect ratio, but zooms in to avoid the black bars (letterbox) that 
-   * would otherwise be present in [[FitContainer]]
+  /**
+   * Fit the viewport to the parent element maintaining aspect ratio given by the game resolution, but zooms in to avoid the black bars
+   * (letterbox) that would otherwise be present in [[FitContainer]]. 
+   *
+   * **warning** This will clip some drawable area from the user because of the zoom,
+   * use [[Screen.contentArea]] to know the safe to draw area.
    */
-  FitContainerAndZoom = 'ZoomToFitContainer',
+  FitContainerAndZoom = 'FitContainerAndZoom',
 
   /**
-   * Fit the viewport to the device screen maintaining aspect ratio, but zooms in to avoid the black bars (letterbox) that 
-   * would otherwise be present in [[FitScreen]]
+   * Fit the viewport to the device screen maintaining aspect ratio given by the game resolution, but zooms in to avoid the black bars
+   * (letterbox) that would otherwise be present in [[FitScreen]].
+   *
+   * **warning** This will clip some drawable area from the user because of the zoom,
+   * use [[Screen.contentArea]] to know the safe to draw area.
    */
-  FitScreenAndZoom = 'ZoomToFitScreen',
+  FitScreenAndZoom = 'FitScreenAndZoom',
 
   /**
    * Fit to screen using as much space as possible while maintaining aspect ratio and resolution.

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -69,6 +69,8 @@ describe('A Screen', () => {
 
     expect(sut.resolution.width).toBe(800);
     expect(sut.resolution.height).toBe(600);
+    expect(sut.contentArea.width).toBe(800);
+    expect(sut.contentArea.height).toBe(600);
     expect(sut.viewport.width).toBe(1000);
     expect(sut.viewport.height).toBe(1000 / sut.aspectRatio);
   });
@@ -89,6 +91,8 @@ describe('A Screen', () => {
 
     expect(sut.resolution.width).toBe(800);
     expect(sut.resolution.height).toBe(600);
+    expect(sut.contentArea.width).toBe(800);
+    expect(sut.contentArea.height).toBe(600);
     expect(sut.viewport.width).toBe(800 * sut.aspectRatio);
     expect(sut.viewport.height).toBe(800);
   });
@@ -109,6 +113,8 @@ describe('A Screen', () => {
 
     expect(sut.resolution.width).toBe(800);
     expect(sut.resolution.height).toBe(800);
+    expect(sut.contentArea.width).toBe(800);
+    expect(sut.contentArea.height).toBe(600);
     expect(sut.viewport.width).toBe(1300);
     expect(sut.viewport.height).toBe(1300);
   });
@@ -129,6 +135,8 @@ describe('A Screen', () => {
 
     expect(sut.resolution.width).toBe(975);
     expect(sut.resolution.height).toBe(600);
+    expect(sut.contentArea.width).toBe(800);
+    expect(sut.contentArea.height).toBe(600);
     expect(sut.viewport.width).toBe(1300);
     expect(sut.viewport.height).toBe(800);
   });
@@ -154,6 +162,8 @@ describe('A Screen', () => {
     expect(sut.parent).toBe(parentEl);
     expect(sut.resolution.width).toBe(800);
     expect(sut.resolution.height).toBe(800);
+    expect(sut.contentArea.width).toBe(800);
+    expect(sut.contentArea.height).toBe(600);
     expect(sut.viewport.width).toBe(1300);
     expect(sut.viewport.height).toBe(1300);
 
@@ -180,9 +190,109 @@ describe('A Screen', () => {
     expect(sut.parent).toBe(parentEl);
     expect(sut.resolution.width).toBe(975);
     expect(sut.resolution.height).toBe(600);
+    expect(sut.contentArea.width).toBe(800);
+    expect(sut.contentArea.height).toBe(600);
     expect(sut.viewport.width).toBe(1300);
     expect(sut.viewport.height).toBe(800);
 
+  });
+
+  it('can use the FitScreenAndZoom display mode, screen aspect ratio < window aspect ratio', () => {
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      displayMode: ex.DisplayMode.FitScreenAndZoom,
+      viewport: { width: 800, height: 600 }
+    });
+
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1300 });
+    Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 800 });
+
+    window.dispatchEvent(new Event('resize'));
+
+    expect(sut.resolution.width).toBe(800);
+    expect(sut.resolution.height).toBe(600);
+    expect(sut.contentArea.width).toBe(800);
+    expect(sut.contentArea.height).toBeCloseTo(492.3, 1);
+    expect(sut.viewport.width).toBe(1300);
+    expect(sut.viewport.height).toBeCloseTo(975);
+  });
+
+  it('can use the FitScreenAndZoom display mode, screen aspect ratio > window aspect ratio', () => {
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      displayMode: ex.DisplayMode.FitScreenAndZoom,
+      viewport: { width: 800, height: 600 }
+    });
+
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1300 });
+    Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 1300 });
+
+    window.dispatchEvent(new Event('resize'));
+
+    expect(sut.resolution.width).toBe(800);
+    expect(sut.resolution.height).toBe(600);
+    expect(sut.contentArea.width).toBe(600);
+    expect(sut.contentArea.height).toBe(600);
+    expect(sut.viewport.width).toBeCloseTo(1733.3, 1);
+    expect(sut.viewport.height).toBe(1300);
+  });
+
+  it('can use the FitContainerAndZoom display mode, screen aspect ratio < container aspect ratio', () => {
+
+    const parentEl = document.createElement('div');
+    document.body.removeChild(canvas);
+    parentEl.appendChild(canvas);
+    document.body.appendChild(parentEl);
+
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      displayMode: ex.DisplayMode.FitContainerAndZoom,
+      viewport: { width: 800, height: 600 }
+    });
+
+    parentEl.style.width = '1300px';
+    parentEl.style.height = '800px';
+    parentEl.dispatchEvent(new Event('resize'));
+
+    expect(sut.resolution.width).toBe(800);
+    expect(sut.resolution.height).toBe(600);
+    expect(sut.contentArea.width).toBe(800);
+    expect(sut.contentArea.height).toBeCloseTo(492.3, 1);
+    expect(sut.viewport.width).toBe(1300);
+    expect(sut.viewport.height).toBeCloseTo(975);
+  });
+
+  it('can use the FitContainerAndZoom display mode, screen aspect ratio > container aspect ratio', () => {
+
+    const parentEl = document.createElement('div');
+    document.body.removeChild(canvas);
+    parentEl.appendChild(canvas);
+    document.body.appendChild(parentEl);
+
+    const sut = new ex.Screen({
+      canvas,
+      context,
+      browser,
+      displayMode: ex.DisplayMode.FitContainerAndZoom,
+      viewport: { width: 800, height: 600 }
+    });
+
+    parentEl.style.width = '1300px';
+    parentEl.style.height = '1300px';
+    parentEl.dispatchEvent(new Event('resize'));
+
+    expect(sut.resolution.width).toBe(800);
+    expect(sut.resolution.height).toBe(600);
+    expect(sut.contentArea.width).toBe(600);
+    expect(sut.contentArea.height).toBe(600);
+    expect(sut.viewport.width).toBeCloseTo(1733.3, 1);
+    expect(sut.viewport.height).toBe(1300);
   });
 
   describe('can use fit container display mode, the viewport', () => {


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Related #2272

This PR implements a fit screen/container and zoom to avoid the letter boxing, this is achieved by over scaling the viewport and positioning. One caveat is this will clip some drawable area so should only be used in games that are okay with losing some draw space. This PR also adds a `ex.Screen.contentArea` which will return the "safe space" to place content given the current screen size.

New display modes `ex.DisplayMode.FitScreenAndZoom` and `ex.DisplayMode.FitContainerAndZoom`

![image](https://user-images.githubusercontent.com/612071/168433294-5bc3467a-f308-4e3f-9b78-30c0a3dce7b5.png)

Notice that some of the viewport is offscreen
