### PR TITLE
fix: [#2599] Update Sound canPlayFile to handle querystrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ are returned
 
 ### Fixed
 
+- Fixed issue where `ex.Sound` would get confused parsing and playing sound files with a querystring in their path
 - Fixed issue where `ex.ColliderComponent` was not deeply cloning the stored `ex.Collider` causing them to be shared across clones.
 - Fixed issue where `ex.GraphicsComponent` was not deeploy cloning the
 stored `ex.Graphics` causing them to be shared across clones.

--- a/src/engine/Util/Sound.ts
+++ b/src/engine/Util/Sound.ts
@@ -6,7 +6,7 @@ import { Logger } from './Log';
 export function canPlayFile(file: string): boolean {
   try {
     const a = new Audio();
-    const filetype = /.*\.([A-Za-z0-9]+)(?:(?:\?|\#).*)$/;
+    const filetype = /.*\.([A-Za-z0-9]+)(?:(?:\?|\#).*)*$/;
     const type = file.match(filetype)[1];
     if (a.canPlayType('audio/' + type)) {
       return true;

--- a/src/engine/Util/Sound.ts
+++ b/src/engine/Util/Sound.ts
@@ -6,7 +6,7 @@ import { Logger } from './Log';
 export function canPlayFile(file: string): boolean {
   try {
     const a = new Audio();
-    const filetype = /.*\.([A-Za-z0-9]+)$/;
+    const filetype = /.*\.([A-Za-z0-9]+)(?:(?:\?|\#).*)$/;
     const type = file.match(filetype)[1];
     if (a.canPlayType('audio/' + type)) {
       return true;

--- a/src/spec/SoundSpec.ts
+++ b/src/spec/SoundSpec.ts
@@ -25,6 +25,10 @@ describe('Sound resource', () => {
     expect(canPlayFile('coin.mp3')).toBe(true);
   });
 
+  it('can detect playability of files', () => {
+    expect(canPlayFile('coin.mp3?12234')).toBe(true);
+  });
+
   it('can detect playability of files with multiple dots', () => {
     expect(canPlayFile('coin.f74d9d70.mp3')).toBe(true);
   });

--- a/src/spec/SoundSpec.ts
+++ b/src/spec/SoundSpec.ts
@@ -1,4 +1,5 @@
 import * as ex from '@excalibur';
+import { canPlayFile } from '../engine/Util/Sound';
 import { delay } from '../engine/Util/Util';
 import { WebAudio } from '../engine/Util/WebAudio';
 import { TestUtils } from './util/TestUtils';
@@ -18,6 +19,26 @@ describe('Sound resource', () => {
 
   it('should be able to be constructed', () => {
     expect(sut).toBeDefined();
+  });
+
+  it('can detect playability of files', () => {
+    expect(canPlayFile('coin.mp3')).toBe(true);
+  });
+
+  it('can detect playability of files with multiple dots', () => {
+    expect(canPlayFile('coin.f74d9d70.mp3')).toBe(true);
+  });
+
+  it('can detect playability of files with querystrings', () => {
+    expect(canPlayFile('coin.f74d9d70.mp3?1678266496281')).toBe(true);
+  });
+
+  it('can detect playability of files with hash', () => {
+    expect(canPlayFile('coin.f74d9d70.mp3#1678266496281')).toBe(true);
+  });
+
+  it('can detect playability of files with querystring and hash', () => {
+    expect(canPlayFile('coin.f74d9d70.mp3?_=1234#1678266496281')).toBe(true);
   });
 
   it('should fire processed event', async () => {


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2599

## Changes:

- Update regex parsing sound paths to determine audio support
