### PR TITLE
fix: [#2359] work around image decode limits in chromium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add target element id to `ex.Screen.goFullScreen('some-element-id')` to influence the fullscreen element in the fullscreen browser API.
 
 ### Fixed
+- Fixed bug in `Clock.schedule` where callbacks would not fire at the correct time, this was because it was scheduling using browser time and not the clock's internal time.
 - Fixed issue in Chromium browsers where Excalibur crashes if more than 256 `Image.decode()` calls are happening in the same frame.
 - Fixed issue where `ex.EdgeCollider` were not working properly in `ex.CompositeCollider` for `ex.TileMap`'s
 - Fixed issue where `ex.BoundingBox` overlap return false due to floating point rounding error causing multiple collisions to be evaluated sometimes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 -
 
 ### Added
+- Added new `ex.Future` type which is a convenient way of wrapping a native browser promise and resolving/rejecting later
+  ```typescript
+  const future = new ex.Future();
+  const promise = future.promise; // returns promise
+  promise.then(() => {
+    console.log('Resolved!');
+  });
+  future.resolve(); // resolved promise
+  ```
+- Added new `ex.Semaphore` type to limit the number of concurrent cans in a section of code, this is used internally to work around a chrome browser limitation, but can be useful for throttling network calls or even async game events.
+  ```typescript
+  const semaphore = new ex.Semaphore(10); // Only allow 10 concurrent between enter() and exit()
+  ...
+
+  await semaphore.enter();
+  await methodToBeLimited();
+  semaphore.exit();
+  ```
 - Added new `ex.WatchVector` type that can observe changes to x/y more efficiently than `ex.watch()`
 - Added performance improvements 
    * `ex.Vector.distance` improvement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add target element id to `ex.Screen.goFullScreen('some-element-id')` to influence the fullscreen element in the fullscreen browser API.
 
 ### Fixed
+- Fixed issue in Chromium browsers where Excalibur crashes if more than 256 `Image.decode()` calls are happening in the same frame.
 - Fixed issue where `ex.EdgeCollider` were not working properly in `ex.CompositeCollider` for `ex.TileMap`'s
 - Fixed issue where `ex.BoundingBox` overlap return false due to floating point rounding error causing multiple collisions to be evaluated sometimes
 - Fixed issue with `ex.EventDispatcher` where removing a handler that didn't already exist would remove another handler by mistake

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -11,6 +11,7 @@
       <li><a href="html/index.html">Sandbox Platformer</a></li>
       <li><a href="tests/parallel/">Parallel Actions</a></li>
       <li><a href="tests/isometric/">Isometric Map</a></li>
+      <li><a href="tests/decode-many/">Decode Many Images without failure (Chrome)</a></li>
       <li><a href="tests/side-collision/">Arcade: Sliding on Floor</a></li>
       <li><a href="tests/side-collision2/">Arcade: No clipping divergent collisions</a></li>
       <li><a href="tests/tilemap-custom-edge-collider/">Edge colliders work in a tilemap</a></li>

--- a/sandbox/tests/decode-many/index.html
+++ b/sandbox/tests/decode-many/index.html
@@ -7,6 +7,7 @@
   <title>Decode Images</title>
 </head>
 <body>
+  <p>There should be no errors in the console relating to loading images</p>
   <script src="../../lib/excalibur.js"></script>
   <script src="./index.js"></script>
 </body>

--- a/sandbox/tests/decode-many/index.html
+++ b/sandbox/tests/decode-many/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Decode Images</title>
+</head>
+<body>
+  <script src="../../lib/excalibur.js"></script>
+  <script src="./index.js"></script>
+</body>
+</html>

--- a/sandbox/tests/decode-many/index.ts
+++ b/sandbox/tests/decode-many/index.ts
@@ -1,0 +1,63 @@
+var game = new ex.Engine({
+  width: 800,
+  height: 600
+});
+
+var loader = new ex.Loader();
+
+function generate() {
+  let srcs = [];
+  for (let i = 0; i < 800; i++) {
+    srcs.push(generateRandomImage());
+  }
+  let images = srcs.map(src => new ex.ImageSource(src));
+  loader.addResources(images);
+
+  let sprites = images.map(i => i.toSprite());
+
+  game.currentScene.onPostDraw = ctx => {
+    ctx.save();
+    ctx.scale(.25, .25);
+    for (let i = 0; i < sprites.length; i++) {
+      sprites[i].draw(ctx, (i * 100) % (800 * 4) + 10, Math.floor((i * 100) / (800 * 4)) * 100 + 10);
+    }
+    ctx.restore();
+  };
+}
+
+function drawRandomCircleOnContext(ctx) {
+  const x = Math.floor(Math.random() * 100);
+  const y = Math.floor(Math.random() * 100);
+  const radius = Math.floor(Math.random() * 20);
+
+  const r = Math.floor(Math.random() * 255);
+  const g = Math.floor(Math.random() * 255);
+  const b = Math.floor(Math.random() * 255);
+
+  ctx.beginPath();
+  ctx.arc(x, y, radius, Math.PI * 2, 0, false);
+  ctx.fillStyle = "rgba(" + r + "," + g + "," + b + ",1)";
+  ctx.fill();
+  ctx.closePath();
+}
+
+function generateRandomImage() {
+  const canvas = document.createElement("canvas");
+  canvas.width = 100;
+  canvas.height = 100;
+
+  const ctx = canvas.getContext("2d");
+  ctx.clearRect(0, 0, 100, 100);
+
+  for (let i = 0; i < 20; i++) {
+    drawRandomCircleOnContext(ctx);
+  }
+  return canvas.toDataURL("image/png");
+}
+
+
+generate();
+
+
+
+game.start(loader);

--- a/src/engine/Graphics/ImageSource.ts
+++ b/src/engine/Graphics/ImageSource.ts
@@ -85,10 +85,15 @@ export class ImageSource implements Loadable<HTMLImageElement> {
 
       // Decode the image
       const image = new Image();
+      // Use Image.onload over Image.decode()
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=1055828#c7
+      // Otherwise chrome will throw still Image.decode() failures for large textures
+      const loadedFuture = new Future<void>();
+      image.onload = () => loadedFuture.resolve();
       image.src = url;
       image.setAttribute('data-original-src', this.path);
 
-      await image.decode();
+      await loadedFuture.promise;
 
       // Set results
       this.data = image;

--- a/src/engine/Loader.ts
+++ b/src/engine/Loader.ts
@@ -13,7 +13,6 @@ import { delay } from './Util/Util';
 import { ImageFiltering } from './Graphics/Filtering';
 import { clamp } from './Math/util';
 import { Sound } from './Resources/Sound/Sound';
-// import { ImageSource } from './Graphics';
 import { Semaphore } from './Util/Semaphore';
 import { Future } from './Util/Future';
 

--- a/src/engine/Util/Clock.ts
+++ b/src/engine/Util/Clock.ts
@@ -93,7 +93,8 @@ export abstract class Clock {
    * @param timeoutMs Optionally specify a timeout in milliseconds from now, default is 0ms which means the next possible tick
    */
   public schedule(cb: () => any, timeoutMs: number = 0) {
-    const scheduledTime = this.now() + timeoutMs;
+    // Scheduled based on internal elapsed time
+    const scheduledTime = this._totalElapsed + timeoutMs;
     this._scheduledCbs.push([cb, scheduledTime]);
   }
 

--- a/src/engine/Util/Future.ts
+++ b/src/engine/Util/Future.ts
@@ -1,0 +1,39 @@
+
+/**
+ * Future is a wrapper around a native browser Promise to allow resolving/rejecting at any time
+ */
+export class Future<T> {
+  // Code from StephenCleary https://gist.github.com/StephenCleary/ba50b2da419c03b9cba1d20cb4654d5e
+  private _resolver: (value: T) => void;
+  private _rejecter: (error: Error) => void;
+  private _isCompleted: boolean = false;
+
+  constructor() {
+    this.promise = new Promise((resolve, reject) => {
+      this._resolver = resolve;
+      this._rejecter = reject;
+    });
+  }
+
+  public readonly promise: Promise<T>;
+
+  public get isCompleted(): boolean {
+    return this._isCompleted;
+  }
+
+  public resolve(value: T): void {
+    if (this._isCompleted) {
+      return;
+    }
+    this._isCompleted = true;
+    this._resolver(value);
+  }
+
+  public reject(error: Error): void {
+    if (this._isCompleted) {
+      return;
+    }
+    this._isCompleted = true;
+    this._rejecter(error);
+  }
+}

--- a/src/engine/Util/Semaphore.ts
+++ b/src/engine/Util/Semaphore.ts
@@ -18,11 +18,6 @@ class AsyncWaitQueue<T> {
     const future = this._queue.shift();
     future.resolve(value);
   }
-
-  public dequeueAll(value: T): void {
-    this._queue.forEach(x => x.resolve(value));
-    this._queue = [];
-  }
 }
 
 /**
@@ -37,6 +32,10 @@ export class Semaphore {
 
   public get count() {
     return this._count;
+  }
+
+  public get waiting() {
+    return this._waitQueue.length;
   }
 
   public async enter() {

--- a/src/engine/Util/Semaphore.ts
+++ b/src/engine/Util/Semaphore.ts
@@ -1,0 +1,83 @@
+class Future<T> {
+  private resolver: (value: T) => void; // readonly
+  private rejecter: (error: Error) => void; // readonly
+  private _isCompleted: boolean = false;
+
+  constructor() {
+      this.promise = new Promise((resolve, reject) => {
+          this.resolver = resolve;
+          this.rejecter = reject;
+      });
+  }
+
+  public readonly promise: Promise<T>;
+  
+  public get isCompleted(): boolean {
+      return this._isCompleted;
+  }
+
+  public resolve(value: T): void {
+      if (this._isCompleted) {
+          return;
+      }
+      this._isCompleted = true;
+      this.resolver(value);
+  }
+
+  public reject(error: Error): void {
+      if (this._isCompleted) {
+          return;
+      }
+      this._isCompleted = true;
+      this.rejecter(error);
+  }
+}
+
+class AsyncWaitQueue<T> {
+  private queue: Future<T>[] = [];
+
+  public get length(): number {
+      return this.queue.length;
+  }
+
+  public enqueue(): Promise<T> {
+      let future = new Future<T>();
+      this.queue.push(future);
+      return future.promise;
+  }
+
+  public dequeue(value: T): void {
+      let future = this.queue.shift();
+      future.resolve(value);
+  }
+
+  public dequeueAll(value: T): void {
+      this.queue.forEach(x => x.resolve(value));
+      this.queue = [];
+  }
+}
+
+export class Semaphore {
+  private _count = 0;
+  private _waitQueue = new AsyncWaitQueue();
+  constructor(private _maxCalls: number) {}
+  
+  public async enter() {
+    if (this._count < this._maxCalls) {
+      this._count++;
+      return Promise.resolve();
+    }
+    return this._waitQueue.enqueue();
+  }
+
+  public exit(count: number = 1) {
+    if (count === 0) {
+        return;
+    }
+    while (count !== 0 && this._waitQueue.length !== 0) {
+        this._waitQueue.dequeue(null);
+        --count;
+        this._count--;
+    }
+  }
+}

--- a/src/engine/Util/Semaphore.ts
+++ b/src/engine/Util/Semaphore.ts
@@ -32,13 +32,16 @@ class AsyncWaitQueue<T> {
  * around browser limitations like max Image.decode() calls in chromium being 256.
  */
 export class Semaphore {
-  private _count = 0;
   private _waitQueue = new AsyncWaitQueue();
-  constructor(private _maxCalls: number) { }
+  constructor(private _count: number) { }
+
+  public get count() {
+    return this._count;
+  }
 
   public async enter() {
-    if (this._count < this._maxCalls) {
-      this._count++;
+    if (this._count !== 0) {
+      this._count--;
       return Promise.resolve();
     }
     return this._waitQueue.enqueue();
@@ -50,8 +53,8 @@ export class Semaphore {
     }
     while (count !== 0 && this._waitQueue.length !== 0) {
       this._waitQueue.dequeue(null);
-      --count;
-      this._count--;
+      count--;
     }
+    this._count += count;
   }
 }

--- a/src/engine/Util/Util.ts
+++ b/src/engine/Util/Util.ts
@@ -1,5 +1,6 @@
 import { Vector } from '../Math/vector';
 import { Clock } from './Clock';
+import { Future } from './Future';
 
 /**
  * Find the screen position of an HTML element
@@ -82,10 +83,10 @@ export function fail(message: never): never {
  * @param clock
  */
 export function delay(milliseconds: number, clock?: Clock): Promise<void> {
+  const future = new Future<void>();
   const schedule = clock?.schedule.bind(clock) ?? setTimeout;
-  return new Promise<void>(resolve => {
-    schedule(() => {
-      resolve();
-    }, milliseconds);
-  });
+  schedule(() => {
+    future.resolve();
+  }, milliseconds);
+  return future.promise;
 }

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -72,6 +72,8 @@ export * from './Util/Clock';
 export * from './Util/WebAudio';
 export * from './Util/Toaster';
 export * from './Util/StateMachine';
+export * from './Util/Future';
+export * from './Util/Semaphore';
 
 // ex.Deprecated
 // import * as deprecated from './Deprecated';

--- a/src/spec/FutureSpec.ts
+++ b/src/spec/FutureSpec.ts
@@ -1,0 +1,73 @@
+import * as ex from '@excalibur';
+
+describe('A Future', () => {
+  it('exists', () => {
+    expect(ex.Future).toBeDefined();
+  });
+
+  it('it can be constructed', () => {
+    const future = new ex.Future();
+
+    expect(future).toBeDefined();
+  });
+
+  it('can be resolved', (done) => {
+    const future = new ex.Future<void>();
+
+    expect(future.isCompleted).toBe(false);
+
+    future.promise.then(() => {
+      expect(future.isCompleted).toBe(true);
+      done();
+    });
+    future.resolve();
+  });
+
+  it('can be resolved multiple times without error', (done) => {
+    const future = new ex.Future<void>();
+
+    expect(future.isCompleted).toBe(false);
+
+    future.promise.then(() => {
+      expect(future.isCompleted).toBe(true);
+      done();
+    });
+    expect(() => {
+      future.resolve();
+      future.resolve();
+      future.resolve();
+      future.resolve();
+    }).not.toThrow();
+  });
+
+  it('can be rejected', (done) => {
+    const future = new ex.Future<void>();
+
+    expect(future.isCompleted).toBe(false);
+
+    future.promise.catch((err) => {
+      expect(err).toEqual(new Error('Some error'));
+      expect(future.isCompleted).toBe(true);
+      done();
+    });
+    future.reject(new Error('Some error'));
+  });
+
+  it('can be rejected multiple times without error', (done) => {
+    const future = new ex.Future<void>();
+
+    expect(future.isCompleted).toBe(false);
+
+    future.promise.catch(() => {
+      expect(future.isCompleted).toBe(true);
+      done();
+    });
+    expect(() => {
+      future.reject(new Error('Some error'));
+      future.reject(new Error('Some error'));
+      future.reject(new Error('Some error'));
+      future.reject(new Error('Some error'));
+      future.reject(new Error('Some error'));
+    }).not.toThrow();
+  });
+});

--- a/src/spec/SemaphoreSpec.ts
+++ b/src/spec/SemaphoreSpec.ts
@@ -1,0 +1,84 @@
+import * as ex from '@excalibur';
+import { delay } from '../engine/Util/Util';
+
+describe('A Semaphore', () => {
+  it('should exist', () => {
+    expect(ex.Semaphore).toBeDefined();
+  });
+
+  it('can be constructed with a count', () => {
+    const semaphore = new ex.Semaphore(10);
+    expect(semaphore.count).toBe(10);
+  });
+
+  it('a trivial exit does not decrement semaphor', () => {
+    const semaphore = new ex.Semaphore(10);
+    for (let i = 0; i < 20; i++) {
+      semaphore.enter();
+    }
+    expect(semaphore.waiting).toBe(10);
+    expect(semaphore.count).toBe(0);
+    semaphore.exit(0);
+    expect(semaphore.waiting).toBe(10);
+    expect(semaphore.count).toBe(0);
+  });
+
+  it('can limit async calls', () => {
+    const semaphore = new ex.Semaphore(10);
+    for (let i = 0; i < 20; i++) {
+      semaphore.enter();
+    }
+    expect(semaphore.waiting).toBe(10);
+    semaphore.exit();
+    semaphore.exit();
+    semaphore.exit();
+    expect(semaphore.waiting).toBe(7);
+  });
+
+
+  it('can block async calls', (done) => {
+    const mockFuture1 = new ex.Future<void>();
+    const mockMethod1 = () => {
+      return mockFuture1.promise;
+    };
+
+    const mockFuture2 = new ex.Future<void>();
+    const mockMethod2 = () => {
+      return mockFuture2.promise;
+    };
+    const semaphore = new ex.Semaphore(1);
+
+    const spy1 = jasmine.createSpy();
+    const spy2 = jasmine.createSpy();
+
+    semaphore.enter().then(() => {
+      expect(semaphore.count).toBe(0);
+      expect(semaphore.waiting).toBe(0);
+      mockMethod1().then(() => {
+        spy1();
+        semaphore.exit();
+      });
+      const final = semaphore.enter().then(() => {
+        mockMethod2().then(() => {
+          spy2();
+          semaphore.exit();
+        });
+      });
+      expect(semaphore.count).toBe(0);
+      expect(semaphore.waiting).toBe(1);
+      return final;
+    }).finally(() => {
+      expect(spy1).toHaveBeenCalled();
+      expect(spy2).toHaveBeenCalled();
+      expect(spy1).toHaveBeenCalledBefore(spy2);
+      done();
+    });
+
+    expect(spy1).not.toHaveBeenCalled();
+    expect(spy2).not.toHaveBeenCalled();
+
+    mockFuture1.resolve();
+    mockFuture2.resolve();
+  });
+
+});


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2359

This PR switches away from `Image.decode()` to use the older method of `Image.onload` this method is more reliable for large or numerous images due to a chromium bug around decode.

@HxShard provided a great codesandbox illustrating the issue https://codesandbox.io/s/happy-gagarin-j1vjr

## Changes:

- Creates a new Future type for working with native Promises' resolve/reject at any time
- Creates a new Semaphore type that can limit async calls in between `enter` and `exit`
- Fixes a small clock schedule bug as well
