### PR TITLE
fix: [#2608] macos meta key issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ are returned
 
 ### Fixed
 
+- Fixed issue in macos where the meta key would prevent keyup's from firing correctly
 - Fixed issue when excalibur was hosted in a x-origin iframe, the engine will grab window focus by default if in an iframe. This can be suppressed with `new ex.Engine({grabWindowFocus: false})`
 - Fixed issue where `ex.Camera.rotation = ...` did not work to rotate the camera, also addressed offscreen culling issues that were revealed by this fix.
 - Fixed issue where the `ex.ScreenElement` anchor was not being accounted for properly when passed as a constructor parameter.

--- a/sandbox/tests/input/keyboard.ts
+++ b/sandbox/tests/input/keyboard.ts
@@ -7,6 +7,14 @@ label.font.textAlign = ex.TextAlign.Center;
 
 game.add(label);
 
+game.input.keyboard.on('press', e => {
+  console.log('Key Pressed:', e.key);
+});
+
+game.input.keyboard.on('release', e => {
+  console.log('Key Released:', e.key);
+});
+
 game.on('postupdate', (ue: ex.PostUpdateEvent) => {
   var keys = game.input.keyboard
     .getKeys()

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -258,14 +258,14 @@ export class Keyboard extends Class {
   }
 
   private _releaseAllKeys = (ev: KeyboardEvent) => {
-    for (let code of this._keys) {
+    for (const code of this._keys) {
       const keyEvent = new KeyEvent(code, ev.key, ev);
       this.eventDispatcher.emit('up', keyEvent);
       this.eventDispatcher.emit('release', keyEvent);
     }
     this._keysUp = Array.from((new Set(this._keys.concat(this._keysUp))));
     this._keys.length = 0;
-  }
+  };
 
   private _handleKeyDown = (ev: KeyboardEvent) => {
     // handle macos meta key issue


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR adds a fix suggested from SO, where release of the meta key causes the release of all keys

- https://stackoverflow.com/a/73419500/839595

Closes #2608 

Following the repro
* Press A key
* Press Command key
* Release A key
* Release Command key

![macos-meta](https://github.com/excaliburjs/Excalibur/assets/612071/91fd18eb-2bc8-4af3-95a6-43d00d826b10)
