### PR TITLE
fix: [#2597] Add defense to ScreenElement ctor for zero width/height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ are returned
 
 ### Fixed
 
+- Fixed issue where `ex.ScreenElement` would log a warning when created without a height or width
 - Fixed issue where `ex.Sound` would get confused parsing and playing sound files with a querystring in their path
 - Fixed issue where `ex.ColliderComponent` was not deeply cloning the stored `ex.Collider` causing them to be shared across clones.
 - Fixed issue where `ex.GraphicsComponent` was not deeploy cloning the

--- a/src/engine/ScreenElement.ts
+++ b/src/engine/ScreenElement.ts
@@ -27,7 +27,9 @@ export class ScreenElement extends Actor {
     this.get(TransformComponent).coordPlane = CoordPlane.Screen;
     this.anchor = vec(0, 0);
     this.body.collisionType = CollisionType.PreventCollision;
-    this.collider.useBoxCollider(this.width, this.height, this.anchor);
+    if (config?.width > 0 && config?.height > 0) {
+      this.collider.useBoxCollider(this.width, this.height, this.anchor);
+    }
   }
 
   public _initialize(engine: Engine) {

--- a/src/spec/ScreenElementSpec.ts
+++ b/src/spec/ScreenElementSpec.ts
@@ -2,6 +2,7 @@ import { ExcaliburMatchers, ensureImagesLoaded, ExcaliburAsyncMatchers } from 'e
 import * as ex from '@excalibur';
 import { Mocks } from './util/Mocks';
 import { TestUtils } from './util/TestUtils';
+import { ScreenElement } from '@excalibur';
 
 describe('A ScreenElement', () => {
   let screenElement: ex.ScreenElement;
@@ -36,6 +37,15 @@ describe('A ScreenElement', () => {
   afterEach(() => {
     engine.stop();
     engine = null;
+  });
+
+  it('can be constructed with zero args without a warning', () => {
+    const logger = ex.Logger.getInstance();
+    spyOn(logger, 'warn');
+
+    const sut = new ScreenElement();
+
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('is drawn when visible', () => {


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2597 

## Changes:

- Adds defense to the `ScreenElement` to avoid an unnecessary warning
