### PR TITLE
feat: QOL Update import site for ex.Input 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
+- The `ex.Input.*` import site is deprecated, will be removed in v0.29.0. All the imports are still available on `ex.` now
 - [[ex.Input.Gamepad]] `isButtonPressed` has been renamed to `isButtonHeld`
 - `ex.EventDispatcher` is marked deprecated, will eventually be removed in v0.29.0
 

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -47,7 +47,7 @@ var game = new ex.Engine({
   canvasElementId: 'game',
   pixelRatio: 1,
   suppressPlayButton: true,
-  pointerScope: ex.Input.PointerScope.Canvas,
+  pointerScope: ex.PointerScope.Canvas,
   displayMode: ex.DisplayMode.FitScreenAndFill,
   antialiasing: false,
   snapToPixel: false,
@@ -623,7 +623,7 @@ var airSpeed = 130;
 var jumpSpeed = 500;
 var direction = 1;
 player.on('postupdate', () => {
-  if (game.input.keyboard.isHeld(ex.Input.Keys.Left)) {
+  if (game.input.keyboard.isHeld(ex.Keys.Left)) {
     direction = -1;
     if (!inAir) {
       player.graphics.use(Animations.Left);
@@ -633,7 +633,7 @@ player.on('postupdate', () => {
       return;
     }
     player.vel.x = -groundSpeed;
-  } else if (game.input.keyboard.isHeld(ex.Input.Keys.Right)) {
+  } else if (game.input.keyboard.isHeld(ex.Keys.Right)) {
     direction = 1;
     if (!inAir) {
       player.graphics.use(Animations.Right);
@@ -645,7 +645,7 @@ player.on('postupdate', () => {
     player.vel.x = groundSpeed;
   }
 
-  if (game.input.keyboard.isHeld(ex.Input.Keys.Up)) {
+  if (game.input.keyboard.isHeld(ex.Keys.Up)) {
     if (!inAir) {
       player.vel.y = -jumpSpeed;
       inAir = true;
@@ -659,15 +659,15 @@ player.on('postupdate', () => {
   }
 });
 
-game.input.keyboard.on('up', (e?: ex.Input.KeyEvent) => {
+game.input.keyboard.on('up', (e?: ex.KeyEvent) => {
   if (inAir) return;
 
-  if (e.key === ex.Input.Keys.Left || e.key === ex.Input.Keys.Right) {
+  if (e.key === ex.Keys.Left || e.key === ex.Keys.Right) {
     player.graphics.use(Animations.Idle);
   }
 });
 
-player.on('pointerdown', (e?: ex.Input.PointerEvent) => {
+player.on('pointerdown', (e?: ex.PointerEvent) => {
   // alert('Player clicked!');
 });
 player.on('pointerdown', () => {
@@ -702,8 +702,8 @@ newScene.on('foo', (ev: ex.GameEvent<any>) => {});
 
 game.addScene('label', newScene);
 
-game.input.keyboard.on('down', (keyDown?: ex.Input.KeyEvent) => {
-  if (keyDown.key === ex.Input.Keys.F) {
+game.input.keyboard.on('down', (keyDown?: ex.KeyEvent) => {
+  if (keyDown.key === ex.Keys.F) {
     var a = new ex.Actor({x: player.pos.x + 10, y: player.pos.y - 50, width: 10, height: 10, color: new ex.Color(222, 222, 222)});
     a.vel.x = 200 * direction;
     a.vel.y = 0;
@@ -724,9 +724,9 @@ game.input.keyboard.on('down', (keyDown?: ex.Input.KeyEvent) => {
       inAir = true;
     });
     game.add(a);
-  } else if (keyDown.key === ex.Input.Keys.U) {
+  } else if (keyDown.key === ex.Keys.U) {
     game.goToScene('label');
-  } else if (keyDown.key === ex.Input.Keys.I) {
+  } else if (keyDown.key === ex.Keys.I) {
     game.goToScene('root');
   }
 });
@@ -743,10 +743,10 @@ player.on('postcollision', (data: ex.PostCollisionEvent) => {
     if (
       data.other &&
       !(
-        game.input.keyboard.isHeld(ex.Input.Keys.Left) ||
-        game.input.keyboard.isHeld(ex.Input.Keys.Right) ||
-        game.input.keyboard.isHeld(ex.Input.Keys.Up) ||
-        game.input.keyboard.isHeld(ex.Input.Keys.Down)
+        game.input.keyboard.isHeld(ex.Keys.Left) ||
+        game.input.keyboard.isHeld(ex.Keys.Right) ||
+        game.input.keyboard.isHeld(ex.Keys.Up) ||
+        game.input.keyboard.isHeld(ex.Keys.Down)
       )
     ) {
       player.vel.x = data.other.vel.x;
@@ -785,14 +785,14 @@ player.on('initialize', (evt?: ex.InitializeEvent) => {
   console.log('Player initialized', evt.engine);
 });
 
-game.input.keyboard.on('down', (keyDown?: ex.Input.KeyEvent) => {
-  if (keyDown.key === ex.Input.Keys.B) {
+game.input.keyboard.on('down', (keyDown?: ex.KeyEvent) => {
+  if (keyDown.key === ex.Keys.B) {
     var block = new ex.Actor({x: currentX, y: 350, width: 44, height: 50, color: color});
     currentX += 46;
     block.graphics.add(blockAnimation);
     game.add(block);
   }
-  if (keyDown.key === ex.Input.Keys.D) {
+  if (keyDown.key === ex.Keys.D) {
     game.toggleDebug();
   }
 });
@@ -866,7 +866,7 @@ var trigger = new ex.Trigger({
 
 game.add(trigger);
 
-game.input.pointers.primary.on('down', (evt: ex.Input.PointerEvent) => {
+game.input.pointers.primary.on('down', (evt: ex.PointerEvent) => {
   var c = tileMap.getTileByPoint(evt.worldPos);
   if (c) {
     if (c.solid) {
@@ -879,11 +879,11 @@ game.input.pointers.primary.on('down', (evt: ex.Input.PointerEvent) => {
   }
 });
 
-game.input.keyboard.on('up', (evt?: ex.Input.KeyEvent) => {
-  if (evt.key == ex.Input.Keys.F) {
+game.input.keyboard.on('up', (evt?: ex.KeyEvent) => {
+  if (evt.key == ex.Keys.F) {
     jump.play();
   }
-  if (evt.key == ex.Input.Keys.S) {
+  if (evt.key == ex.Keys.S) {
     jump.stop();
   }
 });

--- a/sandbox/tests/arcadecollider/index.ts
+++ b/sandbox/tests/arcadecollider/index.ts
@@ -18,16 +18,16 @@ var player = new ex.Actor({
 player.onPostUpdate = () => {
   player.vel.setTo(0, 0);
   const speed = 64;
-  if (game.input.keyboard.isHeld(ex.Input.Keys.Right)) {
+  if (game.input.keyboard.isHeld(ex.Keys.Right)) {
      player.vel.x = speed;
   }
-  if (game.input.keyboard.isHeld(ex.Input.Keys.Left)) {
+  if (game.input.keyboard.isHeld(ex.Keys.Left)) {
      player.vel.x = -speed;
   }
-  if (game.input.keyboard.isHeld(ex.Input.Keys.Up)) {
+  if (game.input.keyboard.isHeld(ex.Keys.Up)) {
      player.vel.y = -speed;
   }
-  if (game.input.keyboard.isHeld(ex.Input.Keys.Down)) {
+  if (game.input.keyboard.isHeld(ex.Keys.Down)) {
      player.vel.y = speed;
   }
 }

--- a/sandbox/tests/boundingbox/bbtester.ts
+++ b/sandbox/tests/boundingbox/bbtester.ts
@@ -26,24 +26,24 @@ var block2 = new ex.Actor({
 
 // Set drag flag
 var boxPointerDragging = false;
-block2.on('pointerdragstart', (pe: ex.Input.PointerEvent) => {
+block2.on('pointerdragstart', (pe: ex.PointerEvent) => {
   boxPointerDragging = true;
 });
 
 // Set drag flag
-block2.on('pointerdragend', (pe: ex.Input.PointerEvent) => {
+block2.on('pointerdragend', (pe: ex.PointerEvent) => {
   boxPointerDragging = false;
 });
 
 // Drag box around
-block2.on('pointerdragmove', (pe: ex.Input.PointerEvent) => {
+block2.on('pointerdragmove', (pe: ex.PointerEvent) => {
   if (boxPointerDragging) {
     block2.pos = pe.worldPos;
   }
 });
 
 // Drag box around
-block2.on('pointerdragleave', (pe: ex.Input.PointerEvent) => {
+block2.on('pointerdragleave', (pe: ex.PointerEvent) => {
   if (boxPointerDragging) {
     block2.pos = pe.worldPos;
   }

--- a/sandbox/tests/camera/lerp.ts
+++ b/sandbox/tests/camera/lerp.ts
@@ -3,7 +3,7 @@
 var game = new ex.Engine({
   width: 600,
   height: 400,
-  pointerScope: ex.Input.PointerScope.Canvas
+  pointerScope: ex.PointerScope.Canvas
 });
 var actor = new ex.Actor({x: 100, y: 100, width: 50, height: 50, color: ex.Color.Red});
 
@@ -13,7 +13,7 @@ game.start().then(() => {});
 
 var easingFn = ex.EasingFunctions.EaseInOutQuad;
 
-game.input.pointers.primary.on('down', (evt: ex.Input.PointerEvent) => {
+game.input.pointers.primary.on('down', (evt: ex.PointerEvent) => {
   game.currentScene.camera.move(new ex.Vector(evt.worldPos.x, evt.worldPos.y), 500, easingFn).then((v) => onLerpEnd(v));
   document.getElementById('lerp-false').style.display = 'none';
   document.getElementById('lerp-true').style.display = 'inline';

--- a/sandbox/tests/camera/strategy.ts
+++ b/sandbox/tests/camera/strategy.ts
@@ -3,7 +3,7 @@
 var game = new ex.Engine({
   width: 600,
   height: 400,
-  pointerScope: ex.Input.PointerScope.Canvas
+  pointerScope: ex.PointerScope.Canvas
 });
 var actor = new ex.Actor({x: 100, y: 100, width: 50, height: 50, color: ex.Color.Red});
 

--- a/sandbox/tests/camera/zoom.ts
+++ b/sandbox/tests/camera/zoom.ts
@@ -18,7 +18,7 @@ var actor = new ex.Actor({
 game.add(actor);
 
 var zoomedIn = false;
-game.input.pointers.primary.on('down', (evt: ex.Input.PointerEvent) => {
+game.input.pointers.primary.on('down', (evt: ex.PointerEvent) => {
   if (!zoomedIn) {
     zoomedIn = true;
     game.currentScene.camera.zoomOverTime(5, 1000);

--- a/sandbox/tests/collisionvelocity/vel.ts
+++ b/sandbox/tests/collisionvelocity/vel.ts
@@ -4,7 +4,7 @@ var engine = new ex.Engine({
   canvasElementId: 'game',
   width: 800,
   height: 300,
-  pointerScope: ex.Input.PointerScope.Canvas
+  pointerScope: ex.PointerScope.Canvas
 });
 engine.showDebug(true);
 engine.debug.body.showAll = true;
@@ -30,13 +30,13 @@ var player = new ex.Actor({
 });
 
 player.update = (e, ms) => {
-  if (engine.input.keyboard.isHeld(ex.Input.Keys.Space)) {
+  if (engine.input.keyboard.isHeld(ex.Keys.Space)) {
     player.vel.x = 0;
   }
-  if (engine.input.keyboard.isHeld(ex.Input.Keys.Left)) {
+  if (engine.input.keyboard.isHeld(ex.Keys.Left)) {
     player.vel.x -= 10;
   }
-  if (engine.input.keyboard.isHeld(ex.Input.Keys.Right)) {
+  if (engine.input.keyboard.isHeld(ex.Keys.Right)) {
     player.vel.x += 10;
   }
   ex.Actor.prototype.update.call(player, e, ms);

--- a/sandbox/tests/culling/culling.ts
+++ b/sandbox/tests/culling/culling.ts
@@ -15,28 +15,28 @@ player.graphics.add('default', playerSprite);
 //player.currentDrawing.scale = new ex.Point(0.5, 0.5);
 engine.currentScene.add(player);
 
-engine.input.keyboard.on('down', (keyDown?: ex.Input.KeyEvent) => {
-  if (keyDown.key === ex.Input.Keys.D) {
+engine.input.keyboard.on('down', (keyDown?: ex.KeyEvent) => {
+  if (keyDown.key === ex.Keys.D) {
     engine.toggleDebug();
-  } else if (keyDown.key === ex.Input.Keys.Up) {
+  } else if (keyDown.key === ex.Keys.Up) {
     player.vel.y = -speed;
-  } else if (keyDown.key === ex.Input.Keys.Down) {
+  } else if (keyDown.key === ex.Keys.Down) {
     player.vel.y = speed;
-  } else if (keyDown.key === ex.Input.Keys.Left) {
+  } else if (keyDown.key === ex.Keys.Left) {
     player.vel.x = -speed;
-  } else if (keyDown.key === ex.Input.Keys.Right) {
+  } else if (keyDown.key === ex.Keys.Right) {
     player.vel.x = speed;
   }
 });
 
-engine.input.keyboard.on('up', (keyUp?: ex.Input.KeyEvent) => {
-  if (keyUp.key === ex.Input.Keys.Up) {
+engine.input.keyboard.on('up', (keyUp?: ex.KeyEvent) => {
+  if (keyUp.key === ex.Keys.Up) {
     player.vel.y = 0;
-  } else if (keyUp.key === ex.Input.Keys.Down) {
+  } else if (keyUp.key === ex.Keys.Down) {
     player.vel.y = 0;
-  } else if (keyUp.key === ex.Input.Keys.Left) {
+  } else if (keyUp.key === ex.Keys.Left) {
     player.vel.x = 0;
-  } else if (keyUp.key === ex.Input.Keys.Right) {
+  } else if (keyUp.key === ex.Keys.Right) {
     player.vel.x = 0;
   }
 });

--- a/sandbox/tests/debug/stats.ts
+++ b/sandbox/tests/debug/stats.ts
@@ -79,7 +79,7 @@ floor.collider.useBoxCollider(50, 50);
 game.add(floor);
 
 game.input.keyboard.on('press', (evt) => {
-  if (evt.key === ex.Input.Keys.B) {
+  if (evt.key === ex.Keys.B) {
     spawnBox();
   }
 });

--- a/sandbox/tests/engine/timescale.ts
+++ b/sandbox/tests/engine/timescale.ts
@@ -5,10 +5,10 @@ var game = new ex.Engine({
   height: 400
 });
 
-game.input.keyboard.on('up', (ev: ex.Input.KeyEvent) => {
-  if (ev.key === ex.Input.Keys.W) {
+game.input.keyboard.on('up', (ev: ex.KeyEvent) => {
+  if (ev.key === ex.Keys.W) {
     increaseTimescale();
-  } else if (ev.key === ex.Input.Keys.S) {
+  } else if (ev.key === ex.Keys.S) {
     decreaseTimescale();
   }
 });

--- a/sandbox/tests/gotoscene/index.ts
+++ b/sandbox/tests/gotoscene/index.ts
@@ -11,7 +11,7 @@ class Scene1 extends ex.Scene {
 
     _engine.input.pointers.primary.on(
       "down",
-      (event: ex.Input.PointerEvent): void => {
+      (event: ex.PointerEvent): void => {
         _engine.goToScene("scene2");
       }
     );

--- a/sandbox/tests/incorrectside/index.ts
+++ b/sandbox/tests/incorrectside/index.ts
@@ -30,13 +30,13 @@ class Player4 extends ex.Actor {
     console.log(this.collisions);
     this.collisions = [];
 
-    if (engine.input.keyboard.wasPressed(ex.Input.Keys.ArrowUp)) {
+    if (engine.input.keyboard.wasPressed(ex.Keys.ArrowUp)) {
       this.vel.y = -400;
     }
 
-    if (engine.input.keyboard.isHeld(ex.Input.Keys.ArrowLeft)) {
+    if (engine.input.keyboard.isHeld(ex.Keys.ArrowLeft)) {
       this.vel.x = -100;
-    } else if (engine.input.keyboard.isHeld(ex.Input.Keys.ArrowRight)) {
+    } else if (engine.input.keyboard.isHeld(ex.Keys.ArrowRight)) {
       this.vel.x = 100;
     } else {
       this.vel.x = 0;

--- a/sandbox/tests/input/gamepad.ts
+++ b/sandbox/tests/input/gamepad.ts
@@ -34,22 +34,22 @@ function start() {
 
   // Buttons
   var buttonDefs = [
-    [ex.Input.Buttons.Face1, 544, 221],
-    [ex.Input.Buttons.Face2, 573, 193],
-    [ex.Input.Buttons.Face3, 516, 193],
-    [ex.Input.Buttons.Face4, 544, 166],
-    [ex.Input.Buttons.LeftBumper, 250, 100],
-    [ex.Input.Buttons.RightBumper, 547, 100],
-    [ex.Input.Buttons.LeftTrigger, 270, 88],
-    [ex.Input.Buttons.RightTrigger, 524, 88],
-    [ex.Input.Buttons.Select, 365, 193],
-    [ex.Input.Buttons.Start, 436, 193],
-    [ex.Input.Buttons.LeftStick, 330, 272],
-    [ex.Input.Buttons.RightStick, 470, 272],
-    [ex.Input.Buttons.DpadUp, 255, 166],
-    [ex.Input.Buttons.DpadDown, 255, 222],
-    [ex.Input.Buttons.DpadLeft, 227, 193],
-    [ex.Input.Buttons.DpadRight, 284, 193]
+    [ex.Buttons.Face1, 544, 221],
+    [ex.Buttons.Face2, 573, 193],
+    [ex.Buttons.Face3, 516, 193],
+    [ex.Buttons.Face4, 544, 166],
+    [ex.Buttons.LeftBumper, 250, 100],
+    [ex.Buttons.RightBumper, 547, 100],
+    [ex.Buttons.LeftTrigger, 270, 88],
+    [ex.Buttons.RightTrigger, 524, 88],
+    [ex.Buttons.Select, 365, 193],
+    [ex.Buttons.Start, 436, 193],
+    [ex.Buttons.LeftStick, 330, 272],
+    [ex.Buttons.RightStick, 470, 272],
+    [ex.Buttons.DpadUp, 255, 166],
+    [ex.Buttons.DpadDown, 255, 222],
+    [ex.Buttons.DpadLeft, 227, 193],
+    [ex.Buttons.DpadRight, 284, 193]
   ];
   var buttons: { [key: number]: CircleActor } = {};
 
@@ -75,10 +75,10 @@ function start() {
 
     if (pad1) {
       // sticks
-      var leftAxisX = pad1.getAxes(ex.Input.Axes.LeftStickX);
-      var leftAxisY = pad1.getAxes(ex.Input.Axes.LeftStickY);
-      var rightAxisX = pad1.getAxes(ex.Input.Axes.RightStickX);
-      var rightAxisY = pad1.getAxes(ex.Input.Axes.RightStickY);
+      var leftAxisX = pad1.getAxes(ex.Axes.LeftStickX);
+      var leftAxisY = pad1.getAxes(ex.Axes.LeftStickY);
+      var rightAxisX = pad1.getAxes(ex.Axes.RightStickX);
+      var rightAxisY = pad1.getAxes(ex.Axes.RightStickY);
 
       leftStick.pos = ex.vec(330 + leftAxisX * 20, 272 + leftAxisY * 20);
       rightStick.pos = ex.vec(470 + rightAxisX * 20, 272 + rightAxisY * 20);

--- a/sandbox/tests/input/iframe.ts
+++ b/sandbox/tests/input/iframe.ts
@@ -11,7 +11,7 @@ game.on('postupdate', (ue: ex.PostUpdateEvent) => {
   var keys = game.input.keyboard
     .getKeys()
     .map((k) => {
-      return (ex.Input.Keys[k] || 'Unknown') + '(' + k.toString() + ')';
+      return (ex.Keys[k] || 'Unknown') + '(' + k.toString() + ')';
     })
     .join(', ');
 

--- a/sandbox/tests/input/index.ts
+++ b/sandbox/tests/input/index.ts
@@ -10,22 +10,22 @@ game.input.gamepads.enabled = true;
 // Move box with Gamepad axes and D-pad
 box.on('postupdate', (ue: ex.PostUpdateEvent) => {
   var pad1 = game.input.gamepads.at(0);
-  var axesLeftX = pad1.getAxes(ex.Input.Axes.LeftStickX);
-  var axesLeftY = pad1.getAxes(ex.Input.Axes.LeftStickY);
+  var axesLeftX = pad1.getAxes(ex.Axes.LeftStickX);
+  var axesLeftY = pad1.getAxes(ex.Axes.LeftStickY);
 
   // Right/Left
-  if (game.input.keyboard.isHeld(ex.Input.Keys.Right) || pad1.isButtonPressed(ex.Input.Buttons.DpadRight)) {
+  if (game.input.keyboard.isHeld(ex.Keys.Right) || pad1.isButtonPressed(ex.Buttons.DpadRight)) {
     box.vel.x = 20;
-  } else if (game.input.keyboard.isHeld(ex.Input.Keys.Left) || pad1.isButtonPressed(ex.Input.Buttons.DpadLeft)) {
+  } else if (game.input.keyboard.isHeld(ex.Keys.Left) || pad1.isButtonPressed(ex.Buttons.DpadLeft)) {
     box.vel.x = -20;
   } else if (!axesLeftX && !axesLeftY) {
     box.vel.x = 0;
   }
 
   // Up/Down
-  if (game.input.keyboard.isHeld(ex.Input.Keys.Up) || pad1.isButtonPressed(ex.Input.Buttons.DpadUp)) {
+  if (game.input.keyboard.isHeld(ex.Keys.Up) || pad1.isButtonPressed(ex.Buttons.DpadUp)) {
     box.vel.y = -20;
-  } else if (game.input.keyboard.isHeld(ex.Input.Keys.Down) || pad1.isButtonPressed(ex.Input.Buttons.DpadDown)) {
+  } else if (game.input.keyboard.isHeld(ex.Keys.Down) || pad1.isButtonPressed(ex.Buttons.DpadDown)) {
     box.vel.y = 20;
   } else if (!axesLeftY && !axesLeftX) {
     box.vel.y = 0;

--- a/sandbox/tests/input/keyboard.ts
+++ b/sandbox/tests/input/keyboard.ts
@@ -19,13 +19,13 @@ game.on('postupdate', (ue: ex.PostUpdateEvent) => {
   var keys = game.input.keyboard
     .getKeys()
     .map((k) => {
-      return (ex.Input.Keys[k] || 'Unknown') + '(' + k.toString() + ')';
+      return (ex.Keys[k] || 'Unknown') + '(' + k.toString() + ')';
     })
     .join(', ');
 
   label.text = keys;
 
-  if (game.input.keyboard.wasPressed(ex.Input.Keys.Enter)) {
+  if (game.input.keyboard.wasPressed(ex.Keys.Enter)) {
     console.log("Enter Pressed");
   }
 });

--- a/sandbox/tests/input/pointer.ts
+++ b/sandbox/tests/input/pointer.ts
@@ -4,7 +4,7 @@ var game = new ex.Engine({
   width: 800,
   height: 600,
   canvasElementId: 'game',
-  pointerScope: ex.Input.PointerScope.Document
+  pointerScope: ex.PointerScope.Document
 });
 var box = new ex.Actor({x: 200, y: 200, width: 100, height: 100, color:  ex.Color.Red});
 var box2 = new ex.Actor({x: 0, y: 0, width: 50, height: 50, color:  ex.Color.White});
@@ -13,14 +13,14 @@ var boxPointerDragging = false;
 
 var uiElement = new ex.ScreenElement({x: 200, y: 0, width: 200, height: 200});
 uiElement.color = ex.Color.Azure;
-uiElement.on('pointerdown', (p: ex.Input.PointerEvent) => {
+uiElement.on('pointerdown', (p: ex.PointerEvent) => {
   console.log(p);
   uiElement.color = ex.Color.Red;
 });
 
 box.addChild(box2);
 // Change color of box when clicked
-box.on('pointerdown', (pe: ex.Input.PointerEvent) => {
+box.on('pointerdown', (pe: ex.PointerEvent) => {
   console.log('box clicked');
   if (box.color.toString() === ex.Color.Red.toString()) {
     box.color = ex.Color.Blue;
@@ -29,7 +29,7 @@ box.on('pointerdown', (pe: ex.Input.PointerEvent) => {
   }
 });
 
-box2.on('pointerdown', (pe: ex.Input.PointerEvent) => {
+box2.on('pointerdown', (pe: ex.PointerEvent) => {
   console.log('box2 clicked');
   pe.cancel();
   if (box2.color.toString() === ex.Color.White.toString()) {
@@ -40,57 +40,57 @@ box2.on('pointerdown', (pe: ex.Input.PointerEvent) => {
 });
 
 // Set drag flag
-box.on('pointerdragstart', (pe: ex.Input.PointerEvent) => {
+box.on('pointerdragstart', (pe: ex.PointerEvent) => {
   boxPointerDragging = true;
 });
 
 // Set drag flag
-box.on('pointerdragend', (pe: ex.Input.PointerEvent) => {
+box.on('pointerdragend', (pe: ex.PointerEvent) => {
   boxPointerDragging = false;
 });
 
 // Drag box around
-box.on('pointerdragmove', (pe: ex.Input.PointerEvent) => {
+box.on('pointerdragmove', (pe: ex.PointerEvent) => {
   if (boxPointerDragging) {
     box.pos = pe.worldPos;
   }
 });
 
 // Drag box around
-box.on('pointerdragleave', (pe: ex.Input.PointerEvent) => {
+box.on('pointerdragleave', (pe: ex.PointerEvent) => {
   if (boxPointerDragging) {
     box.pos = pe.worldPos;
   }
 });
 
-box.on('pointerwheel', (pe: ex.Input.WheelEvent) => {
+box.on('pointerwheel', (pe: ex.WheelEvent) => {
   box.rotation = box.rotation + (pe.deltaY > 0 ? 0.1 : -0.1);
 });
 
 // Follow cursor
-game.input.pointers.primary.on('move', (pe: ex.Input.PointerEvent) => {
+game.input.pointers.primary.on('move', (pe: ex.PointerEvent) => {
   cursor.pos = pe.worldPos;
 });
 
 // Button type
-game.input.pointers.primary.on('down', (pe: ex.Input.PointerEvent) => {
-  document.getElementById('pointer-btn').innerHTML = ex.Input.PointerButton[pe.button];
+game.input.pointers.primary.on('down', (pe: ex.PointerEvent) => {
+  document.getElementById('pointer-btn').innerHTML = ex.PointerButton[pe.button];
 });
-game.input.pointers.primary.on('up', (pe: ex.Input.PointerEvent) => {
+game.input.pointers.primary.on('up', (pe: ex.PointerEvent) => {
   document.getElementById('pointer-btn').innerHTML = 'None';
 });
 
 // Wheel
-game.input.pointers.primary.on('wheel', (pe: ex.Input.WheelEvent) => {
+game.input.pointers.primary.on('wheel', (pe: ex.WheelEvent) => {
   var type: string;
   switch (pe.deltaMode) {
-    case ex.Input.WheelDeltaMode.Pixel:
+    case ex.WheelDeltaMode.Pixel:
       type = 'pixel';
       break;
-    case ex.Input.WheelDeltaMode.Line:
+    case ex.WheelDeltaMode.Line:
       type = 'line';
       break;
-    case ex.Input.WheelDeltaMode.Page:
+    case ex.WheelDeltaMode.Page:
       type = 'page';
       break;
   }
@@ -106,8 +106,8 @@ var paintBrush = {
 };
 
 function handleTouch(color: ex.Color) {
-  return (pe: ex.Input.PointerEvent) => {
-    if (pe.pointerType !== ex.Input.PointerType.Touch) return;
+  return (pe: ex.PointerEvent) => {
+    if (pe.pointerType !== ex.PointerType.Touch) return;
 
     paintBrush.paint(pe.worldPos.x, pe.worldPos.y, color);
   };

--- a/sandbox/tests/parallax/index.ts
+++ b/sandbox/tests/parallax/index.ts
@@ -22,10 +22,10 @@ tilemap.tiles.forEach(t => {
 tilemap.addComponent(new ex.ParallaxComponent(ex.vec(0.5, 0.5)));
 
 game.input.keyboard.on("press", event => {
-  if (event.key === ex.Input.Keys.ArrowUp) {
+  if (event.key === ex.Keys.ArrowUp) {
     game.currentScene.camera.pos.y -= 10;
   }
-  if (event.key === ex.Input.Keys.ArrowDown) {
+  if (event.key === ex.Keys.ArrowDown) {
     game.currentScene.camera.pos.y += 10;
   }
 });

--- a/sandbox/tests/physics/fastphysics.ts
+++ b/sandbox/tests/physics/fastphysics.ts
@@ -77,20 +77,20 @@ ceiling.body.collisionType = ex.CollisionType.Fixed;
 ceiling.collider.useBoxCollider(600, 10); // optional
 game.add(ceiling);
 
-game.input.keyboard.on('down', (evt: ex.Input.KeyEvent) => {
-  if (evt.key === ex.Input.Keys.Up) {
+game.input.keyboard.on('down', (evt: ex.KeyEvent) => {
+  if (evt.key === ex.Keys.Up) {
     spawnRocket('up');
   }
 
-  if (evt.key === ex.Input.Keys.Down) {
+  if (evt.key === ex.Keys.Down) {
     spawnRocket('down');
   }
 
-  if (evt.key === ex.Input.Keys.Left) {
+  if (evt.key === ex.Keys.Left) {
     spawnRocket('left');
   }
 
-  if (evt.key === ex.Input.Keys.Right) {
+  if (evt.key === ex.Keys.Right) {
     spawnRocket('right');
   }
 });

--- a/sandbox/tests/physics/physics.ts
+++ b/sandbox/tests/physics/physics.ts
@@ -113,21 +113,21 @@ rightWall.body.collisionType = ex.CollisionType.Fixed;
 rightWall.collider.useBoxCollider(10, 400);
 game.add(rightWall);
 
-game.input.keyboard.on('down', (evt: ex.Input.KeyEvent) => {
-  if (evt.key === ex.Input.Keys.B) {
+game.input.keyboard.on('down', (evt: ex.KeyEvent) => {
+  if (evt.key === ex.Keys.B) {
     spawnBlock(280, 0);
   }
 
-  if (evt.key === ex.Input.Keys.C) {
+  if (evt.key === ex.Keys.C) {
     spawnCircle(300, 0);
   }
 
-  if (evt.key === ex.Input.Keys.R) {
+  if (evt.key === ex.Keys.R) {
     globalRotation += Math.PI / 4;
   }
 });
 
-game.input.pointers.primary.on('down', (evt: ex.Input.PointerEvent) => {
+game.input.pointers.primary.on('down', (evt: ex.PointerEvent) => {
   // spawnBlock(evt.worldPos.x, evt.worldPos.y);
   spawnCircle(evt.worldPos.x, evt.worldPos.y);
 });

--- a/sandbox/tests/rotation/rotation.ts
+++ b/sandbox/tests/rotation/rotation.ts
@@ -11,7 +11,7 @@ var engine = new ex.Engine({
   width: width,
   height: height,
   canvasElementId: 'game',
-  pointerScope: ex.Input.PointerScope.Canvas
+  pointerScope: ex.PointerScope.Canvas
 });
 engine.backgroundColor = ex.Color.Black;
 
@@ -32,7 +32,7 @@ engine.currentScene.add(player);
 
 // rotation type buttons
 var shortestPath = new ex.Actor({x: 50, y: 50, width: 50, height: 50, color: ex.Color.White});
-shortestPath.on('pointerdown', (e?: ex.Input.PointerEvent) => {
+shortestPath.on('pointerdown', (e?: ex.PointerEvent) => {
   rotationType = ex.RotationType.ShortestPath;
 });
 engine.add(shortestPath);
@@ -43,7 +43,7 @@ labelShortestPath.font.textAlign = ex.TextAlign.Center;
 engine.add(labelShortestPath);
 
 var longestPath = new ex.Actor({x: 150, y: 50, width: 50, height: 50, color: ex.Color.White});
-longestPath.on('pointerdown', (e?: ex.Input.PointerEvent) => {
+longestPath.on('pointerdown', (e?: ex.PointerEvent) => {
   rotationType = ex.RotationType.LongestPath;
 });
 engine.add(longestPath);
@@ -54,7 +54,7 @@ labelLongestPath.font.textAlign = ex.TextAlign.Center;
 engine.add(labelLongestPath);
 
 var clockwise = new ex.Actor({x: 250, y: 50, width: 50, height: 50, color: ex.Color.White});
-clockwise.on('pointerdown', (e?: ex.Input.PointerEvent) => {
+clockwise.on('pointerdown', (e?: ex.PointerEvent) => {
   rotationType = ex.RotationType.Clockwise;
 });
 engine.add(clockwise);
@@ -65,7 +65,7 @@ labelClockwise.font.textAlign = ex.TextAlign.Center;
 engine.add(labelClockwise);
 
 var counterclockwise = new ex.Actor({x: 350, y: 50, width: 50, height: 50, color: ex.Color.White});
-counterclockwise.on('pointerdown', (e?: ex.Input.PointerEvent) => {
+counterclockwise.on('pointerdown', (e?: ex.PointerEvent) => {
   rotationType = ex.RotationType.CounterClockwise;
 });
 engine.add(counterclockwise);
@@ -75,7 +75,7 @@ labelCounterClockwise.color = ex.Color.White;
 labelCounterClockwise.font.textAlign = ex.TextAlign.Center;
 engine.add(labelCounterClockwise);
 
-engine.input.pointers.primary.on('down', (e: ex.Input.PointerEvent) => {
+engine.input.pointers.primary.on('down', (e: ex.PointerEvent) => {
   if (
     !shortestPath.contains(e.worldPos.x, e.worldPos.y) &&
     !longestPath.contains(e.worldPos.x, e.worldPos.y) &&
@@ -94,8 +94,8 @@ function distance(x1, y1, x2, y2) {
   return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
 }
 
-engine.input.keyboard.on('down', (keyDown?: ex.Input.KeyEvent) => {
-  if (keyDown.key === ex.Input.Keys.D) {
+engine.input.keyboard.on('down', (keyDown?: ex.KeyEvent) => {
+  if (keyDown.key === ex.Keys.D) {
     engine.toggleDebug();
   }
 });

--- a/sandbox/tests/scale/scale.ts
+++ b/sandbox/tests/scale/scale.ts
@@ -26,7 +26,7 @@ game.add(aim);
 
 // uncomment loader after adding resources
 game.start(loader).then(() => {
-  game.input.pointers.primary.on('move', (ev: ex.Input.PointerEvent) => {
+  game.input.pointers.primary.on('move', (ev: ex.PointerEvent) => {
     target.pos.setTo(ev.worldPos.x, ev.worldPos.y);
 
     var aimVec = target.pos.sub(aim.pos);

--- a/sandbox/tests/screen/screen.ts
+++ b/sandbox/tests/screen/screen.ts
@@ -17,7 +17,7 @@ var game = new ex.Engine({
   width: 800,
   height: 600,
   displayMode: ex.DisplayMode.FitContainer,
-  pointerScope: ex.Input.PointerScope.Canvas
+  pointerScope: ex.PointerScope.Canvas
 });
 
 game.start();

--- a/sandbox/tests/side-collision/index.ts
+++ b/sandbox/tests/side-collision/index.ts
@@ -44,15 +44,15 @@ class Player2 extends ex.Actor {
     this.vel.x = 0;
 
     // Player input
-    if (engine.input.keyboard.isHeld(ex.Input.Keys.Left)) {
+    if (engine.input.keyboard.isHeld(ex.Keys.Left)) {
       this.vel.x = -150;
     }
 
-    if (engine.input.keyboard.isHeld(ex.Input.Keys.Right)) {
+    if (engine.input.keyboard.isHeld(ex.Keys.Right)) {
       this.vel.x = 150;
     }
 
-    if (engine.input.keyboard.isHeld(ex.Input.Keys.Up) && this.onGround) {
+    if (engine.input.keyboard.isHeld(ex.Keys.Up) && this.onGround) {
       this.vel.y = -400;
       this.onGround = false;
     }

--- a/sandbox/tests/side-collision2/index.ts
+++ b/sandbox/tests/side-collision2/index.ts
@@ -38,15 +38,15 @@ class Player3 extends ex.Actor {
     this.vel.x = 0;
 
     // Player input
-    if (engine.input.keyboard.isHeld(ex.Input.Keys.Left)) {
+    if (engine.input.keyboard.isHeld(ex.Keys.Left)) {
       this.vel.x = -150;
     }
 
-    if (engine.input.keyboard.isHeld(ex.Input.Keys.Right)) {
+    if (engine.input.keyboard.isHeld(ex.Keys.Right)) {
       this.vel.x = 150;
     }
 
-    if (engine.input.keyboard.isHeld(ex.Input.Keys.Up) && this.onGround) {
+    if (engine.input.keyboard.isHeld(ex.Keys.Up) && this.onGround) {
       this.vel.y = -400;
       this.onGround = false;
     }

--- a/sandbox/tests/spritefont/spritefont.ts
+++ b/sandbox/tests/spritefont/spritefont.ts
@@ -4,7 +4,7 @@ var game = new ex.Engine({
   width: 600,
   height: 400,
   canvasElementId: 'game',
-  pointerScope: ex.Input.PointerScope.Canvas
+  pointerScope: ex.PointerScope.Canvas
 });
 
 var spriteFontTex = new ex.ImageSource('spritefont.png');

--- a/sandbox/tests/textcrash/index.ts
+++ b/sandbox/tests/textcrash/index.ts
@@ -19,7 +19,7 @@ class GameScene extends ex.Scene {
       tile.data.set("id", 0);
     });
 
-    engine.input.pointers.primary.on("down", (event: ex.Input.PointerEvent): void => {
+    engine.input.pointers.primary.on("down", (event: ex.PointerEvent): void => {
       this.tilemap.tiles.forEach((tile) => {
         const id = tile.data.get("id")!;
         tile.data.set("id", id + 1);

--- a/sandbox/tests/tilemap-custom-edge-collider/index.ts
+++ b/sandbox/tests/tilemap-custom-edge-collider/index.ts
@@ -50,16 +50,16 @@ var player = new ex.Actor({
 player.onPostUpdate = () => {
   player.vel.setTo(0, 0);
   const speed = 64;
-  if (game.input.keyboard.isHeld(ex.Input.Keys.Right)) {
+  if (game.input.keyboard.isHeld(ex.Keys.Right)) {
      player.vel.x = speed;
   }
-  if (game.input.keyboard.isHeld(ex.Input.Keys.Left)) {
+  if (game.input.keyboard.isHeld(ex.Keys.Left)) {
      player.vel.x = -speed;
   }
-  if (game.input.keyboard.isHeld(ex.Input.Keys.Up)) {
+  if (game.input.keyboard.isHeld(ex.Keys.Up)) {
      player.vel.y = -speed;
   }
-  if (game.input.keyboard.isHeld(ex.Input.Keys.Down)) {
+  if (game.input.keyboard.isHeld(ex.Keys.Down)) {
      player.vel.y = speed;
   }
 }

--- a/sandbox/tests/trigger/trigger.ts
+++ b/sandbox/tests/trigger/trigger.ts
@@ -37,19 +37,19 @@ game.add(actor);
 var speed = 100;
 
 game.input.keyboard.on('press', (evt) => {
-  if (evt.key === ex.Input.Keys.Up) {
+  if (evt.key === ex.Keys.Up) {
     actor.vel.y = -speed;
   }
 
-  if (evt.key === ex.Input.Keys.Down) {
+  if (evt.key === ex.Keys.Down) {
     actor.vel.y = +speed;
   }
 
-  if (evt.key === ex.Input.Keys.Left) {
+  if (evt.key === ex.Keys.Left) {
     actor.vel.x = -speed;
   }
 
-  if (evt.key === ex.Input.Keys.Right) {
+  if (evt.key === ex.Keys.Right) {
     actor.vel.x = +speed;
   }
 });

--- a/sandbox/tests/within/within.ts
+++ b/sandbox/tests/within/within.ts
@@ -142,27 +142,27 @@ if (block4.within(floor, 200)) {
 }
 
 game.input.keyboard.on('press', (evt) => {
-  if (evt.key === ex.Input.Keys.R) {
+  if (evt.key === ex.Keys.R) {
     block4.rotation += 0.2;
   }
-  if (evt.key === ex.Input.Keys.E) {
+  if (evt.key === ex.Keys.E) {
     block4.rotation -= 0.2;
   }
 
   var keyDist = 5;
-  if (evt.key === ex.Input.Keys.Up) {
+  if (evt.key === ex.Keys.Up) {
     block4.pos.addEqual(new ex.Vector(0, -keyDist));
   }
 
-  if (evt.key === ex.Input.Keys.Down) {
+  if (evt.key === ex.Keys.Down) {
     block4.pos.addEqual(new ex.Vector(0, keyDist));
   }
 
-  if (evt.key === ex.Input.Keys.Right) {
+  if (evt.key === ex.Keys.Right) {
     block4.pos.addEqual(new ex.Vector(keyDist, 0));
   }
 
-  if (evt.key === ex.Input.Keys.Left) {
+  if (evt.key === ex.Keys.Left) {
     block4.pos.addEqual(new ex.Vector(-keyDist, 0));
   }
 });

--- a/sandbox/tests/zoom/zoom.ts
+++ b/sandbox/tests/zoom/zoom.ts
@@ -36,35 +36,35 @@ document.addEventListener('mousedown', (ev: MouseEvent) => {
   console.log(game.screenToWorldCoordinates(new ex.Vector(ev.offsetX, ev.offsetY)));
 });
 
-target.on('pointerdown', (ev: ex.Input.PointerEvent) => {
+target.on('pointerdown', (ev: ex.PointerEvent) => {
   target.color = ex.Color.Green.clone();
 });
 
-target.on('pointerup', (ev: ex.Input.PointerEvent) => {
+target.on('pointerup', (ev: ex.PointerEvent) => {
   target.color = ex.Color.Red.clone();
 });
 
 game.add(target);
 
-game.input.keyboard.on('down', (ev: ex.Input.KeyEvent) => {
-  if (ev.key === ex.Input.Keys.NumAdd /* + */) {
+game.input.keyboard.on('down', (ev: ex.KeyEvent) => {
+  if (ev.key === ex.Keys.NumAdd /* + */) {
     game.currentScene.camera.zoomOverTime((currentZoom += 0.03));
   }
-  if (ev.key === ex.Input.Keys.NumSubtract /* - */) {
+  if (ev.key === ex.Keys.NumSubtract /* - */) {
     game.currentScene.camera.zoomOverTime((currentZoom -= 0.03));
   }
 
   var currentFocus = game.currentScene.camera.getFocus();
-  if (ev.key === ex.Input.Keys.Left) {
+  if (ev.key === ex.Keys.Left) {
     game.currentScene.camera.x = currentFocus.x - 10;
   }
-  if (ev.key === ex.Input.Keys.Right) {
+  if (ev.key === ex.Keys.Right) {
     game.currentScene.camera.x = currentFocus.x + 10;
   }
-  if (ev.key === ex.Input.Keys.Up) {
+  if (ev.key === ex.Keys.Up) {
     game.currentScene.camera.y = currentFocus.y - 10;
   }
-  if (ev.key === ex.Input.Keys.Down) {
+  if (ev.key === ex.Keys.Down) {
     game.currentScene.camera.y = currentFocus.y + 10;
   }
 });

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1,4 +1,8 @@
 import { EX_VERSION } from './';
+import { Gamepads } from './Input/Gamepad';
+import { Keyboard } from './Input/Keyboard';
+import { PointerScope } from './Input/PointerScope';
+import { EngineInput } from './Input/EngineInput';
 import { Flags } from './Flags';
 import { polyfill } from './Polyfill';
 polyfill();
@@ -34,7 +38,6 @@ import { Scene } from './Scene';
 import { Entity } from './EntityComponentSystem/Entity';
 import { Debug, DebugStats } from './Debug/Debug';
 import { Class } from './Class';
-import * as Input from './Input/Index';
 import * as Events from './Events';
 import { BrowserEvents } from './Util/Browser';
 import { ExcaliburGraphicsContext, ExcaliburGraphicsContext2DCanvas, ExcaliburGraphicsContextWebGL, TextureLoader } from './Graphics';
@@ -140,7 +143,7 @@ export interface EngineOptions {
    * Configures the pointer scope. Pointers scoped to the 'Canvas' can only fire events within the canvas viewport; whereas, 'Document'
    * (default) scoped will fire anywhere on the page.
    */
-  pointerScope?: Input.PointerScope;
+  pointerScope?: PointerScope;
 
   /**
    * Suppress boot up console message, which contains the "powered by Excalibur message"
@@ -366,7 +369,7 @@ export class Engine extends Class implements CanInitialize, CanUpdate, CanDraw {
   /**
    * Access engine input like pointer, keyboard, or gamepad
    */
-  public input: Input.EngineInput;
+  public input: EngineInput;
 
   /**
    * Access Excalibur debugging functionality.
@@ -551,7 +554,7 @@ export class Engine extends Class implements CanInitialize, CanUpdate, CanDraw {
     canvasElementId: '',
     canvasElement: undefined,
     snapToPixel: false,
-    pointerScope: Input.PointerScope.Canvas,
+    pointerScope: PointerScope.Canvas,
     suppressConsoleBootMessage: null,
     suppressMinimumBrowserFeatureDetection: null,
     suppressHiDPIScaling: null,
@@ -578,7 +581,7 @@ export class Engine extends Class implements CanInitialize, CanUpdate, CanDraw {
    *   enableCanvasTransparency: true, // the transparencySection of the canvas
    *   canvasElementId: '', // the DOM canvas element ID, if you are providing your own
    *   displayMode: ex.DisplayMode.FullScreen, // the display mode
-   *   pointerScope: ex.Input.PointerScope.Document, // the scope of capturing pointer (mouse/touch) events
+   *   pointerScope: ex.PointerScope.Document, // the scope of capturing pointer (mouse/touch) events
    *   backgroundColor: ex.Color.fromHex('#2185d0') // background color of the engine
    * });
    *
@@ -853,7 +856,7 @@ O|===|* >________________>\n\
 
     // Reset pointers
     this.input.pointers.detach();
-    const pointerTarget = options && options.pointerScope === Input.PointerScope.Document ? document : this.canvas;
+    const pointerTarget = options && options.pointerScope === PointerScope.Document ? document : this.canvas;
     this.input.pointers = this.input.pointers.recreate(pointerTarget, this);
     this.input.pointers.init();
   }
@@ -1106,11 +1109,11 @@ O|===|* >________________>\n\
     this.pageScrollPreventionMode = options.scrollPreventionMode;
 
     // initialize inputs
-    const pointerTarget = options && options.pointerScope === Input.PointerScope.Document ? document : this.canvas;
+    const pointerTarget = options && options.pointerScope === PointerScope.Document ? document : this.canvas;
     this.input = {
-      keyboard: new Input.Keyboard(),
+      keyboard: new Keyboard(),
       pointers: new PointerEventReceiver(pointerTarget, this),
-      gamepads: new Input.Gamepads()
+      gamepads: new Gamepads()
     };
     this.input.keyboard.init({
       grabWindowFocus: this._originalOptions?.grabWindowFocus ?? true

--- a/src/engine/Events.ts
+++ b/src/engine/Events.ts
@@ -6,13 +6,13 @@ import { FrameStats } from './Debug';
 import { Engine } from './Engine';
 import { TileMap } from './TileMap';
 import { Side } from './Collision/Side';
-import * as Input from './Input/Index';
 import { CollisionContact } from './Collision/Detection/CollisionContact';
 import { Collider } from './Collision/Colliders/Collider';
 import { Entity } from './EntityComponentSystem/Entity';
 import { OnInitialize, OnPreUpdate, OnPostUpdate, SceneActivationContext } from './Interfaces/LifecycleEvents';
 import { BodyComponent } from './Collision/BodyComponent';
 import { ExcaliburGraphicsContext } from './Graphics';
+import { Axes, Buttons, Gamepad } from './Input/Gamepad';
 
 export enum EventTypes {
   Kill = 'kill',
@@ -318,8 +318,8 @@ export class PostFrameEvent extends GameEvent<Engine> {
 /**
  * Event received when a gamepad is connected to Excalibur. [[Gamepads]] receives this event.
  */
-export class GamepadConnectEvent extends GameEvent<Input.Gamepad> {
-  constructor(public index: number, public gamepad: Input.Gamepad) {
+export class GamepadConnectEvent extends GameEvent<Gamepad> {
+  constructor(public index: number, public gamepad: Gamepad) {
     super();
     this.target = gamepad;
   }
@@ -328,8 +328,8 @@ export class GamepadConnectEvent extends GameEvent<Input.Gamepad> {
 /**
  * Event received when a gamepad is disconnected from Excalibur. [[Gamepads]] receives this event.
  */
-export class GamepadDisconnectEvent extends GameEvent<Input.Gamepad> {
-  constructor(public index: number, public gamepad: Input.Gamepad) {
+export class GamepadDisconnectEvent extends GameEvent<Gamepad> {
+  constructor(public index: number, public gamepad: Gamepad) {
     super();
     this.target = gamepad;
   }
@@ -338,12 +338,12 @@ export class GamepadDisconnectEvent extends GameEvent<Input.Gamepad> {
 /**
  * Gamepad button event. See [[Gamepads]] for information on responding to controller input. [[Gamepad]] instances receive this event;
  */
-export class GamepadButtonEvent extends GameEvent<Input.Gamepad> {
+export class GamepadButtonEvent extends GameEvent<Gamepad> {
   /**
    * @param button  The Gamepad button
    * @param value   A numeric value between 0 and 1
    */
-  constructor(public button: Input.Buttons, public value: number, public target: Input.Gamepad) {
+  constructor(public button: Buttons, public value: number, public target: Gamepad) {
     super();
   }
 }
@@ -351,12 +351,12 @@ export class GamepadButtonEvent extends GameEvent<Input.Gamepad> {
 /**
  * Gamepad axis event. See [[Gamepads]] for information on responding to controller input. [[Gamepad]] instances receive this event;
  */
-export class GamepadAxisEvent extends GameEvent<Input.Gamepad> {
+export class GamepadAxisEvent extends GameEvent<Gamepad> {
   /**
    * @param axis  The Gamepad axis
    * @param value A numeric value between -1 and 1
    */
-  constructor(public axis: Input.Axes, public value: number, public target: Input.Gamepad) {
+  constructor(public axis: Axes, public value: number, public target: Gamepad) {
     super();
   }
 }

--- a/src/engine/Input/Index.ts
+++ b/src/engine/Input/Index.ts
@@ -1,23 +1,170 @@
+// This import site is deprecated
+// TODO remove deprecated exports in v0.29.0
+
 /**
  * @module
  * Provides support for mice, keyboards, and controllers.
  */
 
-/**
- * @typedoc
- */
-export * from './Gamepad';
-export * from './PointerScope';
-export * from './PointerType';
-export * from './PointerSystem';
-export * from './PointerComponent';
-export * from './PointerEventReceiver';
-export * from './Keyboard';
-export * from './EngineInput';
-export * from './CapturePointerConfig';
+export {
+  /**
+   * @deprecated ex.Input.WheelEvent import site will be removed in v0.29.0, use ex.WheelEvent
+   */
+  WheelEvent
+} from './WheelEvent';
 
-export * from './NativePointerButton';
-export * from './PointerButton';
-export * from './WheelDeltaMode';
-export * from './PointerEvent';
-export * from './WheelEvent';
+export {
+  /**
+   * @deprecated ex.Input.PointerEvent import site will be removed in v0.29.0, use ex.PointerEvent
+   */
+  PointerEvent
+} from './PointerEvent';
+
+export {
+  /**
+   * @deprecated ex.Input.WheelDeltaMode import site will be removed in v0.29.0, use ex.WheelDeltaMode
+   */
+  WheelDeltaMode
+} from './WheelDeltaMode';
+
+export {
+  /**
+   * @deprecated ex.Input.PointerButton import site will be removed in v0.29.0, use ex.PointerButton
+   */
+  PointerButton
+} from './PointerButton';
+
+export {
+  /**
+   * @deprecated ex.Input.NativePointerButton import site will be removed in v0.29.0, use ex.NativePointerButton
+   */
+  NativePointerButton
+} from './NativePointerButton';
+
+export {
+  /**
+   * @deprecated ex.Input.CapturePointerConfig import site will be removed in v0.29.0, use ex.CapturePointerConfig
+   */
+  CapturePointerConfig
+} from './CapturePointerConfig';
+
+export {
+  /**
+   * @deprecated ex.Input.EngineInput import site will be removed in v0.29.0, use ex.EngineInput
+   */
+  EngineInput
+} from './EngineInput';
+
+export {
+  /**
+   * @deprecated ex.Input.NativePointerEvent import site will be removed in v0.29.0, use ex.NativePointerEvent
+   */
+  NativePointerEvent,
+  /**
+   * @deprecated ex.Input.NativeMouseEvent import site will be removed in v0.29.0, use ex.NativeMouseEvent
+   */
+  NativeMouseEvent,
+  /**
+   * @deprecated ex.Input.NativeTouchEvent import site will be removed in v0.29.0, use ex.NativeTouchEvent
+   */
+  NativeTouchEvent,
+  /**
+   * @deprecated ex.Input.NativeWheelEvent import site will be removed in v0.29.0, use ex.NativeWheelEvent
+   */
+  NativeWheelEvent,
+  /**
+   * @deprecated ex.Input.PointerInitOptions import site will be removed in v0.29.0, use ex.PointerInitOptions
+   */
+  PointerInitOptions,
+  /**
+   * @deprecated ex.Input.PointerEventReceiver import site will be removed in v0.29.0, use ex.PointerEventReceiver
+   */
+  PointerEventReceiver
+} from './PointerEventReceiver';
+
+export {
+  /**
+   * @deprecated ex.Input.PointerComponent import site will be removed in v0.29.0, use ex.PointerComponent
+   */
+  PointerComponent
+} from './PointerComponent';
+
+export {
+  /**
+   * @deprecated ex.Input.PointerSystem import site will be removed in v0.29.0, use ex.PointerSystem
+   */
+  PointerSystem
+} from './PointerSystem';
+
+export {
+  /**
+   * @deprecated ex.Input.PointerType import site will be removed in v0.29.0, use ex.PointerType
+   */
+  PointerType
+} from './PointerType';
+
+export {
+  /**
+   * @deprecated ex.Input.PointerScope import site will be removed in v0.29.0, use ex.PointerScope
+   */
+  PointerScope
+} from './PointerScope';
+
+export {
+  /**
+   * @deprecated ex.Input.Keys import site will be removed in v0.29.0, use ex.Keys
+   */
+  Keys,
+  /**
+   * @deprecated ex.Input.KeyEvent import site will be removed in v0.29.0, use ex.KeyEvent
+   */
+  KeyEvent,
+  /**
+   * @deprecated ex.Input.KeyboardInitOptions import site will be removed in v0.29.0, use ex.KeyboardInitOptions
+   */
+  KeyboardInitOptions,
+  /**
+   * @deprecated ex.Input.Keyboard import site will be removed in v0.29.0, use ex.Keyboard
+   */
+  Keyboard
+} from './Keyboard';
+
+// Re-export hack to deprecate import site gently
+export {
+  /**
+   * @deprecated ex.Input.Gamepads import site will be removed in v0.29.0, use ex.Gamepads
+   */
+  Gamepads,
+  /**
+   * @deprecated ex.Input.Gamepad import site will be removed in v0.29.0, use ex.Gamepad
+   */
+  Gamepad,
+  /**
+   * @deprecated ex.Input.Buttons import site will be removed in v0.29.0, use ex.Buttons
+   */
+  Buttons,
+  /**
+   * @deprecated ex.Input.Axes import site will be removed in v0.29.0, use ex.Axes
+   */
+  Axes,
+  /**
+   * @deprecated ex.Input.NavigatorGamepads import site will be removed in v0.29.0, use ex.NavigatorGamepads
+   */
+  NavigatorGamepads,
+  /**
+   * @deprecated ex.Input.NavigatorGamepad import site will be removed in v0.29.0, use ex.NavigatorGamepad
+   */
+  NavigatorGamepad,
+  /**
+   * @deprecated ex.Input.NavigatorGamepadButton import site will be removed in v0.29.0, use ex.NavigatorGamepadButton
+   */
+  NavigatorGamepadButton,
+  /**
+   * @deprecated ex.Input.NavigatorGamepadEvent import site will be removed in v0.29.0, use ex.NavigatorGamepadEvent
+   */
+  NavigatorGamepadEvent,
+  /**
+   * @deprecated ex.Input.GamepadConfiguration import site will be removed in v0.29.0, use ex.GamepadConfiguration
+   */
+  GamepadConfiguration
+} from './Gamepad';

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -52,10 +52,70 @@ import * as events from './Events';
 export { events as Events };
 
 // ex.Input namespace
+// TODO deprecated import site remove in v0.29.0
 import * as input from './Input/Index';
 export { input as Input };
-export { PointerComponent } from './Input/Index';
+
+export {
+  WheelEvent
+} from './Input/WheelEvent';
+
+export {
+  PointerEvent
+} from './Input/PointerEvent';
+
+export {
+  WheelDeltaMode
+} from './Input/WheelDeltaMode';
+
+export {
+  PointerButton
+} from './Input/PointerButton';
+
+export {
+  NativePointerButton
+} from './Input/NativePointerButton';
+
+export {
+  CapturePointerConfig
+} from './Input/CapturePointerConfig';
+
+export {
+  EngineInput
+} from './Input/EngineInput';
+
+export {
+  NativePointerEvent,
+  NativeMouseEvent,
+  NativeTouchEvent,
+  NativeWheelEvent,
+  PointerInitOptions,
+  PointerEventReceiver
+} from './Input/PointerEventReceiver';
+
+export { PointerComponent } from './Input/PointerComponent';
 export { PointerSystem } from './Input/PointerSystem';
+export { PointerType } from './Input/PointerType';
+export { PointerScope } from './Input/PointerScope';
+
+export {
+  Gamepads,
+  Gamepad,
+  Buttons,
+  Axes,
+  NavigatorGamepads,
+  NavigatorGamepad,
+  NavigatorGamepadButton,
+  NavigatorGamepadEvent,
+  GamepadConfiguration
+} from './Input/Gamepad';
+
+export {
+  Keys,
+  KeyEvent,
+  KeyboardInitOptions,
+  Keyboard
+} from './Input/Keyboard';
 
 // ex.Util namespaces
 import * as util from './Util/Index';

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -37,7 +37,7 @@ describe('A game actor', () => {
     const clock = engine.clock as ex.TestClock;
     clock.step(1);
     collisionSystem.initialize(scene);
-    scene.world.systemManager.get(ex.Input.PointerSystem).initialize(scene);
+    scene.world.systemManager.get(ex.PointerSystem).initialize(scene);
 
     ex.Physics.useArcadePhysics();
     ex.Physics.acc.setTo(0, 0);

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -334,9 +334,9 @@ describe('The engine', () => {
   });
 
   it('will fire wasPressed in onPostUpdate handler', (done) => {
-    engine.input.keyboard.triggerEvent('down', ex.Input.Keys.Enter);
+    engine.input.keyboard.triggerEvent('down', ex.Keys.Enter);
     engine.on('postupdate', () => {
-      if (engine.input.keyboard.wasPressed(ex.Input.Keys.Enter)) {
+      if (engine.input.keyboard.wasPressed(ex.Keys.Enter)) {
         done();
       }
     });
@@ -346,9 +346,9 @@ describe('The engine', () => {
   });
 
   it('will fire wasReleased in onPostUpdate handler', (done) => {
-    engine.input.keyboard.triggerEvent('up', ex.Input.Keys.Enter);
+    engine.input.keyboard.triggerEvent('up', ex.Keys.Enter);
     engine.on('postupdate', () => {
-      if (engine.input.keyboard.wasReleased(ex.Input.Keys.Enter)) {
+      if (engine.input.keyboard.wasReleased(ex.Keys.Enter)) {
         done();
       }
     });
@@ -358,10 +358,10 @@ describe('The engine', () => {
   });
 
   it('will fire isHeld in onPostUpdate handler', () => {
-    engine.input.keyboard.triggerEvent('down', ex.Input.Keys.Enter);
+    engine.input.keyboard.triggerEvent('down', ex.Keys.Enter);
     const held = jasmine.createSpy('held');
     engine.on('postupdate', () => {
-      if (engine.input.keyboard.isHeld(ex.Input.Keys.Enter)) {
+      if (engine.input.keyboard.isHeld(ex.Keys.Enter)) {
         held();
       }
     });

--- a/src/spec/GamepadSpec.ts
+++ b/src/spec/GamepadSpec.ts
@@ -120,7 +120,7 @@ describe('A gamepad', () => {
     expect(currentButton).toBeNull();
     expect(currentValue).toBeNull();
 
-    for (const button in ex.Input.Buttons) {
+    for (const button in ex.Buttons) {
       if (typeof button === 'number') {
         engine.input.gamepads.update();
         nav.setGamepadButton(0, button, 1.0);

--- a/src/spec/KeyInputSpec.ts
+++ b/src/spec/KeyInputSpec.ts
@@ -3,30 +3,30 @@ import { Mocks } from './util/Mocks';
 
 describe('A keyboard', () => {
   let mockWindow = null;
-  let keyboard: ex.Input.Keyboard = null;
+  let keyboard: ex.Keyboard = null;
   const mocker = new Mocks.Mocker();
 
   beforeEach(() => {
     mockWindow = <any>mocker.window();
-    keyboard = new ex.Input.Keyboard();
+    keyboard = new ex.Keyboard();
     keyboard.init({global: mockWindow});
   });
 
   it('should exist', () => {
-    expect(ex.Input.Keyboard).toBeDefined();
+    expect(ex.Keyboard).toBeDefined();
     expect(keyboard).toBeTruthy();
   });
 
   it('should fire keydown events', () => {
     let eventFired = false;
 
-    keyboard.on('down', function (ev: ex.Input.KeyEvent) {
-      if (ev.key === ex.Input.Keys.Up && ev.value === ex.Input.Keys.Up) {
+    keyboard.on('down', function (ev: ex.KeyEvent) {
+      if (ev.key === ex.Keys.Up && ev.value === ex.Keys.Up) {
         eventFired = true;
       }
     });
 
-    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keydown', { code: ex.Keys.Up, key: ex.Keys.Up });
 
     expect(eventFired).toBeTruthy();
   });
@@ -34,14 +34,14 @@ describe('A keyboard', () => {
   it('should fire keypress events', () => {
     let eventFired = false;
 
-    keyboard.on('press', function (ev: ex.Input.KeyEvent) {
-      if (ev.key === ex.Input.Keys.Up && ev.value === ex.Input.Keys.Up) {
+    keyboard.on('press', function (ev: ex.KeyEvent) {
+      if (ev.key === ex.Keys.Up && ev.value === ex.Keys.Up) {
         eventFired = true;
       }
     });
 
-    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
-    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keydown', { code: ex.Keys.Up, key: ex.Keys.Up });
+    (<any>mockWindow).emit('keyup', { code: ex.Keys.Up, key: ex.Keys.Up });
 
     expect(eventFired).toBeTruthy();
   });
@@ -49,13 +49,13 @@ describe('A keyboard', () => {
   it('should fire keyup events', () => {
     let eventFired = false;
 
-    keyboard.on('up', function (ev: ex.Input.KeyEvent) {
-      if (ev.key === ex.Input.Keys.Up && ev.value === ex.Input.Keys.Up) {
+    keyboard.on('up', function (ev: ex.KeyEvent) {
+      if (ev.key === ex.Keys.Up && ev.value === ex.Keys.Up) {
         eventFired = true;
       }
     });
 
-    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keyup', { code: ex.Keys.Up, key: ex.Keys.Up });
 
     expect(eventFired).toBeTruthy();
   });
@@ -63,51 +63,51 @@ describe('A keyboard', () => {
   it('should fire keyboard event with actual value and physical key', () => {
     let eventFired = false;
 
-    keyboard.on('up', function (ev: ex.Input.KeyEvent) {
-      if (ev.key === ex.Input.Keys.Digit9 && ev.value === '(') {
+    keyboard.on('up', function (ev: ex.KeyEvent) {
+      if (ev.key === ex.Keys.Digit9 && ev.value === '(') {
         eventFired = true;
       }
     });
 
-    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Digit9, key: '(' });
+    (<any>mockWindow).emit('keyup', { code: ex.Keys.Digit9, key: '(' });
 
     expect(eventFired).toBeTruthy();
   });
 
   it('should know if keys are pressed', () => {
     // push key down
-    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keydown', { code: ex.Keys.Up, key: ex.Keys.Up });
 
-    expect(keyboard.isHeld(ex.Input.Keys.Up)).toBeTruthy();
-    expect(keyboard.wasReleased(ex.Input.Keys.Up)).toBeFalsy();
-    expect(keyboard.wasPressed(ex.Input.Keys.Up)).toBeTruthy();
+    expect(keyboard.isHeld(ex.Keys.Up)).toBeTruthy();
+    expect(keyboard.wasReleased(ex.Keys.Up)).toBeFalsy();
+    expect(keyboard.wasPressed(ex.Keys.Up)).toBeTruthy();
 
     // release key
-    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keyup', { code: ex.Keys.Up, key: ex.Keys.Up });
 
     expect(keyboard.getKeys().length).toBe(0);
-    expect(keyboard.isHeld(ex.Input.Keys.Up)).toBeFalsy();
-    expect(keyboard.wasReleased(ex.Input.Keys.Up)).toBeTruthy();
+    expect(keyboard.isHeld(ex.Keys.Up)).toBeFalsy();
+    expect(keyboard.wasReleased(ex.Keys.Up)).toBeTruthy();
   });
 
   it('should have keys stay held until released', () => {
     // push key down
-    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
-    (<any>mockWindow).emit('keydown', { code: ex.Input.Keys.Down, key: ex.Input.Keys.Down });
+    (<any>mockWindow).emit('keydown', { code: ex.Keys.Up, key: ex.Keys.Up });
+    (<any>mockWindow).emit('keydown', { code: ex.Keys.Down, key: ex.Keys.Down });
 
     keyboard.update();
 
     // release key
-    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Up, key: ex.Input.Keys.Up });
+    (<any>mockWindow).emit('keyup', { code: ex.Keys.Up, key: ex.Keys.Up });
 
-    expect(keyboard.wasReleased(ex.Input.Keys.Down)).toBeFalsy();
-    expect(keyboard.isHeld(ex.Input.Keys.Up)).toBeFalsy();
+    expect(keyboard.wasReleased(ex.Keys.Down)).toBeFalsy();
+    expect(keyboard.isHeld(ex.Keys.Up)).toBeFalsy();
 
     keyboard.update();
 
     // release key
-    (<any>mockWindow).emit('keyup', { code: ex.Input.Keys.Down, key: ex.Input.Keys.Down });
+    (<any>mockWindow).emit('keyup', { code: ex.Keys.Down, key: ex.Keys.Down });
 
-    expect(keyboard.wasReleased(ex.Input.Keys.Down)).toBeTruthy();
+    expect(keyboard.wasReleased(ex.Keys.Down)).toBeTruthy();
   });
 });

--- a/src/spec/LoaderSpec.ts
+++ b/src/spec/LoaderSpec.ts
@@ -205,7 +205,7 @@ describe('A loader', () => {
   /**
    *
    */
-  function executeMouseEvent(type: string, target: HTMLElement, button: ex.Input.NativePointerButton = null, x: number = 0, y: number = 0) {
+  function executeMouseEvent(type: string, target: HTMLElement, button: ex.NativePointerButton = null, x: number = 0, y: number = 0) {
     const evt = new PointerEvent(type, {
       clientX: x,
       clientY: y,
@@ -232,7 +232,7 @@ describe('A loader', () => {
     const btnClickHandler = jasmine.createSpy('btnClickHandler');
     btn.addEventListener('pointerup', btnClickHandler);
     const rect = btn.getBoundingClientRect();
-    executeMouseEvent('pointerup', btn as any, ex.Input.NativePointerButton.Left, rect.x + rect.width / 2, rect.y + rect.height / 2);
+    executeMouseEvent('pointerup', btn as any, ex.NativePointerButton.Left, rect.x + rect.width / 2, rect.y + rect.height / 2);
 
     expect(pointerHandler).not.toHaveBeenCalled();
     expect(btnClickHandler).toHaveBeenCalled();

--- a/src/spec/PointerInputSpec.ts
+++ b/src/spec/PointerInputSpec.ts
@@ -12,7 +12,7 @@ describe('A pointer', () => {
    * @param x
    * @param y
    */
-  function executeMouseEvent(type: string, target: HTMLElement, button: ex.Input.NativePointerButton = null, x: number = 0, y: number = 0) {
+  function executeMouseEvent(type: string, target: HTMLElement, button: ex.NativePointerButton = null, x: number = 0, y: number = 0) {
     const evt = new PointerEvent(type, {
       clientX: x,
       clientY: y,
@@ -24,7 +24,7 @@ describe('A pointer', () => {
 
   beforeEach(() => {
     engine = TestUtils.engine({
-      pointerScope: ex.Input.PointerScope.Document
+      pointerScope: ex.PointerScope.Document
     });
     engine.start();
 
@@ -44,21 +44,21 @@ describe('A pointer', () => {
     let eventLeftFired = false;
     let eventRightFired = false;
     let eventMiddleFired = false;
-    engine.input.pointers.primary.on('down', (ev: ex.Input.PointerEvent) => {
-      if (ev.button === ex.Input.PointerButton.Left) {
+    engine.input.pointers.primary.on('down', (ev: ex.PointerEvent) => {
+      if (ev.button === ex.PointerButton.Left) {
         eventLeftFired = true;
       }
-      if (ev.button === ex.Input.PointerButton.Right) {
+      if (ev.button === ex.PointerButton.Right) {
         eventRightFired = true;
       }
-      if (ev.button === ex.Input.PointerButton.Middle) {
+      if (ev.button === ex.PointerButton.Middle) {
         eventMiddleFired = true;
       }
     });
 
-    executeMouseEvent('pointerdown', <any>document, ex.Input.NativePointerButton.Left);
-    executeMouseEvent('pointerdown', <any>document, ex.Input.NativePointerButton.Right);
-    executeMouseEvent('pointerdown', <any>document, ex.Input.NativePointerButton.Middle);
+    executeMouseEvent('pointerdown', <any>document, ex.NativePointerButton.Left);
+    executeMouseEvent('pointerdown', <any>document, ex.NativePointerButton.Right);
+    executeMouseEvent('pointerdown', <any>document, ex.NativePointerButton.Middle);
     // process pointer events
     engine.currentScene.update(engine, 0);
 
@@ -72,21 +72,21 @@ describe('A pointer', () => {
     let eventRightFired = false;
     let eventMiddleFired = false;
 
-    engine.input.pointers.primary.on('up', function (ev: ex.Input.PointerEvent) {
-      if (ev.button === ex.Input.PointerButton.Left) {
+    engine.input.pointers.primary.on('up', function (ev: ex.PointerEvent) {
+      if (ev.button === ex.PointerButton.Left) {
         eventLeftFired = true;
       }
-      if (ev.button === ex.Input.PointerButton.Right) {
+      if (ev.button === ex.PointerButton.Right) {
         eventRightFired = true;
       }
-      if (ev.button === ex.Input.PointerButton.Middle) {
+      if (ev.button === ex.PointerButton.Middle) {
         eventMiddleFired = true;
       }
     });
 
-    executeMouseEvent('pointerup', <any>document, ex.Input.NativePointerButton.Left);
-    executeMouseEvent('pointerup', <any>document, ex.Input.NativePointerButton.Right);
-    executeMouseEvent('pointerup', <any>document, ex.Input.NativePointerButton.Middle);
+    executeMouseEvent('pointerup', <any>document, ex.NativePointerButton.Left);
+    executeMouseEvent('pointerup', <any>document, ex.NativePointerButton.Right);
+    executeMouseEvent('pointerup', <any>document, ex.NativePointerButton.Middle);
     // process pointer events
     engine.currentScene.update(engine, 0);
 
@@ -98,7 +98,7 @@ describe('A pointer', () => {
   it('should fire pointermove events', () => {
     let eventMoveFired = false;
 
-    engine.input.pointers.primary.on('move', function (ev: ex.Input.PointerEvent) {
+    engine.input.pointers.primary.on('move', function (ev: ex.PointerEvent) {
       eventMoveFired = true;
     });
 

--- a/src/spec/ScreenElementSpec.ts
+++ b/src/spec/ScreenElementSpec.ts
@@ -86,6 +86,15 @@ describe('A ScreenElement', () => {
     expect(sut.collider.get().bounds.bottom).toBe(50);
   });
 
+  it('captures pointer by default', () => {
+    const sut = new ScreenElement({
+      width: 100,
+      height: 100
+    });
+
+    expect(sut.pointer.useGraphicsBounds).toBe(true);
+  });
+
   it('is drawn when visible', () => {
     screenElement.graphics.visible = true;
     screenElement.graphics.onPostDraw = jasmine.createSpy('draw');

--- a/src/spec/util/Mocks.ts
+++ b/src/spec/util/Mocks.ts
@@ -142,7 +142,7 @@ export namespace Mocks {
             }
           },
           // eslint-disable-next-line
-          pointers: new ex.Input.PointerEventReceiver(window, null),
+          pointers: new ex.PointerEventReceiver(window, null),
           gamepads: {
             update: function () {
               /* do nothing */

--- a/src/stories/Engine.stories.ts
+++ b/src/stories/Engine.stories.ts
@@ -87,7 +87,7 @@ export const playButton: Story = withEngine(
       width: 50,
       height: 50
     });
-    heart.on('pointerdown', async (_evnt: ex.Input.PointerEvent) => {
+    heart.on('pointerdown', async (_evnt: ex.PointerEvent) => {
       if (game.isRunning()) {
         game.stop();
         await loader.showPlayButton();

--- a/src/stories/Keyboard.stories.ts
+++ b/src/stories/Keyboard.stories.ts
@@ -27,7 +27,7 @@ export const keyEvents = withEngine(async (game) => {
     if (keys.length === 0) {
       keyLabel.text = 'Press some keys';
     } else {
-      const lastKeysPressed = keys.map((k) => k as Input.Keys).join('');
+      const lastKeysPressed = keys.map((k) => k as Keys).join('');
       keyLabel.text = lastKeysPressed;
     }
   });

--- a/src/stories/Keyboard.stories.ts
+++ b/src/stories/Keyboard.stories.ts
@@ -1,4 +1,4 @@
-import { Label, Color, Input } from '../engine';
+import { Label, Color, Keys } from '../engine';
 import { withEngine } from './utils';
 
 export default {

--- a/src/stories/utils.ts
+++ b/src/stories/utils.ts
@@ -1,4 +1,4 @@
-import { DisplayMode, Engine, EngineOptions, Input, Logger } from '../engine';
+import { DisplayMode, Engine, EngineOptions, KeyEvent, Keys, Logger, PointerScope } from '../engine';
 
 interface HTMLCanvasElement {
   gameRef?: Engine;
@@ -48,14 +48,14 @@ export const withEngine = (storyFn: (game: Engine, args?: Record<string, any>) =
       canvasElement: canvas,
       displayMode: DisplayMode.FitScreen,
       suppressPlayButton: true,
-      pointerScope: Input.PointerScope.Canvas,
+      pointerScope: PointerScope.Canvas,
       ...options
     });
 
     Logger.getInstance().info('Press \'d\' for debug mode');
 
-    game.input.keyboard.on('down', (keyDown?: Input.KeyEvent) => {
-      if (keyDown.key === Input.Keys.D) {
+    game.input.keyboard.on('down', (keyDown?: KeyEvent) => {
+      if (keyDown.key === Keys.D) {
         game.toggleDebug();
       }
     });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

This PR deprecates the old `ex.Input.*` import site in favor of just importing off of `ex.*`. 

This is a quality of life improvement, it is rather annoying to need to either import `Input` to use input types, or to type `ex.Input.SomeImport` to use a type.

The old import site will continue to work for now, you'll just see the deprecation warning in the editor.