### PR TITLE
Fix x-axis bug in `actions.scaleTo`

### DIFF
--- a/src/engine/Actions/Action/ScaleTo.ts
+++ b/src/engine/Actions/Action/ScaleTo.ts
@@ -61,7 +61,7 @@ export class ScaleTo implements Action {
   public isComplete(): boolean {
     return (
       this._stopped ||
-      (Math.abs(this._tx.scale.y - this._startX) >= (this._distanceX - 0.01) &&
+      (Math.abs(this._tx.scale.x - this._startX) >= (this._distanceX - 0.01) &&
         Math.abs(this._tx.scale.y - this._startY) >= (this._distanceY - 0.01))
     );
   }

--- a/src/spec/ActionSpec.ts
+++ b/src/spec/ActionSpec.ts
@@ -1051,6 +1051,19 @@ describe('Action', () => {
       expect(actor.scale.x).toBe(1.5);
       expect(actor.scale.y).toBe(1.5);
     });
+
+    it('completes when scaling on the x-axis', () => {
+      expect(actor.scale.x).toBe(1);
+
+      const scaleTo = new ex.ScaleTo(actor, 2, 1, 1, 1);
+      actor.actions.runAction(scaleTo);
+      expect(scaleTo.isComplete()).toBeFalse();
+
+      scene.update(engine, 1000);
+      expect(actor.scale.x).toBe(2);
+      expect(actor.scale.y).toBe(1);
+      expect(scaleTo.isComplete()).toBeTrue();
+    });
   });
 
   describe('scaleBy', () => {


### PR DESCRIPTION
Previously if scaling only on the x-axis, the action would never complete.

<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed) __I think it's not needed for a small bugfix?__

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #2470 

## Changes:

Fixes a bug I found in the `ScaleTo` action, where scaling on the x-axis exclusively may never complete. The `isComplete` method accidentally tested `tx.scale.y` against the x-axis, rather than testing `tx.scale.x` against the x-axis. I wrote the test first, watched it fail, and then fixed the bug and watched the test pass.

It looks like since I'm a first-time contributor I'll need approval from a maintainer to actually run the CI checks, but I pinky swear I ran `npm run all` locally and it all passed. :smile:
