### PR TITLE
fix: [#2418] falsey event values being converted to GameEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed issue where `ex.Font` would become corrupted when re-used by multiple `ex.Text` instances
 - Fixed `engine.on('visible')` event not firing
+- Fixed `EventDispatcher.emit` converting falsy values to `ex.GameEvent`. It will only convert `undefined` or `null` values now.
 
 ### Updates
 

--- a/src/engine/EventDispatcher.ts
+++ b/src/engine/EventDispatcher.ts
@@ -33,7 +33,7 @@ export class EventDispatcher<T = any> implements Eventable {
       return;
     }
     eventName = eventName.toLowerCase();
-    if (!event) {
+    if (typeof event === 'undefined' || event === null) {
       event = new GameEvent();
     }
     let i: number, len: number;

--- a/src/spec/EventSpec.ts
+++ b/src/spec/EventSpec.ts
@@ -160,4 +160,45 @@ describe('An Event Dispatcher', () => {
       dispatcher.emit('foo', null);
     }).not.toThrow();
   });
+
+  it('converts undefined value to GameEvent', () => {
+    const newPubSub = new ex.EventDispatcher();
+    pubsub.wire(newPubSub);
+
+    let value;
+    pubsub.on('someevent', (v) => {
+      value = v;
+    });
+
+    newPubSub.emit('someevent', undefined);
+    expect(value).toBeInstanceOf(ex.GameEvent);
+  });
+
+  it('converts null value to GameEvent', () => {
+    const newPubSub = new ex.EventDispatcher();
+    pubsub.wire(newPubSub);
+
+    let value;
+    pubsub.on('someevent', (v) => {
+      value = v;
+    });
+
+    newPubSub.emit('someevent', null);
+    expect(value).toBeInstanceOf(ex.GameEvent);
+  });
+
+  // issue #2418
+  it('preserves falsy event value', () => {
+    const newPubSub = new ex.EventDispatcher();
+    pubsub.wire(newPubSub);
+
+    let value;
+    pubsub.on('someevent', (v) => {
+      value = v;
+    });
+
+    // emit is typed to take a GameEvent, but inherting classes take `any`
+    newPubSub.emit('someevent', 0 as any);
+    expect(value).toBe(0);
+  });
 });


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #2418

## Changes:

- Fixed `EventDispatcher.emit` converting falsy values to `ex.GameEvent`. It will only convert `undefined` or `null` values now.
