### PR TITLE
fix: [#2409] engine 'visible' event not firing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
--
+- Fixed `engine.on('visible')` event not firing
 
 ### Updates
 

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1117,7 +1117,7 @@ O|===|* >________________>\n\
         this.eventDispatcher.emit('visible', new VisibleEvent(this));
         this._logger.debug('Window visible');
       }
-    })
+    });
 
     if (!this.canvasElementId && !options.canvasElement) {
       document.body.appendChild(this.canvas);

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1109,28 +1109,15 @@ O|===|* >________________>\n\
     // Issue #385 make use of the visibility api
     // https://developer.mozilla.org/en-US/docs/Web/Guide/User_experience/Using_the_Page_Visibility_API
 
-    let hidden: keyof HTMLDocument, visibilityChange: string;
-    if (typeof document.hidden !== 'undefined') {
-      // Opera 12.10 and Firefox 18 and later support
-      hidden = 'hidden';
-      visibilityChange = 'visibilitychange';
-    } else if ('msHidden' in document) {
-      hidden = <keyof HTMLDocument>'msHidden';
-      visibilityChange = 'msvisibilitychange';
-    } else if ('webkitHidden' in document) {
-      hidden = <keyof HTMLDocument>'webkitHidden';
-      visibilityChange = 'webkitvisibilitychange';
-    }
-
-    this.browser.document.on(visibilityChange, () => {
-      if (document[hidden]) {
+    this.browser.document.on('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') {
         this.eventDispatcher.emit('hidden', new HiddenEvent(this));
         this._logger.debug('Window hidden');
-      } else {
+      } else if (document.visibilityState === 'visible') {
         this.eventDispatcher.emit('visible', new VisibleEvent(this));
         this._logger.debug('Window visible');
       }
-    });
+    })
 
     if (!this.canvasElementId && !options.canvasElement) {
       document.body.appendChild(this.canvas);

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -397,6 +397,26 @@ describe('The engine', () => {
     expect(fired).toHaveBeenCalledTimes(2);
   });
 
+  it('should emit a visible event', () => {
+    const fired = jasmine.createSpy('fired');
+    engine.on('visible', fired);
+
+    spyOnProperty(window.document, 'visibilityState').and.returnValue('visible');
+    window.document.dispatchEvent(new CustomEvent('visibilitychange'));
+
+    expect(fired).toHaveBeenCalled();
+  });
+
+  it('should emit a hidden event', () => {
+    const fired = jasmine.createSpy('fired');
+    engine.on('hidden', fired);
+    
+    spyOnProperty(window.document, 'visibilityState').and.returnValue('hidden');
+    window.document.dispatchEvent(new CustomEvent('visibilitychange'));
+
+    expect(fired).toHaveBeenCalled();
+  });
+
   it('should tell engine is running', () => {
     const status = engine.isRunning();
     expect(status).toBe(true);

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -410,7 +410,7 @@ describe('The engine', () => {
   it('should emit a hidden event', () => {
     const fired = jasmine.createSpy('fired');
     engine.on('hidden', fired);
-    
+
     spyOnProperty(window.document, 'visibilityState').and.returnValue('hidden');
     window.document.dispatchEvent(new CustomEvent('visibilitychange'));
 


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

Fixes `engine.on('visible')` not firing by using `document.visibilityState` API to determine current state

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #2409

## Changes:

- Fixed `engine.on('visible')` event not firing
