### PR TITLE
fix: [#2668] ScreenElement pointer capture configured properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ are returned
 
 ### Fixed
 
+- Fixed issue where `ex.ScreenElement` pointer events were not working by default.
 - Fixed issue where setting lineWidth on `ex.Circle` was not accounted for in the bitmap
 - Fixed issue in macos where the meta key would prevent keyup's from firing correctly
 - Fixed issue when excalibur was hosted in a x-origin iframe, the engine will grab window focus by default if in an iframe. This can be suppressed with `new ex.Engine({grabWindowFocus: false})`

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -11,6 +11,7 @@
       <li><a href="html/index.html">Sandbox Platformer</a></li>
       <li><a href="tests/multi-engine/">Multi-engine</a></li>
       <li><a href="tests/sprite-tint/">Sprite Tint</a></li>
+      <li><a href="tests/screenelementpointer/">ScreenElement Pointer by default</a></li>
       <li><a href="tests/clonebehavior/">Clone Behavior</a></li>
       <li><a href="tests/parallel/">Parallel Actions</a></li>
       <li><a href="tests/isometric/">Isometric Map</a></li>

--- a/sandbox/tests/screenelementpointer/index.html
+++ b/sandbox/tests/screenelementpointer/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pointer on Screen Element</title>
+</head>
+<body>
+  <p>Click the ScreenElement an alert should fire</p>
+  <script src="../../lib/excalibur.js"></script>
+  <script src="./index.js"></script>
+</body>
+</html>

--- a/sandbox/tests/screenelementpointer/index.ts
+++ b/sandbox/tests/screenelementpointer/index.ts
@@ -1,0 +1,29 @@
+
+class StartButton extends ex.ScreenElement {
+ constructor(x: number, y: number) {
+  super({
+    x, y
+  })
+ }
+ onInitialize() {
+   this.graphics.use(new ex.Rectangle({
+    color: ex.Color.Green,
+    width: 300,
+    height: 50
+   }));
+   // ...
+   this.on('pointerup', () => {
+     alert("I've been clicked");
+   })
+   // ...
+ }
+}
+
+var engine = new ex.Engine({
+  width: 800,
+  height: 400
+});
+
+engine.add(new StartButton(400, 200));
+
+engine.start();

--- a/src/engine/ScreenElement.ts
+++ b/src/engine/ScreenElement.ts
@@ -27,6 +27,8 @@ export class ScreenElement extends Actor {
     this.get(TransformComponent).coordPlane = CoordPlane.Screen;
     this.anchor = config?.anchor ?? vec(0, 0);
     this.body.collisionType = config?.collisionType ?? CollisionType.PreventCollision;
+    this.pointer.useGraphicsBounds = true;
+    this.pointer.useColliderShape = false;
     if (!config?.collider &&
         config?.width > 0 &&
         config?.height > 0) {


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2668

Update `ex.ScreenElement` to set a sensible default in it's constructor so it uses graphics bounds to capture pointers
