### PR TITLE
feat: pass data to scene activation from goToScene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `ex.TransformComponent.posChanged$` has been removed, it incurs a steep performance cost
 - `ex.EventDispatcher` meta events 'subscribe' and 'unsubscribe' were unused and undocumented and have been removed
 - `ex.TileMap` tlies are now drawn from the lower left by default to match with `ex.IsometricMap` and Tiled, but can be configured with `renderFromTopOfGraphic` to restore the previous behavior.
+- Scene `onActivate` and `onDeactivate` methods have been changed to receive a single parameter, an object containing the `previousScene`, `nextScene`, and optional `data` passed in from `goToScene()`
 
 ### Deprecated
 
@@ -114,6 +115,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   // actor will now move to (100, 100) and rotate to Math.PI/2 at the same time!!
   ```
 - Add target element id to `ex.Screen.goFullScreen('some-element-id')` to influence the fullscreen element in the fullscreen browser API.
+- Added optional `data` parameter to `goToScene`, which gets passed to the target scene's `onActivate` method.
+  ```typescript
+  class SceneA extends ex.Scene {
+    /* ... */
+
+    onActivate(context: ex.SceneActivationContext<{ foo: string }>) {
+      console.log(context.data.foo); // bar
+    }
+  }
+
+  engine.goToScene('sceneA', { foo: 'bar' })
+  ```
 
 ### Fixed
 - Fixed usability issue and log warning if the `ex.ImageSource` is not loaded and a draw was attempted.

--- a/src/engine/Events.ts
+++ b/src/engine/Events.ts
@@ -10,7 +10,7 @@ import * as Input from './Input/Index';
 import { CollisionContact } from './Collision/Detection/CollisionContact';
 import { Collider } from './Collision/Colliders/Collider';
 import { Entity } from './EntityComponentSystem/Entity';
-import { OnInitialize, OnPreUpdate, OnPostUpdate } from './Interfaces/LifecycleEvents';
+import { OnInitialize, OnPreUpdate, OnPostUpdate, SceneActivationContext } from './Interfaces/LifecycleEvents';
 import { BodyComponent } from './Collision/BodyComponent';
 import { ExcaliburGraphicsContext } from './Graphics';
 
@@ -495,11 +495,11 @@ export class InitializeEvent<T extends OnInitialize = Entity> extends GameEvent<
 /**
  * Event thrown on a [[Scene]] on activation
  */
-export class ActivateEvent extends GameEvent<Scene> {
+export class ActivateEvent<TData = undefined> extends GameEvent<Scene> {
   /**
-   * @param oldScene  The reference to the old scene
+   * @param context  The context for the scene activation
    */
-  constructor(public oldScene: Scene, public target: Scene) {
+  constructor(public context: SceneActivationContext<TData>, public target: Scene) {
     super();
   }
 }
@@ -509,9 +509,9 @@ export class ActivateEvent extends GameEvent<Scene> {
  */
 export class DeactivateEvent extends GameEvent<Scene> {
   /**
-   * @param newScene  The reference to the new scene
+   * @param context  The context for the scene deactivation
    */
-  constructor(public newScene: Scene, public target: Scene) {
+  constructor(public context: SceneActivationContext<never>, public target: Scene) {
     super();
   }
 }

--- a/src/engine/Interfaces/LifecycleEvents.ts
+++ b/src/engine/Interfaces/LifecycleEvents.ts
@@ -88,11 +88,18 @@ export interface CanInitialize {
   off(eventName: Events.initialize, handler?: (event: Events.InitializeEvent<any>) => void): void;
 }
 
-export interface CanActivate {
+export interface SceneActivationContext<TData = undefined> {
+  data?: TData;
+  previousScene: Scene;
+  nextScene: Scene;
+  engine: Engine;
+}
+
+export interface CanActivate<TData = undefined> {
   /**
    * Overridable implementation
    */
-  onActivate(oldScene: Scene, newScene: Scene): void;
+  onActivate(context: SceneActivationContext<TData>): void;
 
   /**
    * Event signatures
@@ -106,7 +113,7 @@ export interface CanDeactivate {
   /**
    * Overridable implementation
    */
-  onDeactivate(oldScene: Scene, newScene: Scene): void;
+  onDeactivate(context: SceneActivationContext<never>): void;
 
   /**
    * Event signature

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -18,7 +18,7 @@ import { TileMap } from './TileMap';
 import { Camera } from './Camera';
 import { Actor } from './Actor';
 import { Class } from './Class';
-import { CanInitialize, CanActivate, CanDeactivate, CanUpdate, CanDraw } from './Interfaces/LifecycleEvents';
+import { CanInitialize, CanActivate, CanDeactivate, CanUpdate, CanDraw, SceneActivationContext } from './Interfaces/LifecycleEvents';
 import * as Util from './Util/Util';
 import * as Events from './Events';
 import { Trigger } from './Trigger';
@@ -41,7 +41,9 @@ import { ExcaliburGraphicsContext } from './Graphics';
  *
  * Typical usages of a scene include: levels, menus, loading screens, etc.
  */
-export class Scene extends Class implements CanInitialize, CanActivate, CanDeactivate, CanUpdate, CanDraw {
+export class Scene
+  extends Class
+  implements CanInitialize, CanActivate, CanDeactivate, CanUpdate, CanDraw {
   private _logger: Logger = Logger.getInstance();
   /**
    * Gets or sets the current camera for the scene
@@ -169,7 +171,7 @@ export class Scene extends Class implements CanInitialize, CanActivate, CanDeact
    * This is called when the scene is made active and started. It is meant to be overridden,
    * this is where you should setup any DOM UI or event handlers needed for the scene.
    */
-  public onActivate(_oldScene: Scene, _newScene: Scene): void {
+  public onActivate<TData = undefined>(_context: SceneActivationContext<TData>): void {
     // will be overridden
   }
 
@@ -177,7 +179,7 @@ export class Scene extends Class implements CanInitialize, CanActivate, CanDeact
    * This is called when the scene is made transitioned away from and stopped. It is meant to be overridden,
    * this is where you should cleanup any DOM UI or event handlers needed for the scene.
    */
-  public onDeactivate(_oldScene: Scene, _newScene: Scene): void {
+  public onDeactivate(_context: SceneActivationContext): void {
     // will be overridden
   }
 
@@ -267,9 +269,9 @@ export class Scene extends Class implements CanInitialize, CanActivate, CanDeact
    * Activates the scene with the base behavior, then calls the overridable `onActivate` implementation.
    * @internal
    */
-  public _activate(oldScene: Scene, newScene: Scene): void {
+  public _activate<TData = undefined>(context: SceneActivationContext<TData>): void {
     this._logger.debug('Scene.onActivate', this);
-    this.onActivate(oldScene, newScene);
+    this.onActivate(context);
   }
 
   /**
@@ -278,9 +280,9 @@ export class Scene extends Class implements CanInitialize, CanActivate, CanDeact
    * Deactivates the scene with the base behavior, then calls the overridable `onDeactivate` implementation.
    * @internal
    */
-  public _deactivate(oldScene: Scene, newScene: Scene): void {
+  public _deactivate(context: SceneActivationContext<never>): void {
     this._logger.debug('Scene.onDeactivate', this);
-    this.onDeactivate(oldScene, newScene);
+    this.onDeactivate(context);
   }
 
   /**

--- a/src/spec/SceneSpec.ts
+++ b/src/spec/SceneSpec.ts
@@ -330,12 +330,21 @@ describe('A scene', () => {
     clock.step(100);
     clock.step(100);
 
-    engine.goToScene('sceneB');
+    engine.goToScene('sceneB', { foo: 'bar' });
     clock.step(100);
     clock.step(100);
 
-    expect(sceneA.onDeactivate).toHaveBeenCalledWith(sceneA, sceneB);
-    expect(sceneB.onActivate).toHaveBeenCalledWith(sceneA, sceneB);
+    expect(sceneA.onDeactivate).toHaveBeenCalledWith({
+      engine,
+      previousScene: sceneA,
+      nextScene: sceneB
+    });
+    expect(sceneB.onActivate).toHaveBeenCalledWith({
+      engine,
+      previousScene: sceneA,
+      nextScene: sceneB,
+      data: { foo: 'bar'}
+    });
   });
 
   it('fires initialize before activate', (done) => {


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #1548

## Changes:

- Added optional `data` parameter to `goToScene`, which gets passed to the target scene's `onActivate` method.
  ```typescript
  class SceneA extends ex.Scene {
    /* ... */

    onActivate(context: ex.SceneActivationContext<{ foo: string }>) {
      console.log(context.data.foo); // bar
    }
  }

  engine.goToScene('sceneA', { foo: 'bar' })
  ```
- Scene `onActivate` and `onDeactivate` methods have been changed to receive a single parameter, an object containing the `previousScene`, `nextScene`, and optional `data` passed in from `goToScene()`

