### PR TITLE
fix: [#2425] incorrect event type in `ex.Actor.on('postupdate')`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed incorrect event type returned when `ex.Actor.on('postupdate', (event) => {...})`.
 - Fixed issue where using numerous `ex.Text` instances would cause Excalibur to crash webgl by implementing a global font cache.
 - Fixed issue where child entities did not inherit the scene from their parent
 - Fixed issue where `ex.Font` would become corrupted when re-used by multiple `ex.Text` instances

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -981,7 +981,7 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
    * @internal
    */
   public _postupdate(engine: Engine, delta: number): void {
-    this.emit('postupdate', new PreUpdateEvent(engine, delta, this));
+    this.emit('postupdate', new PostUpdateEvent(engine, delta, this));
     this.onPostUpdate(engine, delta);
   }
 


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2425

## Changes:

- Correct event type
