### PR TITLE
fix: [#2379] Deferred goto preserves wrong scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add target element id to `ex.Screen.goFullScreen('some-element-id')` to influence the fullscreen element in the fullscreen browser API.
 
 ### Fixed
+- Fixed bug where a deferred `goToScene` would preserve the incorrect scene so `engine.add(someActor)` would place actors in the wrong scene after transitioning to another.
 - Fixed usability issue and log warning if the `ex.ImageSource` is not loaded and a draw was attempted.
 - Fixed bug in `ex.Physics.useRealisticPhysics()` solver where `ex.Body.bounciness` was not being respected in the simulation
 - Fixed bug in `ex.Physics.useRealisticPhysics()` solver where `ex.Body.limitDegreeOfFreedom` was not working all the time.

--- a/sandbox/tests/gotoscene/index.html
+++ b/sandbox/tests/gotoscene/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Go To Scene</title>
+</head>
+<body>
+  <canvas id="game"></canvas>
+  <script src="../../lib/excalibur.js"></script>
+  <script src="./index.js"></script>
+</body>
+</html>

--- a/sandbox/tests/gotoscene/index.ts
+++ b/sandbox/tests/gotoscene/index.ts
@@ -17,7 +17,7 @@ class Scene1 extends ex.Scene {
     );
   }
 
-  onActivate(_oldScene: ex.Scene, _newScene: ex.Scene): void {
+  onActivate(): void {
     console.log('Scene 1 Activate')
   }
 }
@@ -34,7 +34,7 @@ class Scene2 extends ex.Scene {
     });
     _engine.add(actor);
   }
-  onActivate(_oldScene: ex.Scene, _newScene: ex.Scene): void {
+  onActivate(): void {
     console.log('Scene 2 Activate')
   }
 }

--- a/sandbox/tests/gotoscene/index.ts
+++ b/sandbox/tests/gotoscene/index.ts
@@ -1,0 +1,57 @@
+class Scene1 extends ex.Scene {
+  onInitialize(_engine: ex.Engine): void {
+    const actor = new ex.Actor({
+      x: _engine.halfDrawWidth,
+      y: _engine.halfDrawHeight,
+      width: 20,
+      height: 20,
+      color: ex.Color.Magenta,
+    });
+    this.add(actor);
+
+    _engine.input.pointers.primary.on(
+      "down",
+      (event: ex.Input.PointerEvent): void => {
+        _engine.goToScene("scene2");
+      }
+    );
+  }
+
+  onActivate(_oldScene: ex.Scene, _newScene: ex.Scene): void {
+    console.log('Scene 1 Activate')
+  }
+}
+
+
+class Scene2 extends ex.Scene {
+  onInitialize(_engine: ex.Engine): void {
+    // _engine.start();
+    const actor = new ex.Actor({
+      pos: ex.Vector.Zero,
+      width: 1000,
+      height: 1000,
+      color: ex.Color.Cyan,
+    });
+    _engine.add(actor);
+  }
+  onActivate(_oldScene: ex.Scene, _newScene: ex.Scene): void {
+    console.log('Scene 2 Activate')
+  }
+}
+
+
+var engine = new ex.Engine({
+  width: 1920 / 2,
+  height: 1080 / 2,
+  canvasElementId: "game",
+});
+
+engine.add("scene1", new Scene1());
+engine.add("scene2", new Scene2());
+engine.goToScene("scene1");
+
+var loader = new ex.Loader();
+
+loader.suppressPlayButton = true;
+
+engine.start(loader);

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1161,7 +1161,9 @@ O|===|* >________________>\n\
       super.emit('initialize', new InitializeEvent(engine, this));
       this._isInitialized = true;
       if (this._deferredGoTo) {
-        this.goToScene(this._deferredGoTo);
+        const deferredScene = this._deferredGoTo;
+        this._deferredGoTo = null;
+        this.goToScene(deferredScene);
       } else {
         this.goToScene('root');
       }

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -617,6 +617,33 @@ describe('The engine', () => {
     expect(ex.Logger.getInstance().error).toHaveBeenCalledWith('Scene', 'madeUp', 'does not exist!');
   });
 
+  it('will add actors to the correct scene when initialized after a deferred goTo', () => {
+    const engine = TestUtils.engine();
+    const scene1 = new ex.Scene();
+    const scene2 = new ex.Scene();
+    engine.add('scene1', scene1);
+    engine.add('scene2', scene2);
+
+    scene1.onInitialize = () => {
+      engine.goToScene('scene2');
+    };
+    scene2.onInitialize = () => {
+      engine.add(new ex.Actor());
+    };
+
+    spyOn(scene1, 'onInitialize').and.callThrough();
+    spyOn(scene2, 'onInitialize').and.callThrough();
+
+
+    engine.goToScene('scene1');
+
+    TestUtils.runToReady(engine);
+
+    expect(engine.currentScene).toBe(scene2);
+    expect(scene1.actors.length).toBe(0);
+    expect(scene2.actors.length).toBe(1);
+  });
+
   it('can screen shot the game (in WebGL)', (done) => {
 
     const engine = TestUtils.engine({}, []);


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2379

## Changes:

- Clears out deferred scenes after they've been transitioned
