### PR TITLE
feat: [#2416] Add Postprocessor hooks and default some uniforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added updates to `ex.PostProcessor` 
+  * New optional `ex.PostProcessor.onUpdate` hook for updating custom uniforms
+  * Added default uniforms that are automatically added
+    * `uniform float u_time_ms` - total playback time in milliseconds
+    * `uniform float u_elapsed_ms` - the elapsed time from the last frame in milliseconds
+    * `uniform vec2 u_resolution` - the resolution of the canvas (in pixels)
+
 - Added new helper called `ex.Animation.fromSpriteSheetCoordinates` to help build animations more tersely from SpriteSheets
   ```typescript
    const spriteSheet = SpriteSheet.fromImageSource({...});

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1202,6 +1202,9 @@ O|===|* >________________>\n\
     // process engine level events
     this.currentScene.update(this, delta);
 
+    // Update graphics postprocessors
+    this.graphicsContext.updatePostProcessors(delta);
+
     // Publish update event
     this._postupdate(delta);
 

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContext.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContext.ts
@@ -241,6 +241,15 @@ export interface ExcaliburGraphicsContext {
   clearPostProcessors(): void;
 
   /**
+   * Updates all post processors in the graphics context
+   *
+   * Called internally by Excalibur
+   * @param delta
+   * @internal
+   */
+  updatePostProcessors(delta: number): void;
+
+  /**
    * Clears the screen with the current background color
    */
   clear(): void;

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContext2DCanvas.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContext2DCanvas.ts
@@ -317,6 +317,10 @@ export class ExcaliburGraphicsContext2DCanvas implements ExcaliburGraphicsContex
     // pass
   }
 
+  public updatePostProcessors(_delta: number) {
+    // pass
+  }
+
   public beginDrawLifecycle() {
     // pass
   }

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
@@ -441,7 +441,7 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
 
   private _totalPostProcessorTime = 0;
   public updatePostProcessors(delta: number) {
-    for (let postprocessor of this._postprocessors) {
+    for (const postprocessor of this._postprocessors) {
       const shader = postprocessor.getShader();
       shader.use();
       const uniforms = shader.getUniforms();

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
@@ -439,6 +439,30 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
     this._postprocessors.length = 0;
   }
 
+  private _totalPostProcessorTime = 0;
+  public updatePostProcessors(delta: number) {
+    for (let postprocessor of this._postprocessors) {
+      const shader = postprocessor.getShader();
+      shader.use();
+      const uniforms = shader.getUniforms();
+      this._totalPostProcessorTime += delta;
+
+      if (uniforms.find(u => u.name ==='u_time_ms')) {
+        shader.setUniformFloat('u_time_ms', this._totalPostProcessorTime);
+      }
+      if (uniforms.find(u => u.name ==='u_elapsed_ms')) {
+        shader.setUniformFloat('u_elapsed_ms', delta);
+      }
+      if (uniforms.find(u => u.name ==='u_resolution')) {
+        shader.setUniformFloatVector('u_resolution', vec(this.width, this.height));
+      }
+
+      if (postprocessor.onUpdate) {
+        postprocessor.onUpdate(delta);
+      }
+    }
+  }
+
   clear() {
     const gl = this.__gl;
     this._renderTarget.use();

--- a/src/engine/Graphics/PostProcessor/PostProcessor.ts
+++ b/src/engine/Graphics/PostProcessor/PostProcessor.ts
@@ -3,8 +3,31 @@ import { VertexLayout } from '..';
 import { Shader } from '../Context/shader';
 
 
+/**
+ * PostProcessors can be used to apply a shader to the entire screen. It is recommended
+ * you use the [[ScreenShader]] to build your post processor shader.
+ * 
+ * The screen texture comes through as this uniform
+ * 
+ * `uniform sampler2D u_image`
+ *
+ * Post processor shaders get some default uniforms passed to them
+ *
+ * `uniform float u_time_ms` - total playback time in milliseconds
+ * `uniform float u_elapsed_ms` - the elapsed time from the last frame in milliseconds
+ * `uniform vec2 u_resolution` - the resolution of the canvas (in pixels)
+ *
+ * Custom uniforms can be updated in the [[PostProcessor.onUpdate]]
+ */
 export interface PostProcessor {
-  initialize(gl: WebGLRenderingContext): void;
+  initialize(gl: WebGL2RenderingContext): void;
   getShader(): Shader;
   getLayout(): VertexLayout;
+  /**
+   * Use the onUpdate hook to update any uniforms in the postprocessors shader
+   *
+   * The shader has already been bound so there is no need to call shader.use();
+   * @param delta
+   */
+  onUpdate?(delta: number): void;
 }

--- a/src/engine/Graphics/PostProcessor/PostProcessor.ts
+++ b/src/engine/Graphics/PostProcessor/PostProcessor.ts
@@ -6,9 +6,9 @@ import { Shader } from '../Context/shader';
 /**
  * PostProcessors can be used to apply a shader to the entire screen. It is recommended
  * you use the [[ScreenShader]] to build your post processor shader.
- * 
+ *
  * The screen texture comes through as this uniform
- * 
+ *
  * `uniform sampler2D u_image`
  *
  * Post processor shaders get some default uniforms passed to them

--- a/src/spec/PostProcessorSpec.ts
+++ b/src/spec/PostProcessorSpec.ts
@@ -1,0 +1,79 @@
+import * as ex from '@excalibur';
+
+const source = `#version 300 es
+precision mediump float;
+uniform vec2 u_resolution;
+
+uniform float u_time_ms;
+
+uniform float u_elapsed_ms;
+
+out vec4 fragColor;
+void main() {
+  // this is nonsense, but uniforms need to be used to show up in js
+  fragColor = vec4(u_time_ms, u_elapsed_ms, u_resolution.x, u_resolution.y);
+}
+`;
+
+class MockPostProcessor implements ex.PostProcessor {
+  private _shader: ex.ScreenShader;
+  initialize(gl: WebGL2RenderingContext): void {
+    this._shader = new ex.ScreenShader(gl, source);
+  }
+  getShader(): ex.Shader {
+    return this._shader.getShader();
+  }
+  getLayout(): ex.VertexLayout {
+    return this._shader.getLayout();
+  }
+  onUpdate = jasmine.createSpy('update');
+}
+
+describe('A PostProcessor', () => {
+  it('will call onUpdate if present', () => {
+    const mock = new MockPostProcessor();
+    const canvas = document.createElement('canvas');
+    canvas.width = 100;
+    canvas.height = 100;
+    const context = new ex.ExcaliburGraphicsContextWebGL({
+      canvasElement: canvas,
+      backgroundColor: ex.Color.Black
+    });
+
+    context.addPostProcessor(mock);
+
+    context.updatePostProcessors(10);
+    context.updatePostProcessors(10);
+    context.updatePostProcessors(10);
+
+    expect(mock.onUpdate).toHaveBeenCalledTimes(3);
+  });
+
+  it('set the default uniforms if present in the source', () => {
+    const mock = new MockPostProcessor();
+    const canvas = document.createElement('canvas');
+    canvas.width = 100;
+    canvas.height = 100;
+    const context = new ex.ExcaliburGraphicsContextWebGL({
+      canvasElement: canvas,
+      backgroundColor: ex.Color.Black
+    });
+    context.addPostProcessor(mock);
+
+    const shader = mock.getShader();
+
+    const setUniformFloatCalls = spyOn(shader, 'setUniformFloat');
+    const setUniformFloatVectorCalls = spyOn(shader, 'setUniformFloatVector');
+
+    context.updatePostProcessors(10);
+
+    expect(shader.setUniformFloat).toHaveBeenCalledTimes(2);
+    expect(shader.setUniformFloatVector).toHaveBeenCalledTimes(1);
+
+    expect(setUniformFloatCalls.calls.argsFor(0)).toEqual(['u_time_ms', 10]);
+    expect(setUniformFloatCalls.calls.argsFor(1)).toEqual(['u_elapsed_ms', 10]);
+    expect(setUniformFloatVectorCalls.calls.argsFor(0)).toEqual(['u_resolution', ex.vec(100, 100)]);
+
+  });
+
+});


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2416 

This PR adds some new default uniforms supplied to postprocessors automatically if they are present in the source
* `uniform float u_time_ms` - total playback time in milliseconds
* `uniform float u_elapsed_ms` - the elapsed time from the last frame in milliseconds
* `uniform vec2 u_resolution` - the resolution of the canvas (in pixels)

Custom uniforms can now be set in an optional `onUpdate()` function on postprocessors, the internal `shader.use()` is called for users.


Example using the CRT post processor, see gist https://gist.github.com/eonarheim/5ebb7f9161c10894935479e0caa0f6c7

<img width="677" alt="image" src="https://github.com/excaliburjs/Excalibur/assets/612071/07521591-934b-4aec-b77b-a01c8488025b">
