### PR TITLE
fix: [#2535] Update to default false on cache busting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ stored `ex.Graphics` causing them to be shared across clones.
 
 ### Changed
 
--
+- Excalibur resources by default no longer add cache busting query string to resources. All built in resources now expose a `bustCache` property to allow setting this before loading, for example `ex.Sound.bustCache`.
 
 
 

--- a/src/engine/Graphics/ImageSource.ts
+++ b/src/engine/Graphics/ImageSource.ts
@@ -67,6 +67,18 @@ export class ImageSource implements Loadable<HTMLImageElement> {
   }
 
   /**
+   * Should excalibur add a cache busting querystring? By default false.
+   * Must be set before loading
+   */
+  public get bustCache() {
+    return this._resource.bustCache;
+  }
+
+  public set bustCache(val: boolean) {
+    this._resource.bustCache = val;
+  }
+
+  /**
    * Begins loading the image and returns a promise that resolves when the image is loaded
    */
   async load(): Promise<HTMLImageElement> {

--- a/src/engine/Resources/Gif.ts
+++ b/src/engine/Resources/Gif.ts
@@ -38,9 +38,21 @@ export class Gif implements Loadable<ImageSource[]> {
    * @param color      Optionally set the color to treat as transparent the gif, by default [[Color.Magenta]]
    * @param bustCache  Optionally load texture with cache busting
    */
-  constructor(public path: string, public color: Color = Color.Magenta, public bustCache = true) {
+  constructor(public path: string, public color: Color = Color.Magenta, bustCache = false) {
     this._resource = new Resource(path, 'arraybuffer', bustCache);
     this._transparentColor = color;
+  }
+
+  /**
+   * Should excalibur add a cache busting querystring? By default false.
+   * Must be set before loading
+   */
+  public get bustCache() {
+    return this._resource.bustCache;
+  }
+
+  public set bustCache(val: boolean) {
+    this._resource.bustCache = val;
   }
 
   /**

--- a/src/engine/Resources/Resource.ts
+++ b/src/engine/Resources/Resource.ts
@@ -19,7 +19,7 @@ export class Resource<T> implements Loadable<T> {
   constructor(
     public path: string,
     public responseType: '' | 'arraybuffer' | 'blob' | 'document' | 'json' | 'text',
-    public bustCache: boolean = true
+    public bustCache: boolean = false
   ) {}
 
   /**

--- a/src/engine/Resources/Sound/Sound.ts
+++ b/src/engine/Resources/Sound/Sound.ts
@@ -84,6 +84,19 @@ export class Sound extends Class implements Audio, Loadable<AudioBuffer> {
     this._resource.path = val;
   }
 
+
+  /**
+   * Should excalibur add a cache busting querystring? By default false.
+   * Must be set before loading
+   */
+  public get bustCache() {
+    return this._resource.bustCache;
+  }
+
+  public set bustCache(val: boolean) {
+    this._resource.bustCache = val;
+  }
+
   private _loop = false;
   private _volume = 1;
   private _isStopped = false;


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2535

This PR updates `bustCache= false` by default and provides a `bustCache` property on all built in `Resource` implementations.
