### PR TITLE
fix: [#2726] Entity manager memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ are returned
 
 ### Fixed
 
+- Fixed memory leak in the internal `ex.EntityManager`, it did not properly clear internal state when removing entities
 - Fixed issue where scaling a `ex.TileMap` didn't properly offscreen cull due to the bounds not scaling properly.
 - Fixed issue where `ex.Text.flipHorizontal` or `ex.Text.flipVertical` would not work
 - Fixed issue where overriding existing components did not work properly because of deferred component removal

--- a/src/engine/EntityComponentSystem/EntityManager.ts
+++ b/src/engine/EntityComponentSystem/EntityManager.ts
@@ -130,6 +130,7 @@ export class EntityManager<ContextType = any> implements Observer<RemovedCompone
       }
       this.removeEntity(entity, false);
     }
+    this._entitiesToRemove.length = 0;
   }
 
   public processComponentRemovals(): void {

--- a/src/spec/EntityManagerSpec.ts
+++ b/src/spec/EntityManagerSpec.ts
@@ -92,7 +92,10 @@ describe('An EntityManager', () => {
 
     expect(entityManager.entities.length).toBe(2);
     entityManager.clear();
+    expect((entityManager as any)._entitiesToRemove.length).toBe(2);
+    expect(entityManager.entities.length).toBe(2);
     entityManager.processEntityRemovals();
     expect(entityManager.entities.length).toBe(0);
+    expect((entityManager as any)._entitiesToRemove.length).toBe(0);
   });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2726

Properly clears internal state after entities have removed from the world
