### PR TITLE
feat: Implement Fixed timestep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   const game = new ex.Engine({
     fixedUpdateFps: 20 // 20 fps fixed update, or a fixed update delta of 50 milliseconds
   });
+  // turn off interpolation on a per actor basis
+  const actor = new ex.Actor({...});
+  actor.body.enableFixedUpdateInterpolate = false;
+  game.add(game);
   ```
 
 - Allowed setting playback `ex.Sound.duration` which will limit the amount of time that a clip plays from the current playback position.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 -
 
 ### Added
+- Added new fixed update step to Excalibur! This allows developers to configure a fixed FPS for the update loop. One advantage of setting a fix update is that you will have a more consistent and predictable physics simulation. Excalibur graphics will be interpolated automatically to avoid any jitter in the fixed update.
+  * If the fixed update FPS is greater than the display FPS, excalibur will run multiple updates in a row (at the configured update elapsed) to catch up, for example there could be X updates and 1 draw each clock step.
+  * If the fixed update FPS is less than the display FPS, excalibur will skip updates until it meets the desired FPS, for example there could be no update for 1 draw each clock step.
+  ```typescript
+  const game = new ex.Engine({
+    fixedUpdateFps: 20 // 20 fps fixed update, or a fixed update delta of 50 milliseconds
+  });
+  ```
+
 - Allowed setting playback `ex.Sound.duration` which will limit the amount of time that a clip plays from the current playback position.
 - Added a new lightweight `ex.StateMachine` type for building finite state machines
   ```typescript

--- a/sandbox/tests/side-collision/index.ts
+++ b/sandbox/tests/side-collision/index.ts
@@ -2,6 +2,7 @@
 var game = new ex.Engine({
   width: 400,
   height: 400,
+  fixedUpdateFps: 10,
   displayMode: ex.DisplayMode.FitScreenAndFill
 });
 

--- a/sandbox/tests/side-collision/index.ts
+++ b/sandbox/tests/side-collision/index.ts
@@ -41,7 +41,7 @@ class Player2 extends ex.Actor {
   // After main update, once per frame execute this code
   onPreUpdate(engine) {
     // Reset x velocity
-    // this.vel.x = 0;
+    this.vel.x = 0;
 
     // Player input
     if (engine.input.keyboard.isHeld(ex.Input.Keys.Left)) {
@@ -84,7 +84,7 @@ game.add(
     collisionType: ex.CollisionType.Fixed
   })
 );
-
-game.add(new Player2());
+var player2 = new Player2();
+game.add(player2);
 
 game.start();

--- a/sandbox/tests/side-collision2/index.ts
+++ b/sandbox/tests/side-collision2/index.ts
@@ -2,6 +2,7 @@
 var game = new ex.Engine({
   width: 400,
   height: 400,
+  fixedUpdateFps: 10,
   displayMode: ex.DisplayMode.FitScreenAndFill
 });
 

--- a/src/engine/Collision/BodyComponent.ts
+++ b/src/engine/Collision/BodyComponent.ts
@@ -36,7 +36,17 @@ export class BodyComponent extends Component<'ex.body'> implements Clonable<Body
   public events = new EventDispatcher();
 
   private _oldTransform = Matrix.identity();
-  public oldTransformValid: boolean = false;
+
+  /**
+   * Indicates whether the old transform has been captured at least once for interpolation
+   * @internal
+   */
+  public __oldTransformCaptured: boolean = false;
+
+  /**
+   * Enable or disabled the fixed update interpolation, by default interpolation is on.
+   */
+  public enableFixedUpdateInterpolate = true;
 
   constructor(options?: BodyComponentOptions) {
     super();
@@ -372,7 +382,7 @@ export class BodyComponent extends Component<'ex.body'> implements Clonable<Body
    */
   public captureOldTransform() {
     // Capture old values before integration step updates them
-    this.oldTransformValid = true;
+    this.__oldTransformCaptured = true;
     this.transform.getGlobalMatrix().clone(this._oldTransform);
     this.oldVel.setTo(this.vel.x, this.vel.y);
     this.oldAcc.setTo(this.acc.x, this.acc.y);

--- a/src/engine/Collision/BodyComponent.ts
+++ b/src/engine/Collision/BodyComponent.ts
@@ -36,6 +36,7 @@ export class BodyComponent extends Component<'ex.body'> implements Clonable<Body
   public events = new EventDispatcher();
 
   private _oldTransform = Matrix.identity();
+  public oldTransformValid: boolean = false;
 
   constructor(options?: BodyComponentOptions) {
     super();
@@ -371,6 +372,7 @@ export class BodyComponent extends Component<'ex.body'> implements Clonable<Body
    */
   public captureOldTransform() {
     // Capture old values before integration step updates them
+    this.oldTransformValid = true;
     this.transform.getGlobalMatrix().clone(this._oldTransform);
     this.oldVel.setTo(this.vel.x, this.vel.y);
     this.oldAcc.setTo(this.acc.x, this.acc.y);

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -185,6 +185,19 @@ export interface EngineOptions {
   maxFps?: number;
 
   /**
+   * Optionally configure a fixed update fps, this can be desireable if you need the physics simulation to be very stable. When set
+   * the update step and physics will use the same elapsed time for each tick even if the graphical framerate drops. In order for the 
+   * simulation to be correct, excalibur will run multiple updates in a row (at the configured update elapsed) to catch up, for example
+   * there could be X updates and 1 draw each clock step.
+   * 
+   * **NOTE:** This does come at a potential perf cost because each catch-up update will need to be run if the fixed rate is greater than
+   * the current instantaneous framerate, or perf gain if the fixed rate is less than the current framerate.
+   * 
+   * By default is unset and updates will use the current instantaneous framerate with 1 update and 1 draw each clock step.
+   */
+  fixedUpdateFps?: number
+
+  /**
    * Default `true`, optionally configure excalibur to use optimal draw call sorting, to opt out set this to `false`.
    *
    * Excalibur will automatically sort draw calls by z and priority into renderer batches for maximal draw performance,
@@ -257,6 +270,19 @@ export class Engine extends Class implements CanInitialize, CanUpdate, CanDraw {
    * one that bounces between 30fps and 60fps
    */
   public maxFps: number = Number.POSITIVE_INFINITY;
+
+  /**
+   * Optionally configure a fixed update fps, this can be desireable if you need the physics simulation to be very stable. When set
+   * the update step and physics will use the same elapsed time for each tick even if the graphical framerate drops. In order for the
+   * simulation to be correct, excalibur will run multiple updates in a row (at the configured update elapsed) to catch up, for example
+   * there could be X updates and 1 draw each clock step.
+   *
+   * **NOTE:** This does come at a potential perf cost because each catch-up update will need to be run if the fixed rate is greater than
+   * the current instantaneous framerate, or perf gain if the fixed rate is less than the current framerate.
+   *
+   * By default is unset and updates will use the current instantaneous framerate with 1 update and 1 draw each clock step.
+   */
+  public fixedUpdateFps?: number;
 
   /**
    * Direct access to the excalibur clock
@@ -699,6 +725,7 @@ O|===|* >________________>\n\
     }
 
     this.maxFps = options.maxFps ?? this.maxFps;
+    this.fixedUpdateFps = options.fixedUpdateFps ?? this.fixedUpdateFps;
 
     this.clock = new StandardClock({
       maxFps: this.maxFps,
@@ -1198,7 +1225,7 @@ O|===|* >________________>\n\
    * Draws the entire game
    * @param delta  Number of milliseconds elapsed since the last draw.
    */
-  private _draw(delta: number) {
+  private _draw(delta: number, _lag: number) {
     this.graphicsContext.beginDrawLifecycle();
     this.graphicsContext.clear();
     this._predraw(this.graphicsContext, delta);
@@ -1213,7 +1240,7 @@ O|===|* >________________>\n\
     // TODO move to graphics systems?
     this.graphicsContext.backgroundColor = this.backgroundColor;
 
-    this.currentScene.draw(this.graphicsContext, delta);
+    this.currentScene.draw(this.graphicsContext, delta, _lag);
 
     this._postdraw(this.graphicsContext, delta);
 
@@ -1340,13 +1367,13 @@ O|===|* >________________>\n\
     return this._isReadyPromise;
   }
 
-  private _useFixedUpdateTimeStep = false;
-  private _fixedUpdateFps = 60;
-  private _fixedTimestep = 1000 / this._fixedUpdateFps;
-  private _lag = 0;
+  public elapsed = 0;
+  public lag = 0;
+  private _lagMs = 0;
   private _mainloop(elapsed: number) {
     this.emit('preframe', new PreFrameEvent(this, this.stats.prevFrame));
     const delta = elapsed * this.timescale;
+    this.elapsed = delta;
 
     // reset frame stats (reuse existing instances)
     const frameId = this.stats.prevFrame.id + 1;
@@ -1357,20 +1384,20 @@ O|===|* >________________>\n\
     GraphicsDiagnostics.clear();
 
     const beforeUpdate = this.clock.now();
-    if (this._useFixedUpdateTimeStep) {
-      this._lag += elapsed;
-      while (this._lag >= this._fixedTimestep) {
-        // updates++;
-        this._update(this._fixedTimestep);
-        this._lag -= this._fixedTimestep;
+    const fixedTimestepMs = 1000 / this.fixedUpdateFps;
+    if (this.fixedUpdateFps) {
+      this._lagMs += delta;
+      while (this._lagMs >= fixedTimestepMs) {
+        this._update(fixedTimestepMs);
+        this._lagMs -= fixedTimestepMs;
       }
     } else {
       this._update(delta);
     }
     const afterUpdate = this.clock.now();
     // TODO interpolate offset
-    // const lagOffset = this._lag / this._fixedTimestep;
-    this._draw(delta);
+    this.lag = this._lagMs;
+    this._draw(delta, this._lagMs);
     const afterDraw = this.clock.now();
 
     this.stats.currFrame.duration.update = afterUpdate - beforeUpdate;

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1367,13 +1367,21 @@ O|===|* >________________>\n\
     return this._isReadyPromise;
   }
 
-  public elapsed = 0;
-  public lag = 0;
+  /**
+   * Returns the current frames elapsed milliseconds
+   */
+  public currentFrameElapsedMs = 0;
+
+  /**
+   * Returns the current frame lag when in fixed update mode
+   */
+  public currentFrameLagMs = 0;
+
   private _lagMs = 0;
   private _mainloop(elapsed: number) {
     this.emit('preframe', new PreFrameEvent(this, this.stats.prevFrame));
     const delta = elapsed * this.timescale;
-    this.elapsed = delta;
+    this.currentFrameElapsedMs = delta;
 
     // reset frame stats (reuse existing instances)
     const frameId = this.stats.prevFrame.id + 1;
@@ -1396,7 +1404,7 @@ O|===|* >________________>\n\
     }
     const afterUpdate = this.clock.now();
     // TODO interpolate offset
-    this.lag = this._lagMs;
+    this.currentFrameLagMs = this._lagMs;
     this._draw(delta, this._lagMs);
     const afterDraw = this.clock.now();
 

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -186,13 +186,13 @@ export interface EngineOptions {
 
   /**
    * Optionally configure a fixed update fps, this can be desireable if you need the physics simulation to be very stable. When set
-   * the update step and physics will use the same elapsed time for each tick even if the graphical framerate drops. In order for the 
+   * the update step and physics will use the same elapsed time for each tick even if the graphical framerate drops. In order for the
    * simulation to be correct, excalibur will run multiple updates in a row (at the configured update elapsed) to catch up, for example
    * there could be X updates and 1 draw each clock step.
-   * 
+   *
    * **NOTE:** This does come at a potential perf cost because each catch-up update will need to be run if the fixed rate is greater than
    * the current instantaneous framerate, or perf gain if the fixed rate is less than the current framerate.
-   * 
+   *
    * By default is unset and updates will use the current instantaneous framerate with 1 update and 1 draw each clock step.
    */
   fixedUpdateFps?: number

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1340,6 +1340,10 @@ O|===|* >________________>\n\
     return this._isReadyPromise;
   }
 
+  private _useFixedUpdateTimeStep = false;
+  private _fixedUpdateFps = 60;
+  private _fixedTimestep = 1000 / this._fixedUpdateFps;
+  private _lag = 0;
   private _mainloop(elapsed: number) {
     this.emit('preframe', new PreFrameEvent(this, this.stats.prevFrame));
     const delta = elapsed * this.timescale;
@@ -1353,8 +1357,19 @@ O|===|* >________________>\n\
     GraphicsDiagnostics.clear();
 
     const beforeUpdate = this.clock.now();
-    this._update(delta);
+    if (this._useFixedUpdateTimeStep) {
+      this._lag += elapsed;
+      while (this._lag >= this._fixedTimestep) {
+        // updates++;
+        this._update(this._fixedTimestep);
+        this._lag -= this._fixedTimestep;
+      }
+    } else {
+      this._update(delta);
+    }
     const afterUpdate = this.clock.now();
+    // TODO interpolate offset
+    // const lagOffset = this._lag / this._fixedTimestep;
     this._draw(delta);
     const afterDraw = this.clock.now();
 

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -186,18 +186,27 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
       const transform = ancestor?.get(TransformComponent);
       const optionalBody = ancestor?.get(BodyComponent);
       let interpolatedPos = transform.pos;
+      let interpolatedScale = transform.scale;
+      let interpolatedRotation = transform.rotation;
       if (this._engine.fixedUpdateFps && optionalBody && optionalBody.oldTransformValid) {
         // Interpolate graphics if needed
         const blend = this._engine.lag / Math.max(this._engine.elapsed, 1000 / this._engine.fixedUpdateFps);
         interpolatedPos = optionalBody.pos.scale(blend).add(
           optionalBody.oldPos.scale(1.0 - blend)
         );
+        interpolatedScale = optionalBody.scale.scale(blend).add(
+          optionalBody.oldScale.scale(1.0 - blend)
+        )
+        // Rotational lerp https://stackoverflow.com/a/30129248
+        const cosine = (1.0 - blend) * Math.cos(optionalBody.oldRotation) + blend * Math.cos(optionalBody.rotation);
+        const sine = (1.0 - blend) * Math.sin(optionalBody.oldRotation) + blend * Math.sin(optionalBody.rotation);
+        interpolatedRotation = Math.atan2(sine, cosine);
       }
       if (transform) {
         this._graphicsContext.z = transform.z;
         this._graphicsContext.translate(interpolatedPos.x, interpolatedPos.y);
-        this._graphicsContext.scale(transform.scale.x, transform.scale.y);
-        this._graphicsContext.rotate(transform.rotation);
+        this._graphicsContext.scale(interpolatedScale.x, interpolatedScale.y);
+        this._graphicsContext.rotate(interpolatedRotation);
       }
     }
   }

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -196,7 +196,7 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
         );
         interpolatedScale = optionalBody.scale.scale(blend).add(
           optionalBody.oldScale.scale(1.0 - blend)
-        )
+        );
         // Rotational lerp https://stackoverflow.com/a/30129248
         const cosine = (1.0 - blend) * Math.cos(optionalBody.oldRotation) + blend * Math.cos(optionalBody.rotation);
         const sine = (1.0 - blend) * Math.sin(optionalBody.oldRotation) + blend * Math.sin(optionalBody.rotation);

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -109,7 +109,7 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
       }
 
       // Position the entity + estimate lag
-      this._applyTransform(entity, delta);
+      this._applyTransform(entity);
 
       // Optionally run the onPreDraw graphics lifecycle draw
       if (graphics.onPreDraw) {
@@ -180,7 +180,7 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
    * This applies the current entity transform to the graphics context
    * @param entity
    */
-  private _applyTransform(entity: Entity, _delta: number): void {
+  private _applyTransform(entity: Entity): void {
     const ancestors = entity.getAncestors();
     for (const ancestor of ancestors) {
       const transform = ancestor?.get(TransformComponent);
@@ -194,7 +194,7 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
             optionalBody.enableFixedUpdateInterpolate) {
 
           // Interpolate graphics if needed
-          const blend = this._engine.lag / Math.max(this._engine.elapsed, 1000 / this._engine.fixedUpdateFps);
+          const blend = this._engine.currentFrameLagMs / (1000 / this._engine.fixedUpdateFps);
           interpolatedPos = optionalBody.pos.scale(blend).add(
             optionalBody.oldPos.scale(1.0 - blend)
           );

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -188,20 +188,26 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
       let interpolatedPos = transform.pos;
       let interpolatedScale = transform.scale;
       let interpolatedRotation = transform.rotation;
-      if (this._engine.fixedUpdateFps && optionalBody && optionalBody.oldTransformValid) {
-        // Interpolate graphics if needed
-        const blend = this._engine.lag / Math.max(this._engine.elapsed, 1000 / this._engine.fixedUpdateFps);
-        interpolatedPos = optionalBody.pos.scale(blend).add(
-          optionalBody.oldPos.scale(1.0 - blend)
-        );
-        interpolatedScale = optionalBody.scale.scale(blend).add(
-          optionalBody.oldScale.scale(1.0 - blend)
-        );
-        // Rotational lerp https://stackoverflow.com/a/30129248
-        const cosine = (1.0 - blend) * Math.cos(optionalBody.oldRotation) + blend * Math.cos(optionalBody.rotation);
-        const sine = (1.0 - blend) * Math.sin(optionalBody.oldRotation) + blend * Math.sin(optionalBody.rotation);
-        interpolatedRotation = Math.atan2(sine, cosine);
+      if (optionalBody) {
+        if (this._engine.fixedUpdateFps &&
+            optionalBody.__oldTransformCaptured &&
+            optionalBody.enableFixedUpdateInterpolate) {
+
+          // Interpolate graphics if needed
+          const blend = this._engine.lag / Math.max(this._engine.elapsed, 1000 / this._engine.fixedUpdateFps);
+          interpolatedPos = optionalBody.pos.scale(blend).add(
+            optionalBody.oldPos.scale(1.0 - blend)
+          );
+          interpolatedScale = optionalBody.scale.scale(blend).add(
+            optionalBody.oldScale.scale(1.0 - blend)
+          );
+          // Rotational lerp https://stackoverflow.com/a/30129248
+          const cosine = (1.0 - blend) * Math.cos(optionalBody.oldRotation) + blend * Math.cos(optionalBody.rotation);
+          const sine = (1.0 - blend) * Math.sin(optionalBody.oldRotation) + blend * Math.sin(optionalBody.rotation);
+          interpolatedRotation = Math.atan2(sine, cosine);
+        }
       }
+
       if (transform) {
         this._graphicsContext.z = transform.z;
         this._graphicsContext.translate(interpolatedPos.x, interpolatedPos.y);

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -368,10 +368,10 @@ export class Scene extends Class implements CanInitialize, CanActivate, CanDeact
    * @param ctx    The current rendering context
    * @param delta  The number of milliseconds since the last draw
    */
-  public draw(ctx: ExcaliburGraphicsContext, delta: number) {
+  public draw(ctx: ExcaliburGraphicsContext, delta: number, _lag?: number) {
     this._predraw(ctx, delta);
 
-    this.world.update(SystemType.Draw, delta);
+    this.world.update(SystemType.Draw, _lag ?? delta);
 
     if (this.engine?.isDebug) {
       this.debugDraw(ctx);

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -145,6 +145,44 @@ describe('The engine', () => {
     expect(engine.useCanvas2DFallback).toHaveBeenCalled();
   });
 
+  it('can use a fixed update fps and can catch up', async () => {
+    engine = TestUtils.engine({
+      fixedUpdateFps: 30
+    });
+
+    const clock = engine.clock as ex.TestClock;
+
+    await TestUtils.runToReady(engine);
+
+    spyOn(engine as any, '_update');
+    spyOn(engine as any, '_draw');
+
+    clock.step(101);
+
+    expect((engine as any)._update).toHaveBeenCalledTimes(3);
+    expect((engine as any)._draw).toHaveBeenCalledTimes(1);
+  });
+
+  it('can use a fixed update fps and will skip updates', async () => {
+    engine = TestUtils.engine({
+      fixedUpdateFps: 30
+    });
+
+    const clock = engine.clock as ex.TestClock;
+
+    await TestUtils.runToReady(engine);
+
+    spyOn(engine as any, '_update');
+    spyOn(engine as any, '_draw');
+
+    clock.step(16);
+    clock.step(16);
+    clock.step(16);
+
+    expect((engine as any)._update).toHaveBeenCalledTimes(1);
+    expect((engine as any)._draw).toHaveBeenCalledTimes(3);
+  });
+
   it('can flag on to the canvas fallback', async () => {
     engine = TestUtils.engine({
       suppressPlayButton: false


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

v0.27.0 Milestone related,

This PR adds the ability to configure a fixed FPS for the update loop. One advantage of setting a fix update is that you will have a more consistent and predictable physics simulation. Excalibur graphics will be interpolated automatically to avoid any jitter in the fixed update.
  * If the fixed update FPS is greater than the display FPS, excalibur will run multiple updates in a row (at the configured update elapsed) to catch up, for example there could be X updates and 1 draw each clock step.
  * If the fixed update FPS is less than the display FPS, excalibur will skip updates until it meets the desired FPS, for example there could be no update for 1 draw each clock step.

```typescript
const game = new ex.Engine({
  fixedUpdateFps: 20 // 20 fps fixed update, or a fixed update delta of 50 milliseconds
});
```

The graphics interpolation can be turned off on a per body basis.

```typescript
// turn off interpolation on a per actor basis
const actor = new ex.Actor({...});
actor.body.enableFixedUpdateInterpolate = false;
```

Fixed update @ 10 fps - graphics without interpolation

![no-interpolation](https://user-images.githubusercontent.com/612071/173153936-892c3f50-fc1c-42a5-b508-1ababd780fa2.gif)

Fixed update @ 10 fps - graphics with interpolation

![interpolation](https://user-images.githubusercontent.com/612071/173153955-e8fa0204-0380-4e70-868b-20db4dcc6deb.gif)

TODOs:

* [x] Interpolate graphics to prevent jitter
* [x] Convenient way to set in constructor
* [x] Tests

