### PR TITLE
fix [#2538] wait for image to load before draw

### DIFF
--- a/src/engine/Loader.ts
+++ b/src/engine/Loader.ts
@@ -413,9 +413,13 @@ export class Loader extends Class implements Loadable<Loadable<any>[]> {
     const oldAntialias = this._engine.getAntialiasing();
     this._engine.setAntialiasing(true);
     if (!this.logoPosition) {
-      this._image.onload = () => ctx.drawImage(this._image, 0, 0, this.logoWidth, this.logoHeight, logoX, logoY - imageHeight - 20, width, imageHeight);
+      this._image.onload = () => {
+        ctx.drawImage(this._image, 0, 0, this.logoWidth, this.logoHeight, logoX, logoY - imageHeight - 20, width, imageHeight);
+      }
     } else {
-      this._image.onload = () => ctx.drawImage(this._image, 0, 0, this.logoWidth, this.logoHeight, logoX, logoY, width, imageHeight);
+      this._image.onload = () => {
+        ctx.drawImage(this._image, 0, 0, this.logoWidth, this.logoHeight, logoX, logoY, width, imageHeight);
+      }
     }
 
     // loading box

--- a/src/engine/Loader.ts
+++ b/src/engine/Loader.ts
@@ -413,9 +413,9 @@ export class Loader extends Class implements Loadable<Loadable<any>[]> {
     const oldAntialias = this._engine.getAntialiasing();
     this._engine.setAntialiasing(true);
     if (!this.logoPosition) {
-      ctx.drawImage(this._image, 0, 0, this.logoWidth, this.logoHeight, logoX, logoY - imageHeight - 20, width, imageHeight);
+      this._image.onload = () => ctx.drawImage(this._image, 0, 0, this.logoWidth, this.logoHeight, logoX, logoY - imageHeight - 20, width, imageHeight);
     } else {
-      ctx.drawImage(this._image, 0, 0, this.logoWidth, this.logoHeight, logoX, logoY, width, imageHeight);
+      this._image.onload = () => ctx.drawImage(this._image, 0, 0, this.logoWidth, this.logoHeight, logoX, logoY, width, imageHeight);
     }
 
     // loading box

--- a/src/engine/Loader.ts
+++ b/src/engine/Loader.ts
@@ -415,11 +415,11 @@ export class Loader extends Class implements Loadable<Loadable<any>[]> {
     if (!this.logoPosition) {
       this._image.onload = () => {
         ctx.drawImage(this._image, 0, 0, this.logoWidth, this.logoHeight, logoX, logoY - imageHeight - 20, width, imageHeight);
-      }
+      };
     } else {
       this._image.onload = () => {
         ctx.drawImage(this._image, 0, 0, this.logoWidth, this.logoHeight, logoX, logoY, width, imageHeight);
-      }
+      };
     }
 
     // loading box


### PR DESCRIPTION
In some cases on low spec pc, the image, when populated from the getter, does not complete loaded when calling the drawImage.

<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #2538

## Changes:

- Wait for load before draw
