### PR TITLE
fix: Fixed update Interpolation incorrect with child actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added the ability to select variable duration into Timer constructor. 
 ### Fixed
 
+- Fixed unreleased issue where fixed update interpolation was incorrect with child actors
 - Fixed unreleased bug where CompositeCollider components would not collide appropriately because contacts did not have unique ids
 - Fixed issue where CompositeColliders treat separate constituents as separate collisionstart/collisionend which is unexpected
 - Fixed issue where resources that failed to load would silently fail making debugging challenging

--- a/src/engine/Collision/BodyComponent.ts
+++ b/src/engine/Collision/BodyComponent.ts
@@ -210,8 +210,11 @@ export class BodyComponent extends Component<'ex.body'> implements Clonable<Body
     return !!this.owner?.active;
   }
 
+  /**
+   * @deprecated Use globalP0s
+   */
   public get center() {
-    return this.pos;
+    return this.globalPos;
   }
 
   public get transform(): TransformComponent {
@@ -222,16 +225,24 @@ export class BodyComponent extends Component<'ex.body'> implements Clonable<Body
     return  this.owner?.get(MotionComponent);
   }
 
+  public get pos(): Vector {
+    return this.transform.pos;
+  }
+
+  public set pos(val: Vector) {
+    this.transform.pos = val;
+  }
+
   /**
    * The (x, y) position of the actor this will be in the middle of the actor if the
    * [[Actor.anchor]] is set to (0.5, 0.5) which is default.
    * If you want the (x, y) position to be the top left of the actor specify an anchor of (0, 0).
    */
-  public get pos(): Vector {
+  public get globalPos(): Vector {
     return this.transform.globalPos;
   }
 
-  public set pos(val: Vector) {
+  public set globalPos(val: Vector) {
     this.transform.globalPos = val;
   }
 
@@ -368,7 +379,7 @@ export class BodyComponent extends Component<'ex.body'> implements Clonable<Body
     this.vel.addEqual(finalImpulse);
 
     if (!this.limitDegreeOfFreedom.includes(DegreeOfFreedom.Rotation)) {
-      const distanceFromCenter = point.sub(this.pos);
+      const distanceFromCenter = point.sub(this.globalPos);
       this.angularVelocity += this.inverseInertia * distanceFromCenter.cross(impulse);
     }
   }
@@ -405,7 +416,7 @@ export class BodyComponent extends Component<'ex.body'> implements Clonable<Body
     }
 
     if (!this.limitDegreeOfFreedom.includes(DegreeOfFreedom.Rotation)) {
-      const distanceFromCenter = point.sub(this.pos);
+      const distanceFromCenter = point.sub(this.globalPos);
       this.angularVelocity += this.inverseInertia * distanceFromCenter.cross(impulse);
     }
   }

--- a/src/engine/Collision/Detection/DynamicTreeCollisionProcessor.ts
+++ b/src/engine/Collision/Detection/DynamicTreeCollisionProcessor.ts
@@ -142,7 +142,7 @@ export class DynamicTreeCollisionProcessor implements CollisionProcessor {
 
           // start with the oldPos because the integration for actors has already happened
           // objects resting on a surface may be slightly penetrating in the current position
-          const updateVec = body.pos.sub(body.oldPos);
+          const updateVec = body.globalPos.sub(body.oldPos);
           const centerPoint = collider.center;
           const furthestPoint = collider.getFurthestPoint(body.vel);
           const origin: Vector = furthestPoint.sub(updateVec);
@@ -176,7 +176,7 @@ export class DynamicTreeCollisionProcessor implements CollisionProcessor {
             // move the fast moving object to the other body
             // need to push into the surface by ex.Physics.surfaceEpsilon
             const shift = centerPoint.sub(furthestPoint);
-            body.pos = origin
+            body.globalPos = origin
               .add(shift)
               .add(minTranslate)
               .add(ray.dir.scale(10 * Physics.surfaceEpsilon)); // needed to push the shape slightly into contact

--- a/src/engine/Collision/Solver/ArcadeSolver.ts
+++ b/src/engine/Collision/Solver/ArcadeSolver.ts
@@ -122,14 +122,14 @@ export class ArcadeSolver implements CollisionSolver {
 
       // Resolve overlaps
       if (bodyA.collisionType === CollisionType.Active) {
-        bodyA.pos.x -= mtv.x;
-        bodyA.pos.y -= mtv.y;
+        bodyA.globalPos.x -= mtv.x;
+        bodyA.globalPos.y -= mtv.y;
         colliderA.update(bodyA.transform.get());
       }
 
       if (bodyB.collisionType === CollisionType.Active) {
-        bodyB.pos.x += mtv.x;
-        bodyB.pos.y += mtv.y;
+        bodyB.globalPos.x += mtv.x;
+        bodyB.globalPos.y += mtv.y;
         colliderB.update(bodyB.transform.get());
       }
     }

--- a/src/engine/Collision/Solver/ContactConstraintPoint.ts
+++ b/src/engine/Collision/Solver/ContactConstraintPoint.ts
@@ -21,8 +21,8 @@ export class ContactConstraintPoint {
       const normal = this.contact.normal;
       const tangent = this.contact.tangent;
 
-      this.aToContact = this.point.sub(bodyA.pos);
-      this.bToContact = this.point.sub(bodyB.pos);
+      this.aToContact = this.point.sub(bodyA.globalPos);
+      this.bToContact = this.point.sub(bodyB.globalPos);
 
       const aToContactNormal = this.aToContact.cross(normal);
       const bToContactNormal = this.bToContact.cross(normal);

--- a/src/engine/Collision/Solver/RealisticSolver.ts
+++ b/src/engine/Collision/Solver/RealisticSolver.ts
@@ -78,8 +78,8 @@ export class RealisticSolver implements CollisionSolver {
           const normal = contact.normal;
           const tangent = contact.tangent;
 
-          const aToContact = point.sub(bodyA.pos);
-          const bToContact = point.sub(bodyB.pos);
+          const aToContact = point.sub(bodyA.globalPos);
+          const bToContact = point.sub(bodyB.globalPos);
 
           const aToContactNormal = aToContact.cross(normal);
           const bToContactNormal = bToContact.cross(normal);
@@ -256,7 +256,7 @@ export class RealisticSolver implements CollisionSolver {
                 impulseForce.y = 0;
               }
 
-              bodyA.pos = bodyA.pos.add(impulseForce);
+              bodyA.globalPos = bodyA.globalPos.add(impulseForce);
               if (!bodyA.limitDegreeOfFreedom.includes(DegreeOfFreedom.Rotation)) {
                 bodyA.rotation -= point.aToContact.cross(impulse) * bodyA.inverseInertia;
               }
@@ -271,7 +271,7 @@ export class RealisticSolver implements CollisionSolver {
                 impulseForce.y = 0;
               }
 
-              bodyB.pos = bodyB.pos.add(impulseForce);
+              bodyB.globalPos = bodyB.globalPos.add(impulseForce);
               if (!bodyB.limitDegreeOfFreedom.includes(DegreeOfFreedom.Rotation)) {
                 bodyB.rotation += point.bToContact.cross(impulse) * bodyB.inverseInertia;
               }

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -196,15 +196,15 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
 
           // Interpolate graphics if needed
           const blend = this._engine.currentFrameLagMs / (1000 / this._engine.fixedUpdateFps);
-          interpolatedPos = optionalBody.pos.scale(blend).add(
+          interpolatedPos = transform.pos.scale(blend).add(
             optionalBody.oldPos.scale(1.0 - blend)
           );
-          interpolatedScale = optionalBody.scale.scale(blend).add(
+          interpolatedScale = transform.scale.scale(blend).add(
             optionalBody.oldScale.scale(1.0 - blend)
           );
           // Rotational lerp https://stackoverflow.com/a/30129248
-          const cosine = (1.0 - blend) * Math.cos(optionalBody.oldRotation) + blend * Math.cos(optionalBody.rotation);
-          const sine = (1.0 - blend) * Math.sin(optionalBody.oldRotation) + blend * Math.sin(optionalBody.rotation);
+          const cosine = (1.0 - blend) * Math.cos(optionalBody.oldRotation) + blend * Math.cos(transform.rotation);
+          const sine = (1.0 - blend) * Math.sin(optionalBody.oldRotation) + blend * Math.sin(transform.rotation);
           interpolatedRotation = Math.atan2(sine, cosine);
         }
       }

--- a/src/spec/BodyComponentSpec.ts
+++ b/src/spec/BodyComponentSpec.ts
@@ -5,7 +5,7 @@ import { ExcaliburMatchers } from 'excalibur-jasmine';
 describe('A body component', () => {
   beforeAll(() => {
     jasmine.addMatchers(ExcaliburMatchers);
-  })
+  });
   it('exists', () => {
     expect(ex.BodyComponent).toBeDefined();
   });

--- a/src/spec/BodyComponentSpec.ts
+++ b/src/spec/BodyComponentSpec.ts
@@ -1,6 +1,11 @@
 import * as ex from '@excalibur';
+import { BodyComponent } from '@excalibur';
+import { ExcaliburMatchers } from 'excalibur-jasmine';
 
 describe('A body component', () => {
+  beforeAll(() => {
+    jasmine.addMatchers(ExcaliburMatchers);
+  })
   it('exists', () => {
     expect(ex.BodyComponent).toBeDefined();
   });
@@ -26,6 +31,22 @@ describe('A body component', () => {
     actor.body.mass = 1;
     expect((actor.body as any)._cachedInertia).toBe(undefined);
     expect((actor.body as any)._cachedInverseInertia).toBe(undefined);
+  });
+
+  it('will reflect the transform positions', () => {
+    const actor = new ex.Actor({
+      pos: ex.vec(100, 100)
+    });
+
+    const child = new ex.Actor({
+      pos: ex.vec(10, 10)
+    });
+
+    actor.addChild(child);
+
+    const body = child.get(BodyComponent);
+    expect(body.pos).toBeVector(ex.vec(10, 10));
+    expect(body.globalPos).toBeVector(ex.vec(110, 110));
   });
 
 });

--- a/src/spec/GraphicsSystemSpec.ts
+++ b/src/spec/GraphicsSystemSpec.ts
@@ -131,6 +131,43 @@ describe('A Graphics ECS System', () => {
     expect(game.graphicsContext.translate).toHaveBeenCalledWith(24, 24);
   });
 
+  it('will interpolate child body graphics when fixed update is enabled', async () => {
+    const game = TestUtils.engine({
+      fixedUpdateFps: 30
+    });
+
+    await TestUtils.runToReady(game);
+
+    const parent = new ex.Actor({
+      x: 10,
+      y: 10
+    });
+
+    const actor = new ex.Actor({
+      x: 100,
+      y: 100,
+      rotation: 2,
+      scale: ex.vec(2, 2)
+    });
+    parent.addChild(actor);
+
+    actor.body.__oldTransformCaptured = true;
+
+    spyOn(game.graphicsContext, 'translate');
+    spyOn(game.graphicsContext, 'rotate');
+    spyOn(game.graphicsContext, 'scale');
+
+    const graphicsSystem = new ex.GraphicsSystem();
+    graphicsSystem.initialize(game.currentScene);
+    graphicsSystem.preupdate();
+    graphicsSystem.notify(new ex.AddedEntity(actor));
+
+    game.currentFrameLagMs = 8; // current lag in a 30 fps frame
+    graphicsSystem.update([actor], 30);
+
+    expect(game.graphicsContext.translate).toHaveBeenCalledWith(24, 24);
+  });
+
   it('will not interpolate body graphics if disabled', async () => {
     const game = TestUtils.engine({
       fixedUpdateFps: 30


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR fixes an unreleased issue where fixed step update interpolation was incorrect with child actors. The issue was global and local positions were mixed in the interpolate.

![interpolation-bug](https://user-images.githubusercontent.com/612071/177008946-1e56d054-ef18-466f-b30f-6a29192e05ed.gif)


## Changes:

- Switch interpolation to use local positions for start and end
