### PR TITLE
fix: [#2353] EdgeColliders in Composite calculate offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add target element id to `ex.Screen.goFullScreen('some-element-id')` to influence the fullscreen element in the fullscreen browser API.
 
 ### Fixed
+- Fixed issue where `ex.EdgeCollider` were not working properly in `ex.CompositeCollider` for `ex.TileMap`'s
 - Fixed issue where `ex.BoundingBox` overlap return false due to floating point rounding error causing multiple collisions to be evaluated sometimes
 - Fixed issue with `ex.EventDispatcher` where removing a handler that didn't already exist would remove another handler by mistake
 - Fixed issue with `ex.EventDispatcher` where concurrent modifications of the handler list where handlers would or would not fire correctly and throw

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -11,6 +11,9 @@
       <li><a href="html/index.html">Sandbox Platformer</a></li>
       <li><a href="tests/parallel/">Parallel Actions</a></li>
       <li><a href="tests/isometric/">Isometric Map</a></li>
+      <li><a href="tests/side-collision/">Arcade: Sliding on Floor</a></li>
+      <li><a href="tests/side-collision2/">Arcade: No clipping divergent collisions</a></li>
+      <li><a href="tests/tilemap-custom-edge-collider/">Edge colliders work in a tilemap</a></li>
       <li><a href="tests/triangulation/index.html">Triangulation</a></li>
       <li><a href="tests/parallax/">Parallax</a></li>
       <li><a href="tests/parallel/">Parallel</a></li>

--- a/sandbox/tests/physics/physics.ts
+++ b/sandbox/tests/physics/physics.ts
@@ -73,11 +73,17 @@ function spawnCircle(x: number, y: number) {
   game.add(circle);
 }
 
-// var edge = new ex.Actor(200, 300, 5, 5, ex.Color.Blue.clone());
-// edge.body.collisionType = ex.CollisionType.Fixed;
-// edge.collider.useEdgeCollider(new ex.Vector(0, 0), new ex.Vector(200, 0));
+var edge = new ex.Actor({
+  x: 200,
+  y:300,
+  width: 5,
+  height: 5, 
+  color: ex.Color.Blue.clone()
+});
+edge.body.collisionType = ex.CollisionType.Fixed;
+edge.collider.useEdgeCollider(new ex.Vector(0, 0), new ex.Vector(200, 0));
 // // edge.rx = .4;
-// game.add(edge);
+game.add(edge);
 
 
 // var solid = new ex.Actor(300, 380, 100, 100, ex.Color.Azure.clone());
@@ -122,4 +128,4 @@ game.input.pointers.primary.on('down', (evt: ex.Input.PointerEvent) => {
 
 game.start();
 //@ts-ignore
-const dev = new ex.DevTools.DevTool(game);
+// const dev = new ex.DevTools.DevTool(game);

--- a/sandbox/tests/side-collision/index.html
+++ b/sandbox/tests/side-collision/index.html
@@ -7,6 +7,7 @@
   <title>Side Collision</title>
 </head>
 <body>
+  <p>There should be no left right collisions in the console when sliding on the floor</p>
   <script src="../../lib/excalibur.js"></script>
   <script src="index.js"></script>
 </body>

--- a/sandbox/tests/side-collision2/index.html
+++ b/sandbox/tests/side-collision2/index.html
@@ -7,6 +7,7 @@
   <title>Side Collision</title>
 </head>
 <body>
+  <p>Arcade solver collisions shouldn't clip on the edge of a collider and cancel velocity</p>
   <script src="../../lib/excalibur.js"></script>
   <script src="index.js"></script>
 </body>

--- a/sandbox/tests/tilemap-custom-edge-collider/index.html
+++ b/sandbox/tests/tilemap-custom-edge-collider/index.html
@@ -7,6 +7,7 @@
   <title>TileMap Edge Collider</title>
 </head>
 <body>
+  <p>TileMap should support edge colliders, the green collider to the left should work</p>
   <script src="../../lib/excalibur.js"></script>
    <script src="index.js"></script>
 </body>

--- a/sandbox/tests/tilemap-custom-edge-collider/index.html
+++ b/sandbox/tests/tilemap-custom-edge-collider/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TileMap Edge Collider</title>
+</head>
+<body>
+  <script src="../../lib/excalibur.js"></script>
+   <script src="index.js"></script>
+</body>
+</html>

--- a/sandbox/tests/tilemap-custom-edge-collider/index.ts
+++ b/sandbox/tests/tilemap-custom-edge-collider/index.ts
@@ -1,0 +1,84 @@
+// Creates a spritesheet
+// var tilesheet = ex.SpriteSheet.fromImageSource({
+//   image: new ex.ImageSource("path/to/source"),
+//   grid: {
+//     rows: 17,
+//     columns: 20,
+//     spriteHeight: 32,
+//     spriteWidth: 32
+//   },
+// });
+
+var game = new ex.Engine({
+  width: 800,
+  height: 600
+});
+game.toggleDebug();
+
+// Initializes an empty tilemap
+var tilemap = new ex.TileMap({
+  columns: 30,
+  rows: 30,
+  tileHeight: 32,
+  tileWidth: 32
+});
+
+// Sets properties and graphic to each tile
+tilemap.tiles.forEach(tile => {
+  if (tile.x === 1) {
+    // Graphic symbolizing a path
+    // tile.addGraphic(tilesheet.getSprite(4, 1));
+    // This works right but copies bounds of the tile
+    tile.solid = true;
+    tile.clearColliders();
+    // This part doesn't work
+    // tile.addCollider(ex.Shape.Circle(16));
+    tile.addCollider(new ex.EdgeCollider({
+      begin: new ex.Vector(0, 0),
+      end: new ex.Vector(0, 32)
+    }));
+  } else {
+    // Random graphic with no colliders
+    // tile.addGraphic(tilesheet.getSprite(Math.floor(Math.random() * 10), Math.floor(Math.random() * 10)));
+  }
+});
+// This refers to a Scene
+game.add(tilemap);
+
+var edge = new ex.Actor({
+  pos: ex.vec(100, 200),
+  collisionType: ex.CollisionType.Fixed
+});
+
+edge.collider.useEdgeCollider(ex.vec(0, 0), ex.vec(0, 100));
+game.add(edge);
+
+var player = new ex.Actor({
+  pos: ex.vec(100, 100),
+  width: 16,
+  height: 16,
+  color: ex.Color.Blue,
+  collisionType: ex.CollisionType.Active
+});
+
+player.onPostUpdate = () => {
+  player.vel.setTo(0, 0);
+  const speed = 64;
+  if (game.input.keyboard.isHeld(ex.Input.Keys.Right)) {
+     player.vel.x = speed;
+  }
+  if (game.input.keyboard.isHeld(ex.Input.Keys.Left)) {
+     player.vel.x = -speed;
+  }
+  if (game.input.keyboard.isHeld(ex.Input.Keys.Up)) {
+     player.vel.y = -speed;
+  }
+  if (game.input.keyboard.isHeld(ex.Input.Keys.Down)) {
+     player.vel.y = speed;
+  }
+}
+game.add(player);
+
+game.currentScene.camera.strategy.elasticToActor(player, .8, .9);
+game.currentScene.camera.zoom = 3;
+game.start();

--- a/sandbox/tests/tilemap-custom-edge-collider/index.ts
+++ b/sandbox/tests/tilemap-custom-edge-collider/index.ts
@@ -1,14 +1,3 @@
-// Creates a spritesheet
-// var tilesheet = ex.SpriteSheet.fromImageSource({
-//   image: new ex.ImageSource("path/to/source"),
-//   grid: {
-//     rows: 17,
-//     columns: 20,
-//     spriteHeight: 32,
-//     spriteWidth: 32
-//   },
-// });
-
 var game = new ex.Engine({
   width: 800,
   height: 600
@@ -30,9 +19,6 @@ tilemap.tiles.forEach(tile => {
     // tile.addGraphic(tilesheet.getSprite(4, 1));
     // This works right but copies bounds of the tile
     tile.solid = true;
-    tile.clearColliders();
-    // This part doesn't work
-    // tile.addCollider(ex.Shape.Circle(16));
     tile.addCollider(new ex.EdgeCollider({
       begin: new ex.Vector(0, 0),
       end: new ex.Vector(0, 32)
@@ -50,7 +36,7 @@ var edge = new ex.Actor({
   collisionType: ex.CollisionType.Fixed
 });
 
-edge.collider.useEdgeCollider(ex.vec(0, 0), ex.vec(0, 100));
+edge.collider.useEdgeCollider(ex.vec(0, 0), ex.vec(0, 100),);
 game.add(edge);
 
 var player = new ex.Actor({

--- a/src/engine/Collision/Colliders/CollisionJumpTable.ts
+++ b/src/engine/Collision/Colliders/CollisionJumpTable.ts
@@ -208,7 +208,6 @@ export const CollisionJumpTable = {
       // Fudge the contact back to edge
       contact[0].colliderB = edge;
       (contact[0].id as any) = Pair.calculatePairHash(polygon.id, edge.id);
-      // contact[0].info.collider
     }
     return contact;
   },

--- a/src/engine/Collision/Colliders/EdgeCollider.ts
+++ b/src/engine/Collision/Colliders/EdgeCollider.ts
@@ -13,6 +13,7 @@ import { Collider } from './Collider';
 import { ClosestLineJumpTable } from './ClosestLineJumpTable';
 import { ExcaliburGraphicsContext } from '../../Graphics/Context/ExcaliburGraphicsContext';
 import { Transform } from '../../Math/transform';
+import { AffineMatrix } from '../../Math/affine-matrix';
 
 export interface EdgeColliderOptions {
   /**
@@ -38,6 +39,7 @@ export class EdgeCollider extends Collider {
   end: Vector;
 
   private _transform: Transform;
+  private _globalMatrix: AffineMatrix = AffineMatrix.identity();
 
   constructor(options: EdgeColliderOptions) {
     super();
@@ -76,15 +78,11 @@ export class EdgeCollider extends Collider {
   }
 
   private _getTransformedBegin(): Vector {
-    const tx = this._transform;
-    const angle = tx ? tx.globalRotation : 0;
-    return this.begin.rotate(angle).add(this._getBodyPos());
+    return this._globalMatrix.multiply(this.begin);//.rotate(angle).add(this._getBodyPos());
   }
 
   private _getTransformedEnd(): Vector {
-    const tx = this._transform;
-    const angle = tx ? tx.globalRotation : 0;
-    return this.end.rotate(angle).add(this._getBodyPos());
+    return this._globalMatrix.multiply(this.end);//.rotate(angle).add(this._getBodyPos());
   }
 
   /**
@@ -257,6 +255,9 @@ export class EdgeCollider extends Collider {
    */
   public update(transform: Transform): void {
     this._transform = transform;
+    const globalMat = transform.matrix ?? this._globalMatrix;
+    globalMat.clone(this._globalMatrix);
+    this._globalMatrix.translate(this.offset.x, this.offset.y);
   }
 
   /**

--- a/src/engine/Collision/Colliders/EdgeCollider.ts
+++ b/src/engine/Collision/Colliders/EdgeCollider.ts
@@ -67,22 +67,18 @@ export class EdgeCollider extends Collider {
    * Get the center of the collision area in world coordinates
    */
   public get center(): Vector {
-    const pos = this.begin.average(this.end).add(this._getBodyPos());
+    const begin = this._getTransformedBegin();
+    const end = this._getTransformedEnd();
+    const pos = begin.average(end);
     return pos;
   }
 
-  private _getBodyPos(): Vector {
-    const tx = this._transform;
-    const bodyPos = tx?.globalPos ?? Vector.Zero;
-    return bodyPos;
-  }
-
   private _getTransformedBegin(): Vector {
-    return this._globalMatrix.multiply(this.begin);//.rotate(angle).add(this._getBodyPos());
+    return this._globalMatrix.multiply(this.begin);
   }
 
   private _getTransformedEnd(): Vector {
-    return this._globalMatrix.multiply(this.end);//.rotate(angle).add(this._getBodyPos());
+    return this._globalMatrix.multiply(this.end);
   }
 
   /**

--- a/src/spec/CollisionShapeSpec.ts
+++ b/src/spec/CollisionShapeSpec.ts
@@ -896,12 +896,59 @@ describe('Collision Shape', () => {
 
     it('has bounds', () => {
       actor.pos = ex.vec(400, 400);
+      actor.collider.update();
       const boundingBox = edge.bounds;
       const transformedBegin = new ex.Vector(395, 400);
       const transformedEnd = new ex.Vector(405, 400);
-
       expect(boundingBox.contains(transformedBegin)).toBe(true);
       expect(boundingBox.contains(transformedEnd)).toBe(true);
+    });
+
+    it('will calculate center', () => {
+      const transform = new ex.Transform();
+      const edge = new ex.EdgeCollider({
+        begin: ex.vec(0, 0),
+        end: ex.vec(0, 10),
+        offset: ex.vec(10, 10)
+      });
+
+      edge.update(transform);
+
+      expect(edge.center).toBeVector(ex.vec(10, 15));
+    });
+
+    it('will calculate world space by the transform', () => {
+      const transform = new ex.Transform();
+      const edge = new ex.EdgeCollider({
+        begin: ex.vec(0, 0),
+        end: ex.vec(0, 10),
+        offset: ex.vec(10, 10)
+      });
+
+      edge.update(transform);
+
+      expect(edge.bounds.left).toBe(0);
+      expect(edge.bounds.right).toBe(20);
+      expect(edge.bounds.top).toBe(0);
+      expect(edge.bounds.bottom).toBe(30);
+    });
+
+
+    it('can be rotated', () => {
+      const transform = new ex.Transform();
+      transform.rotation = Math.PI/2;
+      const edge = new ex.EdgeCollider({
+        begin: ex.vec(0, 0),
+        end: ex.vec(0, 10),
+        offset: ex.vec(10, 10)
+      });
+
+      edge.update(transform);
+
+      expect(edge.bounds.left).toBe(-30);
+      expect(edge.bounds.right).toBe(0);
+      expect(edge.bounds.top).toBe(0);
+      expect(edge.bounds.bottom).toBe(20);
     });
 
     it('has a moi', () => {


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2353

The PR includes a fix for `EdgeColliders` when placed into a composite collider

TODOs:
* [x] Tests
* [x] More exploration into the issue

