### PR TITLE
feat: [#2460] add support for wasButtonPressed and wasButtonReleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added the emitted particle transform style as part of `ex.ParticleEmitter({particleTransform: ex.ParticleTransform.Global})`, [[ParticleTransform.Global]] is the default and emits particles as if they were world space objects, useful for most effects. If set to [[ParticleTransform.Local]] particles are children of the emitter and move relative to the emitter as they would in a parent/child actor relationship.
+- Added `wasButtonReleased` and `wasButtonPressed` methods to [[ex.Input.Gamepad]]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
--
+- [[ex.Input.Gamepad]] `isButtonPressed` has been renamed to `isButtonHeld`
+
 
 ### Added
 

--- a/sandbox/tests/input/gamepad.ts
+++ b/sandbox/tests/input/gamepad.ts
@@ -88,12 +88,21 @@ function start() {
       for (var btn in buttons) {
         if (!buttons.hasOwnProperty(btn)) continue;
         btnIndex = parseInt(btn, 10);
+
+        const actor = buttons[btn];
+        if (pad1.wasButtonPressed(btnIndex, 0.1) || pad1.wasButtonReleased(btnIndex)) {
+          actor.actions.clearActions()
+          actor.actions
+            .scaleTo(ex.Vector.One.scale(1.25), ex.Vector.One.scale(5))
+            .scaleTo(ex.Vector.One.scale(1), ex.Vector.One.scale(5))
+        }
+        
         if (pad1.isButtonPressed(btnIndex, 0.1)) {
-          buttons[btn].color = new ex.Color(255, 0, 0, 0.8);
-          buttons[btn].value = pad1.getButton(btnIndex);
+          actor.color = new ex.Color(255, 0, 0, 0.8);
+          actor.value = pad1.getButton(btnIndex);
         } else {
-          buttons[btn].color = new ex.Color(0, 0, 0, 0.7);
-          buttons[btn].value = 0;
+          actor.color = new ex.Color(0, 0, 0, 0.7);
+          actor.value = 0;
         }
       }
     }

--- a/src/engine/Input/Gamepad.ts
+++ b/src/engine/Input/Gamepad.ts
@@ -283,6 +283,8 @@ export class Gamepad extends Class {
 
   /**
    * Whether or not the given button is pressed
+   *
+   * @deprecated will be removed in v0.28.0. Use isButtonHeld instead
    * @param button     The button to query
    * @param threshold  The threshold over which the button is considered to be pressed
    */
@@ -291,7 +293,18 @@ export class Gamepad extends Class {
   }
 
   /**
+   * Tests if a certain button is held down. This is persisted between frames.
+   *
+   * @param button     The button to query
+   * @param threshold  The threshold over which the button is considered to be pressed
+   */
+  public isButtonHeld(button: Buttons, threshold: number = 1) {
+    return this._buttons[button] >= threshold;
+  }
+
+  /**
    * Tests if a certain button was just pressed this frame. This is cleared at the end of the update frame.
+   *
    * @param button Test whether a button was just pressed
    * @param threshold  The threshold over which the button is considered to be pressed
    */
@@ -301,6 +314,7 @@ export class Gamepad extends Class {
 
   /**
    * Tests if a certain button was just released this frame. This is cleared at the end of the update frame.
+   *
    * @param button  Test whether a button was just released
    */
   public wasButtonReleased(button: Buttons) {

--- a/src/engine/Input/Gamepad.ts
+++ b/src/engine/Input/Gamepad.ts
@@ -134,6 +134,8 @@ export class Gamepads extends Class {
         this.at(i).connected = true;
       }
 
+      this.at(i).update();
+
       // Only supported in Chrome
       if (gamepads[i].timestamp && gamepads[i].timestamp === this._gamePadTimeStamps[i]) {
         continue;
@@ -245,6 +247,7 @@ export class Gamepads extends Class {
       clonedPad.updateAxes(i, pad.axes[i]);
     }
 
+
     return clonedPad;
   }
 }
@@ -256,8 +259,10 @@ export class Gamepads extends Class {
 export class Gamepad extends Class {
   public connected = false;
   public navigatorGamepad: NavigatorGamepad;
-  private _buttons: number[] = new Array(16);
   private _axes: number[] = new Array(4);
+  private _buttons: number[] = new Array(16);
+  private _buttonsUp: number[] = new Array(16);
+  private _buttonsDown: number[] = new Array(16);
 
   constructor() {
     super();
@@ -270,6 +275,12 @@ export class Gamepad extends Class {
     }
   }
 
+  public update() {
+    // Reset buttonsDown and buttonsUp after update is complete
+    this._buttonsDown = new Array(16);
+    this._buttonsUp = new Array(16);
+  }
+
   /**
    * Whether or not the given button is pressed
    * @param button     The button to query
@@ -277,6 +288,23 @@ export class Gamepad extends Class {
    */
   public isButtonPressed(button: Buttons, threshold: number = 1) {
     return this._buttons[button] >= threshold;
+  }
+
+  /**
+   * Tests if a certain button was just pressed this frame. This is cleared at the end of the update frame.
+   * @param button Test whether a button was just pressed
+   * @param threshold  The threshold over which the button is considered to be pressed
+   */
+  public wasButtonPressed(button: Buttons, threshold: number = 1) {
+    return this._buttonsDown[button] >= threshold;
+  }
+
+  /**
+   * Tests if a certain button was just released this frame. This is cleared at the end of the update frame.
+   * @param button  Test whether a button was just released
+   */
+  public wasButtonReleased(button: Buttons) {
+    return Boolean(this._buttonsUp[button]);
   }
 
   /**
@@ -301,6 +329,15 @@ export class Gamepad extends Class {
   }
 
   public updateButton(buttonIndex: number, value: number) {
+    // button was just released
+    if (value === 0 && this._buttons[buttonIndex]) {
+      this._buttonsUp[buttonIndex] = 1;
+
+    // button was just pressed
+    } else {
+      this._buttonsDown[buttonIndex] = value;
+    }
+
     this._buttons[buttonIndex] = value;
   }
 


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #2460

## Changes:

- add support for gamepad wasButtonPressed and wasButtonReleased
