### PR TITLE
fix: [#2762] wasPressed in input mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,37 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-
 ## [Unreleased]
+
+### Breaking Changes
+
+-
+
+### Deprecated
+
+-
+
+### Added
+
+-
+
+### Fixed
+
+- Fixed issue with input mapper where `keyboard.wasPressed(...)` did not fire
+
+### Updates
+
+-
+
+### Changed
+
+-
+
+<!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
+<!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
+<!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
+
+## [v0.28.0]
 
 ### Breaking Changes
 
@@ -192,11 +221,6 @@ stored `ex.Graphics` causing them to be shared across clones.
 - Excalibur will now use `ex.EventEmitter` to broadcast events, Excalibur types that have events support will also have an `.events` member.
 - Excalibur resources by default no longer add cache busting query string to resources. All built in resources now expose a `bustCache` property to allow setting this before loading, for example `ex.Sound.bustCache`.
 
-
-
-<!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
-<!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
-<!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 
 ## [0.27.0] - 2022-07-08
 

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1205,9 +1205,9 @@ O|===|* >________________>\n\
       // suspend updates until loading is finished
       this._loader.update(this, delta);
       // Update input listeners
+      this.inputMapper.execute();
       this.input.keyboard.update();
       this.input.gamepads.update();
-      this.inputMapper.execute();
       return;
     }
 
@@ -1225,9 +1225,9 @@ O|===|* >________________>\n\
     this._postupdate(delta);
 
     // Update input listeners
+    this.inputMapper.execute();
     this.input.keyboard.update();
     this.input.gamepads.update();
-    this.inputMapper.execute();
   }
 
   /**

--- a/src/spec/InputMapperSpec.ts
+++ b/src/spec/InputMapperSpec.ts
@@ -1,4 +1,5 @@
 import * as ex from '@excalibur';
+import { TestUtils } from './util/TestUtils';
 
 describe('An InputMapper', () => {
   it('exists', () => {
@@ -49,4 +50,25 @@ describe('An InputMapper', () => {
     expect(command).toHaveBeenCalledTimes(0);
   });
 
+  it('can fire wasPressed events when used in a engine', () => {
+
+    const engine = TestUtils.engine({ width: 100, height: 100 });
+
+    const clock = engine.clock as ex.TestClock;
+    clock.start();
+    engine.input.keyboard.triggerEvent('down', ex.Keys.Space);
+
+    const sut = engine.inputMapper;
+    const keyPressedSpy = jasmine.createSpy('keyPressed');
+    const keyReleasedSpy = jasmine.createSpy('keyReleased');
+    sut.on(({keyboard}) => keyboard.wasPressed(ex.Keys.Space), keyPressedSpy);
+    sut.on(({keyboard}) => keyboard.wasReleased(ex.Keys.Space), keyReleasedSpy);
+
+    clock.step();
+    expect(keyPressedSpy).toHaveBeenCalled();
+
+    engine.input.keyboard.triggerEvent('up', ex.Keys.Space);
+    clock.step();
+    expect(keyReleasedSpy).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2762

## Changes:

- Changes the input mapper execution order to run input mapping before clearing keyboard events per frame
