### PR TITLE
fix: Add warning if ImageSource not loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add target element id to `ex.Screen.goFullScreen('some-element-id')` to influence the fullscreen element in the fullscreen browser API.
 
 ### Fixed
+- Fixed usability issue and log warning if the `ex.ImageSource` is not loaded and a draw was attempted.
 - Fixed bug in `ex.Physics.useRealisticPhysics()` solver where `ex.Body.bounciness` was not being respected in the simulation
 - Fixed bug in `ex.Physics.useRealisticPhysics()` solver where `ex.Body.limitDegreeOfFreedom` was not working all the time.
 - Fixed bug in `Clock.schedule` where callbacks would not fire at the correct time, this was because it was scheduling using browser time and not the clock's internal time.

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -111,6 +111,11 @@ var jump = new ex.Sound('../sounds/jump.wav', '../sounds/jump.mp3');
 var cards = new ex.ImageSource('../images/kenny-cards.png');
 var cloud = new ex.ImageSource('../images/background_cloudA.png', false, ex.ImageFiltering.Blended);
 
+// Log one warning
+var cards2 = new ex.ImageSource('../images/kenny-cards.png').toSprite();
+cards2.draw(game.graphicsContext, 0, 0);
+cards2.draw(game.graphicsContext, 0, 0);
+
 jump.volume = 0.3;
 
 var loader = new ex.Loader();

--- a/src/engine/Graphics/Sprite.ts
+++ b/src/engine/Graphics/Sprite.ts
@@ -1,6 +1,7 @@
 import { Graphic, GraphicOptions } from './Graphic';
 import { ImageSource } from './ImageSource';
 import { ExcaliburGraphicsContext } from './Context/ExcaliburGraphicsContext';
+import { Logger } from '../Util/Log';
 
 export type SourceView = { x: number; y: number; width: number; height: number };
 export type DestinationSize = { width: number; height: number };
@@ -21,6 +22,7 @@ export interface SpriteOptions {
 }
 
 export class Sprite extends Graphic {
+  private _logger = Logger.getInstance();
   public image: ImageSource;
   public sourceView: SourceView;
   public destSize: DestinationSize;
@@ -87,6 +89,7 @@ export class Sprite extends Graphic {
     super._preDraw(ex, x, y);
   }
 
+  private _logNotLoadedWarning = false;
   public _drawImage(ex: ExcaliburGraphicsContext, x: number, y: number): void {
     if (this.image.isLoaded()) {
       ex.drawImage(
@@ -100,6 +103,15 @@ export class Sprite extends Graphic {
         this.destSize.width,
         this.destSize.height
       );
+    } else {
+      if (!this._logNotLoadedWarning) {
+        this._logger.warn(
+          `ImageSource ${this.image.path}` +
+          ` is not yet loaded and won't be drawn. Please call .load() or include in a Loader.\n\n` +
+          `Read https://excaliburjs.com/docs/imagesource for more information.`
+        );
+      }
+      this._logNotLoadedWarning = true;
     }
   }
 

--- a/src/spec/SpriteSpec.ts
+++ b/src/spec/SpriteSpec.ts
@@ -1,4 +1,5 @@
 import * as ex from '@excalibur';
+import { Logger } from '@excalibur';
 import { ExcaliburAsyncMatchers, ExcaliburMatchers } from 'excalibur-jasmine';
 import { TestUtils } from './util/TestUtils';
 
@@ -302,5 +303,22 @@ describe('A Sprite Graphic', () => {
     ctx.flush();
 
     await expectAsync(TestUtils.flushWebGLCanvasTo2D(canvasElement)).toEqualImage('src/spec/images/GraphicsSpriteSpec/dest-view.png');
+  });
+
+  it('will log one warning if the imagesource is not loaded', () => {
+    const logger = Logger.getInstance();
+    spyOn(logger, 'warn');
+    const image = new ex.ImageSource('path/to/non/existing/image');
+
+    const sut = image.toSprite();
+
+    sut.draw(ctx, 0, 0);
+    sut.draw(ctx, 0, 0);
+    sut.draw(ctx, 0, 0);
+
+    expect(logger.warn).toHaveBeenCalledOnceWith(
+      `ImageSource path/to/non/existing/image is not yet loaded and won't be drawn. Please call .load() or include in a Loader.\n\n` +
+      'Read https://excaliburjs.com/docs/imagesource for more information.'
+    );
   });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Related to discussion #2356

## Changes:

- Logs warning if `ex.ImageSource` not yet loaded and a draw was attempted
