### PR TITLE
fix: [#2347] EventDispatcher concurrent update issue and removal bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Breaking Changes
 
--
+- `ex.EventDispatcher` meta events 'subscribe' and 'unsubscribe' were unused and undocumented and have been removed
 
 ### Deprecated
 
@@ -83,6 +83,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue with `ex.EventDispatcher` where removing a handler that didn't already exist would remove another handler by mistake
+- Fixed issue with `ex.EventDispatcher` where concurrent modifications of the handler list where handlers would or would not fire correctly and throw
 - Fixed issue with `ex.ArcadeSolver` based collisions where colliders were catching on seams when sliding along a floor of multiple colliders. This was by sorting contacts by distance between bodies.
   ![sorted-collisions](https://user-images.githubusercontent.com/612071/172401390-9e9c3490-3566-47bf-b258-6a7da86a3464.gif)
 

--- a/src/engine/EventDispatcher.ts
+++ b/src/engine/EventDispatcher.ts
@@ -15,7 +15,7 @@ export class EventDispatcher<T = any> implements Eventable {
 
   private _deferedHandlerRemovals: {name: string, handler?: (...args: any[]) => any }[] = [];
   private _processDeferredHandlerRemovals() {
-    for (let eventHandler of this._deferedHandlerRemovals) {
+    for (const eventHandler of this._deferedHandlerRemovals) {
       this._removeHandler(eventHandler.name, eventHandler.handler);
     }
     this._deferedHandlerRemovals.length = 0;
@@ -62,7 +62,7 @@ export class EventDispatcher<T = any> implements Eventable {
   public on(eventName: string, handler: (event: GameEvent<T>) => void) {
     this._processDeferredHandlerRemovals();
     eventName = eventName.toLowerCase();
-    
+
     if (!this._handlers[eventName]) {
       this._handlers[eventName] = [];
     }
@@ -84,7 +84,7 @@ export class EventDispatcher<T = any> implements Eventable {
   private _removeHandler(eventName: string, handler?: (event: GameEvent<T>) => void) {
     eventName = eventName.toLowerCase();
     const eventHandlers = this._handlers[eventName];
-    
+
     if (eventHandlers) {
       // if no explicit handler is give with the event name clear all handlers
       if (!handler) {

--- a/src/engine/Events.ts
+++ b/src/engine/Events.ts
@@ -51,9 +51,6 @@ export enum EventTypes {
   Button = 'button',
   Axis = 'axis',
 
-  Subscribe = 'subscribe',
-  Unsubscribe = 'unsubscribe',
-
   Visible = 'visible',
   Hidden = 'hidden',
   Start = 'start',
@@ -360,26 +357,6 @@ export class GamepadAxisEvent extends GameEvent<Input.Gamepad> {
    * @param value A numeric value between -1 and 1
    */
   constructor(public axis: Input.Axes, public value: number, public target: Input.Gamepad) {
-    super();
-  }
-}
-
-/**
- * Subscribe event thrown when handlers for events other than subscribe are added. Meta event that is received by
- * [[EventDispatcher|event dispatchers]].
- */
-export class SubscribeEvent<T> extends GameEvent<T> {
-  constructor(public topic: string, public handler: (event: GameEvent<T>) => void) {
-    super();
-  }
-}
-
-/**
- * Unsubscribe event thrown when handlers for events other than unsubscribe are removed. Meta event that is received by
- * [[EventDispatcher|event dispatchers]].
- */
-export class UnsubscribeEvent<T> extends GameEvent<T> {
-  constructor(public topic: string, public handler: (event: GameEvent<T>) => void) {
     super();
   }
 }

--- a/src/spec/EventSpec.ts
+++ b/src/spec/EventSpec.ts
@@ -154,9 +154,9 @@ describe('An Event Dispatcher', () => {
   it('should not fail if event handlers change during iteration', () => {
     expect(() => {
       const dispatcher = new ex.EventDispatcher();
-      dispatcher.once('foo', () => console.log('foo1'));
-      dispatcher.on('foo', () => console.log('foo2'));
-      dispatcher.on('foo', () => console.log('foo3'));
+      dispatcher.once('foo', () => 'foo1');
+      dispatcher.on('foo', () => 'foo2');
+      dispatcher.on('foo', () => 'foo3');
       dispatcher.emit('foo', null);
     }).not.toThrow();
   });

--- a/src/spec/EventSpec.ts
+++ b/src/spec/EventSpec.ts
@@ -57,7 +57,7 @@ describe('An Event Dispatcher', () => {
     pubsub.emit('event', null);
     expect(eventHistory).toEqual(subscriptions);
 
-    pubsub.off('event');
+    pubsub.off('event'); // clear all handlers
     subscriptions.push(subscriptions.shift());
 
     eventHistory = [];
@@ -115,5 +115,49 @@ describe('An Event Dispatcher', () => {
     pubsub.emit('onlyonce', null);
 
     expect(callCount).toBe(1, 'There should only be one call to the handler with once.');
+  });
+
+  it('will handle remove invalid handler', () => {
+    const eventSpy1 = jasmine.createSpy('handler');
+    const eventSpy2 = jasmine.createSpy('handler');
+    const eventSpy3 = jasmine.createSpy('handler');
+    const dispatcher = new ex.EventDispatcher();
+    dispatcher.on('foo', () => eventSpy1());
+    dispatcher.on('foo', () => eventSpy2());
+    dispatcher.on('foo', () => eventSpy3());
+    dispatcher.off('foo', () => 'invalid');
+    dispatcher.emit('foo', null);
+
+    expect(eventSpy1).toHaveBeenCalled();
+    expect(eventSpy2).toHaveBeenCalled();
+    expect(eventSpy3).toHaveBeenCalled();
+    expect(eventSpy1).toHaveBeenCalledBefore(eventSpy2);
+    expect(eventSpy2).toHaveBeenCalledBefore(eventSpy3);
+  });
+
+  it('once will remove the handler correctly', () => {
+    const eventSpy1 = jasmine.createSpy('handler');
+    const eventSpy2 = jasmine.createSpy('handler');
+    const eventSpy3 = jasmine.createSpy('handler');
+    const dispatcher = new ex.EventDispatcher();
+    dispatcher.once('foo', () => eventSpy1());
+    dispatcher.on('foo', () => eventSpy2());
+    dispatcher.on('foo', () => eventSpy3());
+    dispatcher.emit('foo', null);
+    dispatcher.emit('foo', null);
+
+    expect(eventSpy1).toHaveBeenCalledTimes(1);
+    expect(eventSpy2).toHaveBeenCalledTimes(2);
+    expect(eventSpy3).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not fail if event handlers change during iteration', () => {
+    expect(() => {
+      const dispatcher = new ex.EventDispatcher();
+      dispatcher.once('foo', () => console.log('foo1'));
+      dispatcher.on('foo', () => console.log('foo2'));
+      dispatcher.on('foo', () => console.log('foo3'));
+      dispatcher.emit('foo', null);
+    }).not.toThrow();
   });
 });


### PR DESCRIPTION

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2347

This PR fixes several issues in the `ex.EventDispatcher`
* Concurrent updates of handlers was not handled well, this has been fixed by implementing deferred removal
* If a handler didn't exist the wrong handler would be removed instead (classic splice(-1, 1) bug)

