### PR TITLE
fix: [#2403] Allow ex.Canvas and ex.Raster to have NPOT dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue with `ex.Canvas` and `ex.Raster` graphics that forced their dimensions to the next highest power of two.
 - Fixed issue with `ex.Engine.snapToPixel` where positions very close to pixel boundary created jarring 1 pixel oscillations.
 - Fixed bug where a deferred `goToScene` would preserve the incorrect scene so `engine.add(someActor)` would place actors in the wrong scene after transitioning to another.
 - Fixed usability issue and log warning if the `ex.ImageSource` is not loaded and a draw was attempted.

--- a/src/engine/Graphics/Raster.ts
+++ b/src/engine/Graphics/Raster.ts
@@ -1,7 +1,6 @@
 import { Graphic, GraphicOptions } from './Graphic';
 import { ExcaliburGraphicsContext } from './Context/ExcaliburGraphicsContext';
 import { Color } from '../Color';
-import { ensurePowerOfTwo } from './Context/webgl-util';
 import { Vector } from '../Math/vector';
 import { BoundingBox } from '../Collision/BoundingBox';
 import { watch } from '../Util/Watch';
@@ -94,9 +93,8 @@ export abstract class Raster extends Graphic {
     // get the default canvas width/height as a fallback
     const bitmapWidth = options?.width ?? this._bitmap.width;
     const bitmapHeight = options?.height ?? this._bitmap.height;
-    // Rasters use power of two images as an optimization for webgl
-    this.width = ensurePowerOfTwo(bitmapWidth);
-    this.height = ensurePowerOfTwo(bitmapHeight);
+    this.width = bitmapWidth;
+    this.height = bitmapHeight;
     const maybeCtx = this._bitmap.getContext('2d');
     if (!maybeCtx) {
       /* istanbul ignore next */


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2403

## Changes:

- Removes unnecessary POT enforcement in the `ex.Raster` base class
