### PR TITLE
fix: [#2424] crash when using many ex.Text instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where using numerous `ex.Text` instances would cause Excalibur to crash webgl by implementing a global font cache.
 - Fixed issue where `ex.Font` would become corrupted when re-used by multiple `ex.Text` instances
 - Fixed `engine.on('visible')` event not firing
 - Fixed `EventDispatcher.emit` converting falsy values to `ex.GameEvent`. It will only convert `undefined` or `null` values now.

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -12,6 +12,7 @@
       <li><a href="tests/sprite-tint/">Sprite Tint</a></li>
       <li><a href="tests/parallel/">Parallel Actions</a></li>
       <li><a href="tests/isometric/">Isometric Map</a></li>
+      <li><a href="tests/textcrash/">Many Text instances without failure (Chrome)</a></li>
       <li><a href="tests/decode-many/">Decode Many Images without failure (Chrome)</a></li>
       <li><a href="tests/side-collision/">Arcade: Sliding on Floor</a></li>
       <li><a href="tests/side-collision2/">Arcade: No clipping divergent collisions</a></li>

--- a/sandbox/tests/textcrash/index.html
+++ b/sandbox/tests/textcrash/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Crash</title>
+</head>
+<body>
+  <p>Click on the screen, numbers should increment, there should be no errors in the console</p>
+  <script src="../../lib/excalibur.js"></script>
+  <script src="./index.js"></script>
+</body>
+</html>

--- a/sandbox/tests/textcrash/index.ts
+++ b/sandbox/tests/textcrash/index.ts
@@ -1,0 +1,55 @@
+
+class GameScene extends ex.Scene {
+  private tilemap!: ex.TileMap;
+  private font!: ex.Font;
+
+  onInitialize(engine: ex.Engine): void {
+    this.tilemap = new ex.TileMap({
+      pos: ex.Vector.Zero,
+      rows: 24,
+      columns: 16,
+      tileWidth: 32,
+      tileHeight: 32,
+    });
+    engine.add(this.tilemap);
+    this.font = new ex.Font();
+    // this.font.showDebug = true;
+
+    this.tilemap.tiles.forEach((tile) => {
+      tile.data.set("id", 0);
+    });
+
+    engine.input.pointers.primary.on("down", (event: ex.Input.PointerEvent): void => {
+      this.tilemap.tiles.forEach((tile) => {
+        const id = tile.data.get("id")!;
+        tile.data.set("id", id + 1);
+      });
+
+      this.updateTilemap();
+    });
+  }
+
+  updateTilemap(): void {
+    this.tilemap.tiles.forEach((tile) => {
+      const id = tile.data.get("id")!;
+
+      const text = new ex.Text({
+        text: `${id}`,
+        color: ex.Color.White,
+        // font: this.font
+      });
+      tile.clearGraphics();
+      tile.addGraphic(text);
+    });
+  }
+}
+
+var game = new ex.Engine({
+  width: 1080/2,
+  height: 1920/2,
+  displayMode: ex.DisplayMode.FitScreen
+});
+game.addScene('scene', new GameScene());
+game.start().then(() => {
+  game.goToScene('scene');
+});

--- a/src/engine/Graphics/Font.ts
+++ b/src/engine/Graphics/Font.ts
@@ -7,7 +7,7 @@ import { Graphic, GraphicOptions } from './Graphic';
 import { RasterOptions } from './Raster';
 import { ImageFiltering } from './Filtering';
 import { FontTextInstance } from './FontTextInstance';
-import { Logger } from '../Util/Log';
+import { FontCache } from './FontCache';
 
 /**
  * Represents a system or web font in Excalibur
@@ -17,7 +17,6 @@ import { Logger } from '../Util/Log';
  * If loading a custom web font be sure to have the font loaded before you use it https://erikonarheim.com/posts/dont-test-fonts/
  */
 export class Font extends Graphic implements FontRenderer {
-  private _logger = Logger.getInstance();
   /**
    * Set the font filtering mode, by default set to [[ImageFiltering.Blended]] regardless of the engine default smoothing
    *
@@ -139,9 +138,11 @@ export class Font extends Graphic implements FontRenderer {
     }
   }
 
-  private _textCache = new Map<string, FontTextInstance>();
-  private _measurementCache = new Map<string, BoundingBox>();
   private _textMeasurement = new FontTextInstance(this, '', Color.Black);
+
+  public measureTextWithoutCache(text: string) {
+    return this._textMeasurement.measureText(text);
+  }
 
   /**
    * Returns a BoundingBox that is the total size of the text including multiple lines
@@ -151,35 +152,15 @@ export class Font extends Graphic implements FontRenderer {
    * @returns BoundingBox
    */
   public measureText(text: string): BoundingBox {
-    const hash = FontTextInstance.getHashCode(this, text);
-    if (this._measurementCache.has(hash)) {
-      return this._measurementCache.get(hash);
-    }
-    this._logger.debug('font text measurement cache miss');
-    const measurement = this._textMeasurement.measureText(text);
-    this._measurementCache.set(hash, measurement);
-    return measurement;
+    return FontCache.measureText(text, this);
   }
 
   protected _postDraw(ex: ExcaliburGraphicsContext): void {
     ex.restore();
   }
 
-  private _textUsage = new Map<FontTextInstance, number>();
-
   public render(ex: ExcaliburGraphicsContext, text: string, colorOverride: Color, x: number, y: number) {
-    if (this.showDebug) {
-      this.clearCache();
-    }
-    this.checkAndClearCache();
-
-    const hash = FontTextInstance.getHashCode(this, text, colorOverride);
-    let textInstance = this._textCache.get(hash);
-    if (!textInstance) {
-      textInstance =  new FontTextInstance(this, text, colorOverride);
-      this._textCache.set(hash, textInstance);
-      this._logger.debug('Font text instance cache miss');
-    }
+    let textInstance = FontCache.getTextInstance(text, this, colorOverride);
 
     // Apply affine transformations
     this._textBounds = textInstance.dimensions;
@@ -188,60 +169,5 @@ export class Font extends Graphic implements FontRenderer {
     textInstance.render(ex, x, y);
 
     this._postDraw(ex);
-
-    // Cache the bitmap for certain amount of time
-    this._textUsage.set(textInstance, performance.now());
-  }
-
-  /**
-   * Get the internal cache size of the font
-   * This is useful when debugging memory usage, these numbers indicate the number of cached in memory text bitmaps
-   */
-  public get cacheSize() {
-    return this._textUsage.size;
-  }
-
-  /**
-   * Force clear all cached text bitmaps
-   */
-  public clearCache() {
-    this._textUsage.clear();
-  }
-
-  /**
-   * Remove any expired cached text bitmaps
-   */
-  public checkAndClearCache() {
-    const deferred: FontTextInstance[] = [];
-    const currentHashCodes = new Set<string>();
-    for (const [textInstance, time] of this._textUsage.entries()) {
-      // if bitmap hasn't been used in 100 ms clear it
-      if (time + 100 < performance.now()) {
-        deferred.push(textInstance);
-        textInstance.dispose();
-      } else {
-        const hash = textInstance.getHashCode(false);
-        currentHashCodes.add(hash);
-      }
-    }
-    // Deferred removal of text instances
-    deferred.forEach(t => {
-      this._textUsage.delete(t);
-    });
-
-    // Regenerate text instance cache
-    this._textCache.clear();
-    for (const [textInstance] of this._textUsage.entries()) {
-      this._textCache.set(textInstance.getHashCode(), textInstance);
-    }
-
-    // Regenerated measurement cache
-    const newTextMeasurementCache = new Map<string, BoundingBox>();
-    for (const current of currentHashCodes) {
-      if (this._measurementCache.has(current)) {
-        newTextMeasurementCache.set(current, this._measurementCache.get(current));
-      }
-    }
-    this._measurementCache = newTextMeasurementCache;
   }
 }

--- a/src/engine/Graphics/Font.ts
+++ b/src/engine/Graphics/Font.ts
@@ -160,7 +160,7 @@ export class Font extends Graphic implements FontRenderer {
   }
 
   public render(ex: ExcaliburGraphicsContext, text: string, colorOverride: Color, x: number, y: number) {
-    let textInstance = FontCache.getTextInstance(text, this, colorOverride);
+    const textInstance = FontCache.getTextInstance(text, this, colorOverride);
 
     // Apply affine transformations
     this._textBounds = textInstance.dimensions;

--- a/src/engine/Graphics/FontCache.ts
+++ b/src/engine/Graphics/FontCache.ts
@@ -1,0 +1,87 @@
+import { BoundingBox } from "../Collision/BoundingBox";
+import { Color } from "../Color";
+import { Logger } from "../Util/Log";
+import { Font } from "./Font";
+import { FontTextInstance } from "./FontTextInstance";
+
+export class FontCache {
+  private static _LOGGER = Logger.getInstance();
+  private static _TEXT_USAGE = new Map<FontTextInstance, number>();
+  private static _TEXT_CACHE = new Map<string, FontTextInstance>();
+  private static _MEASURE_CACHE = new Map<string, BoundingBox>();
+
+  static measureText(text: string, font: Font) {
+    const hash = FontTextInstance.getHashCode(font, text);
+    if (FontCache._MEASURE_CACHE.has(hash)) {
+      return FontCache._MEASURE_CACHE.get(hash);
+    }
+    FontCache._LOGGER.debug('Font text measurement cache miss');
+    const measurement = font.measureTextWithoutCache(text);
+    FontCache._MEASURE_CACHE.set(hash, measurement);
+    return measurement;
+  }
+
+  static getTextInstance(text: string, font: Font, color: Color) {
+    const hash = FontTextInstance.getHashCode(font, text, color);
+    let textInstance = FontCache._TEXT_CACHE.get(hash);
+    if (!textInstance) {
+      textInstance =  new FontTextInstance(font, text, color);
+      FontCache._TEXT_CACHE.set(hash, textInstance);
+      FontCache._LOGGER.debug('Font text instance cache miss');
+    }
+
+    // Cache the bitmap for certain amount of time
+    FontCache._TEXT_USAGE.set(textInstance, performance.now());
+
+    return textInstance;
+  }
+
+  static checkAndClearCache() {
+    const deferred: FontTextInstance[] = [];
+    const currentHashCodes = new Set<string>();
+    for (const [textInstance, time] of FontCache._TEXT_USAGE.entries()) {
+      // if bitmap hasn't been used in 100 ms clear it
+      if (time + 100 < performance.now()) {
+        FontCache._LOGGER.debug(`Text cache entry timed out ${textInstance.text}`)
+        deferred.push(textInstance);
+        textInstance.dispose();
+      } else {
+        const hash = textInstance.getHashCode(false);
+        currentHashCodes.add(hash);
+      }
+    }
+    // Deferred removal of text instances
+    deferred.forEach(t => {
+      FontCache._TEXT_USAGE.delete(t);
+    });
+
+    // Regenerate text instance cache
+    this._TEXT_CACHE.clear();
+    for (const [textInstance] of this._TEXT_USAGE.entries()) {
+      this._TEXT_CACHE.set(textInstance.getHashCode(), textInstance);
+    }
+
+    // Regenerated measurement cache
+    const newTextMeasurementCache = new Map<string, BoundingBox>();
+    for (const current of currentHashCodes) {
+      if (FontCache._MEASURE_CACHE.has(current)) {
+        newTextMeasurementCache.set(current, FontCache._MEASURE_CACHE.get(current));
+      }
+    }
+    this._MEASURE_CACHE.clear();
+    this._MEASURE_CACHE = newTextMeasurementCache;
+  }
+
+
+  public static get cacheSize() {
+    return FontCache._TEXT_USAGE.size;
+  }
+
+  /**
+   * Force clear all cached text bitmaps
+   */
+  public clearCache() {
+    FontCache._TEXT_USAGE.clear();
+  }
+
+}

--- a/src/engine/Graphics/FontCache.ts
+++ b/src/engine/Graphics/FontCache.ts
@@ -1,8 +1,8 @@
-import { BoundingBox } from "../Collision/BoundingBox";
-import { Color } from "../Color";
-import { Logger } from "../Util/Log";
-import { Font } from "./Font";
-import { FontTextInstance } from "./FontTextInstance";
+import { BoundingBox } from '../Collision/BoundingBox';
+import { Color } from '../Color';
+import { Logger } from '../Util/Log';
+import { Font } from './Font';
+import { FontTextInstance } from './FontTextInstance';
 
 export class FontCache {
   private static _LOGGER = Logger.getInstance();
@@ -42,7 +42,7 @@ export class FontCache {
     for (const [textInstance, time] of FontCache._TEXT_USAGE.entries()) {
       // if bitmap hasn't been used in 100 ms clear it
       if (time + 100 < performance.now()) {
-        FontCache._LOGGER.debug(`Text cache entry timed out ${textInstance.text}`)
+        FontCache._LOGGER.debug(`Text cache entry timed out ${textInstance.text}`);
         deferred.push(textInstance);
         textInstance.dispose();
       } else {

--- a/src/engine/Graphics/FontCache.ts
+++ b/src/engine/Graphics/FontCache.ts
@@ -80,8 +80,13 @@ export class FontCache {
   /**
    * Force clear all cached text bitmaps
    */
-  public clearCache() {
+  public static clearCache() {
+    for (const [textInstance] of FontCache._TEXT_USAGE.entries()) {
+      textInstance.dispose();
+    }
     FontCache._TEXT_USAGE.clear();
+    FontCache._TEXT_CACHE.clear();
+    FontCache._MEASURE_CACHE.clear();
   }
 
 }

--- a/src/engine/Graphics/FontTextInstance.ts
+++ b/src/engine/Graphics/FontTextInstance.ts
@@ -160,6 +160,9 @@ export class FontTextInstance {
     return textImages;
   }
 
+  public flagDirty() {
+    this._dirty = true;
+  }
   private _dirty = true;
   public render(ex: ExcaliburGraphicsContext, x: number, y: number) {
     if (this.disposed) {

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -12,6 +12,7 @@ import { Particle } from '../Particles';
 import { ParallaxComponent } from './ParallaxComponent';
 import { CoordPlane } from '../Math/coord-plane';
 import { BodyComponent } from '../Collision/BodyComponent';
+import { FontCache } from './FontCache';
 
 export class GraphicsSystem extends System<TransformComponent | GraphicsComponent> {
   public readonly types = ['ex.transform', 'ex.graphics'] as const;
@@ -67,6 +68,7 @@ export class GraphicsSystem extends System<TransformComponent | GraphicsComponen
   public update(_entities: Entity[], delta: number): void {
     this._token++;
     let graphics: GraphicsComponent;
+    FontCache.checkAndClearCache();
 
     // This is a performance enhancement, most things are in world space
     // so if we can only do this once saves a ton of transform updates

--- a/src/engine/Graphics/index.ts
+++ b/src/engine/Graphics/index.ts
@@ -22,6 +22,7 @@ export * from './Polygon';
 export * from './Text';
 export * from './FontCommon';
 export * from './Font';
+export * from './FontCache';
 export * from './SpriteFont';
 export * from './Canvas';
 

--- a/src/spec/TextSpec.ts
+++ b/src/spec/TextSpec.ts
@@ -813,11 +813,11 @@ describe('A Text Graphic', () => {
 
   it('can create lots of text without crash', () => {
     expect(() => {
-      let text: ex.Text[] = [];
+      const text: ex.Text[] = [];
       for (let i = 0; i < 1000; i++) {
         text.push(new ex.Text({
           text: 'text that is long' + i
-        }))
+        }));
       }
     }).not.toThrow();
   });

--- a/src/spec/TextSpec.ts
+++ b/src/spec/TextSpec.ts
@@ -479,6 +479,7 @@ describe('A Text Graphic', () => {
   });
 
   it('can force clear text bitmap cache', () => {
+    ex.FontCache.clearCache();
     const sut = new ex.Font({
       family: 'Open Sans',
       size: 18,
@@ -511,13 +512,14 @@ describe('A Text Graphic', () => {
     text.draw(ctx, 10, 50);
     text2.draw(ctx, 10, 50);
 
-    expect(sut.cacheSize).toBe(2);
-    sut.clearCache();
-    expect(sut.cacheSize).toBe(0);
+    expect(ex.FontCache.cacheSize).toBe(2);
+    ex.FontCache.clearCache();
+    expect(ex.FontCache.cacheSize).toBe(0);
 
   });
 
   it('will collect text bitmap garbage', async () => {
+    ex.FontCache.clearCache();
     const sut = new ex.Font({
       family: 'Open Sans',
       size: 18,
@@ -549,15 +551,16 @@ describe('A Text Graphic', () => {
     ctx.clear();
     text.draw(ctx, 10, 50);
     text2.draw(ctx, 10, 50);
-    expect(sut.cacheSize).toBe(2);
+    expect(ex.FontCache.cacheSize).toBe(2);
 
     await delay(1001); // text is cached for 1 second
 
-    sut.checkAndClearCache();
-    expect(sut.cacheSize).toBe(0);
+    ex.FontCache.checkAndClearCache();
+    expect(ex.FontCache.cacheSize).toBe(0);
   });
 
   it('will collect text bitmap garbage', async () => {
+    ex.FontCache.clearCache();
     const sut = new ex.Font({
       family: 'Open Sans',
       size: 18,
@@ -589,15 +592,16 @@ describe('A Text Graphic', () => {
     ctx.clear();
     text.draw(ctx, 10, 50);
     text2.draw(ctx, 10, 50);
-    expect(sut.cacheSize).toBe(2);
+    expect(ex.FontCache.cacheSize).toBe(2);
 
     await delay(1001); // text is cached for 1 second
 
-    sut.checkAndClearCache();
-    expect(sut.cacheSize).toBe(0);
+    ex.FontCache.checkAndClearCache();
+    expect(ex.FontCache.cacheSize).toBe(0);
   });
 
   it('should cache based on text and raster props', () => {
+    ex.FontCache.clearCache();
     const sut = new ex.Font({
       family: 'Open Sans',
       size: 18,
@@ -629,7 +633,7 @@ describe('A Text Graphic', () => {
     ctx.clear();
     text.draw(ctx, 10, 50);
     text2.draw(ctx, 10, 50);
-    expect(sut.cacheSize).toBe(2);
+    expect(ex.FontCache.cacheSize).toBe(2);
   });
 
   it('can reuse a font', async () => {
@@ -805,6 +809,17 @@ describe('A Text Graphic', () => {
     await runOnLinux(async () => {
       await expectAsync(flushWebGLCanvasTo2D(canvasElement)).toEqualImage('src/spec/images/GraphicsTextSpec/long-text-linux.png');
     });
+  });
+
+  it('can create lots of text without crash', () => {
+    expect(() => {
+      let text: ex.Text[] = [];
+      for (let i = 0; i < 1000; i++) {
+        text.push(new ex.Text({
+          text: 'text that is long' + i
+        }))
+      }
+    }).not.toThrow();
   });
 
   describe('with a SpriteFont', () => {


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2424

## Changes:

- Implements a global font cache so that any functionally identical fonts can share resources
