### PR TITLE
fix: [#2732] TileMap collider consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ are returned
 
 ### Fixed
 
+- Fixed issue with `ex.TileMap` collider consolidation where custom colliders would prevent normal solid tile colliders from being included.
 - Fixed memory leak in the internal `ex.EntityManager`, it did not properly clear internal state when removing entities
 - Fixed issue where scaling a `ex.TileMap` didn't properly offscreen cull due to the bounds not scaling properly.
 - Fixed issue where `ex.Text.flipHorizontal` or `ex.Text.flipVertical` would not work

--- a/src/engine/TileMap/TileMap.ts
+++ b/src/engine/TileMap/TileMap.ts
@@ -301,17 +301,24 @@ export class TileMap extends Entity {
         if (tile.solid) {
           // Use custom collider otherwise bounding box
           if (tile.getColliders().length > 0) {
+            // tile with custom collider interrupting the current run
             for (const collider of tile.getColliders()) {
               const originalOffset = this._getOrSetColliderOriginalOffset(collider);
               collider.offset = vec(tile.x * this.tileWidth * this.scale.x, tile.y * this.tileHeight * this.scale.y).add(originalOffset);
               collider.owner = this;
               this._composite.addCollider(collider);
             }
+            //we push any current collider before nulling the current run
+            if (current) {
+              colliders.push(current);
+            }
             current = null;
           } else {
             if (!current) {
+              // no current run, start one
               current = tile.bounds;
             } else {
+              // combine with current run
               current = current.combine(tile.bounds);
             }
           }


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2732

Fixes bug where the current run of collider is not saved if the next tile has a custom collider

<img width="761" alt="image" src="https://github.com/excaliburjs/Excalibur/assets/612071/563531b1-d924-43ee-bf41-fd81467e9fab">

