### PR TITLE
fix: use generic on Scene for better onActivate data type

### DIFF
--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1031,7 +1031,7 @@ O|===|* >________________>\n\
    * @param key  The key of the scene to transition to.
    * @param data Optional data to send to the scene's onActivate method
    */
-  public goToScene<Data = undefined>(key: string, data?: Data): void {
+  public goToScene<TData = undefined>(key: string, data?: TData): void {
     // if not yet initialized defer goToScene
     if (!this.isInitialized) {
       this._deferredGoTo = key;

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -41,9 +41,9 @@ import { ExcaliburGraphicsContext } from './Graphics';
  *
  * Typical usages of a scene include: levels, menus, loading screens, etc.
  */
-export class Scene
+export class Scene<TActivationData = unknown>
   extends Class
-  implements CanInitialize, CanActivate, CanDeactivate, CanUpdate, CanDraw {
+  implements CanInitialize, CanActivate<TActivationData>, CanDeactivate, CanUpdate, CanDraw {
   private _logger: Logger = Logger.getInstance();
   /**
    * Gets or sets the current camera for the scene
@@ -171,7 +171,7 @@ export class Scene
    * This is called when the scene is made active and started. It is meant to be overridden,
    * this is where you should setup any DOM UI or event handlers needed for the scene.
    */
-  public onActivate<TData = undefined>(_context: SceneActivationContext<TData>): void {
+  public onActivate(_context: SceneActivationContext<TActivationData>): void {
     // will be overridden
   }
 
@@ -269,7 +269,7 @@ export class Scene
    * Activates the scene with the base behavior, then calls the overridable `onActivate` implementation.
    * @internal
    */
-  public _activate<TData = undefined>(context: SceneActivationContext<TData>): void {
+  public _activate(context: SceneActivationContext<TActivationData>): void {
     this._logger.debug('Scene.onActivate', this);
     this.onActivate(context);
   }


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Addresses [follow up](https://github.com/excaliburjs/Excalibur/issues/1548#issuecomment-1172504724) in #1548 

## Changes:

- removes the generic in `onActivation` and adds it to the Scene instead. This allows it to be inferred by doing `onActivation(ctx: SceneActivationContext<Data>)` in Scene subclasses.