### PR TITLE
feat: Implement async onInitialize

### DIFF
--- a/sandbox/tests/gotoscene/index.ts
+++ b/sandbox/tests/gotoscene/index.ts
@@ -1,5 +1,5 @@
 class Scene1 extends ex.Scene {
-  onInitialize(_engine: ex.Engine): void {
+  async onInitialize(_engine: ex.Engine) {
     const actor = new ex.Actor({
       x: _engine.halfDrawWidth,
       y: _engine.halfDrawHeight,
@@ -24,7 +24,7 @@ class Scene1 extends ex.Scene {
 
 
 class Scene2 extends ex.Scene {
-  onInitialize(_engine: ex.Engine): void {
+  async onInitialize(_engine: ex.Engine) {
     // _engine.start();
     const actor = new ex.Actor({
       pos: ex.Vector.Zero,

--- a/sandbox/tests/gotoscene/index.ts
+++ b/sandbox/tests/gotoscene/index.ts
@@ -1,7 +1,8 @@
 class Scene1 extends ex.Scene {
   async onInitialize(_engine: ex.Engine) {
-
+    console.log('before async');
     await ex.Util.delay(1000);
+    console.log('after async');
     const actor = new ex.Actor({
       x: _engine.halfDrawWidth,
       y: _engine.halfDrawHeight,
@@ -13,20 +14,21 @@ class Scene1 extends ex.Scene {
 
     _engine.input.pointers.primary.on(
       "down",
-      (event: ex.PointerEvent): void => {
-        _engine.goToScene("scene2");
+      async (event: ex.PointerEvent) => {
+        await _engine.goToScene("scene2");
       }
     );
   }
 
-  onActivate(): void {
+  async onActivate() {
     console.log('Scene 1 Activate')
   }
 }
 
 
 class Scene2 extends ex.Scene {
-  onInitialize(_engine: ex.Engine) {
+  async onInitialize(_engine: ex.Engine) {
+    await ex.Util.delay(1000);
     // _engine.start();
     const actor = new ex.Actor({
       pos: ex.Vector.Zero,
@@ -34,9 +36,11 @@ class Scene2 extends ex.Scene {
       height: 1000,
       color: ex.Color.Cyan,
     });
+    actor.angularVelocity = 1;
     _engine.add(actor);
   }
-  onActivate(): void {
+  async onActivate() {
+    await ex.Util.delay(1000);
     console.log('Scene 2 Activate')
   }
 }

--- a/sandbox/tests/gotoscene/index.ts
+++ b/sandbox/tests/gotoscene/index.ts
@@ -1,5 +1,7 @@
 class Scene1 extends ex.Scene {
   async onInitialize(_engine: ex.Engine) {
+
+    await ex.Util.delay(1000);
     const actor = new ex.Actor({
       x: _engine.halfDrawWidth,
       y: _engine.halfDrawHeight,
@@ -24,7 +26,7 @@ class Scene1 extends ex.Scene {
 
 
 class Scene2 extends ex.Scene {
-  async onInitialize(_engine: ex.Engine) {
+  onInitialize(_engine: ex.Engine) {
     // _engine.start();
     const actor = new ex.Actor({
       pos: ex.Vector.Zero,

--- a/sandbox/tests/scene/lifecycle.ts
+++ b/sandbox/tests/scene/lifecycle.ts
@@ -17,7 +17,7 @@ class MyGame2 extends ex.Engine {
       console.log("scene deactivate");
     }
   }
-  onInitialize() {
+  async onInitialize() {
     console.log("engine init");
   }
 }

--- a/sandbox/tsconfig.json
+++ b/sandbox/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "sourceMap": true,
     "experimentalDecorators": true,
-    "target": "es2015",
-    "module": "es2015",
+    "target": "ES2022",
+    "module": "ESNext",
     "removeComments": false,
     "skipLibCheck": true,
     "lib": ["dom", "es5", "es2015", "es2015.promise", "es2015.collection", "es2015.iterable"]

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -609,7 +609,7 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
    *
    * Synonymous with the event handler `.on('initialize', (evt) => {...})`
    */
-  public async onInitialize(_engine: Engine) {
+  public onInitialize(_engine: Engine) {
     // Override me
   }
 

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -609,7 +609,7 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
    *
    * Synonymous with the event handler `.on('initialize', (evt) => {...})`
    */
-  public onInitialize(_engine: Engine): void {
+  public async onInitialize(_engine: Engine) {
     // Override me
   }
 
@@ -619,10 +619,10 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
    * It is not recommended that internal excalibur methods be overridden, do so at your own risk.
    * @internal
    */
-  public _initialize(engine: Engine) {
-    super._initialize(engine);
+  public async _initialize(engine: Engine) {
+    await super._initialize(engine);
     for (const child of this.children) {
-      child._initialize(engine);
+      await child._initialize(engine);
     }
   }
 

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1077,7 +1077,7 @@ O|===|* >________________>\n\
       // only deactivate when initialized
       if (this.currentScene.isInitialized) {
         const context = { engine: this, previousScene, nextScene };
-        this.currentScene._deactivate.apply(this.currentScene, [context, nextScene]);
+        await this.currentScene._deactivate(context);
         this.currentScene.events.emit('deactivate', new DeactivateEvent(context, this.currentScene));
       }
 
@@ -1090,7 +1090,7 @@ O|===|* >________________>\n\
       await this.currentScene._initialize(this);
 
       const context = { engine: this, previousScene, nextScene, data };
-      this.currentScene._activate.apply(this.currentScene, [context, nextScene]);
+      await this.currentScene._activate(context);
       this.currentScene.events.emit('activate', new ActivateEvent(context, this.currentScene));
     } else {
       this._logger.error('Scene', key, 'does not exist!');

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -46,6 +46,7 @@ import { ImageFiltering } from './Graphics/Filtering';
 import { GraphicsDiagnostics } from './Graphics/GraphicsDiagnostics';
 import { Toaster } from './Util/Toaster';
 import { InputMapper } from './Input/InputMapper';
+import { isAsync } from './Util/Util';
 
 export type EngineEvents = {
   fallbackgraphicscontext: ExcaliburGraphicsContext2DCanvas,
@@ -1152,7 +1153,7 @@ O|===|* >________________>\n\
     }
   }
 
-  public async onInitialize(_engine: Engine) {
+  public onInitialize(_engine: Engine) {
     // Override me
   }
 
@@ -1182,7 +1183,11 @@ O|===|* >________________>\n\
 
   private async _overrideInitialize(engine: Engine) {
     if (!this.isInitialized) {
-      await this.onInitialize(engine);
+      if (isAsync) {
+        await this.onInitialize(engine);
+      } else {
+        this.onInitialize(engine);
+      }
       this.events.emit('initialize', new InitializeEvent(engine, this));
       this._isInitialized = true;
       if (this._deferredGoTo) {

--- a/src/engine/EntityComponentSystem/Entity.ts
+++ b/src/engine/EntityComponentSystem/Entity.ts
@@ -477,9 +477,9 @@ export class Entity implements OnInitialize, OnPreUpdate, OnPostUpdate {
    * It is not recommended that internal excalibur methods be overridden, do so at your own risk.
    * @internal
    */
-  public _initialize(engine: Engine) {
+  public async _initialize(engine: Engine) {
     if (!this.isInitialized) {
-      this.onInitialize(engine);
+      await this.onInitialize(engine);
       this.events.emit('initialize', new InitializeEvent(engine, this));
       this._isInitialized = true;
     }

--- a/src/engine/EntityComponentSystem/Entity.ts
+++ b/src/engine/EntityComponentSystem/Entity.ts
@@ -5,6 +5,7 @@ import { OnInitialize, OnPreUpdate, OnPostUpdate } from '../Interfaces/Lifecycle
 import { Engine } from '../Engine';
 import { InitializeEvent, PreUpdateEvent, PostUpdateEvent } from '../Events';
 import { EventEmitter, EventKey, Handler, Scene, Subscription, Util } from '..';
+import { isAsync } from '../Util/Util';
 
 /**
  * Interface holding an entity component pair
@@ -479,7 +480,11 @@ export class Entity implements OnInitialize, OnPreUpdate, OnPostUpdate {
    */
   public async _initialize(engine: Engine) {
     if (!this.isInitialized) {
-      await this.onInitialize(engine);
+      if (isAsync(this.onInitialize)) {
+        await this.onInitialize(engine);
+      } else {
+        this.onInitialize(engine);
+      }
       this.events.emit('initialize', new InitializeEvent(engine, this));
       this._isInitialized = true;
     }

--- a/src/engine/EntityComponentSystem/Entity.ts
+++ b/src/engine/EntityComponentSystem/Entity.ts
@@ -5,7 +5,6 @@ import { OnInitialize, OnPreUpdate, OnPostUpdate } from '../Interfaces/Lifecycle
 import { Engine } from '../Engine';
 import { InitializeEvent, PreUpdateEvent, PostUpdateEvent } from '../Events';
 import { EventEmitter, EventKey, Handler, Scene, Subscription, Util } from '..';
-import { isAsync } from '../Util/Util';
 
 /**
  * Interface holding an entity component pair
@@ -480,11 +479,7 @@ export class Entity implements OnInitialize, OnPreUpdate, OnPostUpdate {
    */
   public async _initialize(engine: Engine) {
     if (!this.isInitialized) {
-      if (isAsync(this.onInitialize)) {
-        await this.onInitialize(engine);
-      } else {
-        this.onInitialize(engine);
-      }
+      await this.onInitialize(engine);
       this.events.emit('initialize', new InitializeEvent(engine, this));
       this._isInitialized = true;
     }

--- a/src/engine/Label.ts
+++ b/src/engine/Label.ts
@@ -111,8 +111,8 @@ export class Label extends Actor {
     gfx.use(this._text);
   }
 
-  public _initialize(engine: Engine) {
-    super._initialize(engine);
+  public async _initialize(engine: Engine) {
+    await super._initialize(engine);
   }
 
   /**

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -33,7 +33,6 @@ import { OffscreenSystem } from './Graphics/OffscreenSystem';
 import { ExcaliburGraphicsContext } from './Graphics';
 import { PhysicsWorld } from './Collision/PhysicsWorld';
 import { EventEmitter, EventKey, Handler, Subscription } from './EventEmitter';
-import { isAsync } from './Util/Util';
 
 export type SceneEvents = {
   initialize: InitializeEvent<Scene>,
@@ -271,13 +270,7 @@ implements CanInitialize, CanActivate<TActivationData>, CanDeactivate, CanUpdate
 
       // This order is important! we want to be sure any custom init that add actors
       // fire before the actor init
-      if (isAsync(this.onInitialize)) {
-        console.log('Async scene init')
-        await this.onInitialize.call(this, engine);
-      } else {
-        console.log('Sync scene init')
-        this.onInitialize.call(this, engine);
-      }
+      await this.onInitialize.call(this, engine);
       await this._initializeChildren();
 
       this._logger.debug('Scene.onInitialize', this, engine);
@@ -292,9 +285,9 @@ implements CanInitialize, CanActivate<TActivationData>, CanDeactivate, CanUpdate
    * Activates the scene with the base behavior, then calls the overridable `onActivate` implementation.
    * @internal
    */
-  public _activate(context: SceneActivationContext<TActivationData>): void {
+  public async _activate(context: SceneActivationContext<TActivationData>) {
     this._logger.debug('Scene.onActivate', this);
-    this.onActivate(context);
+    await this.onActivate(context);
   }
 
   /**
@@ -303,9 +296,9 @@ implements CanInitialize, CanActivate<TActivationData>, CanDeactivate, CanUpdate
    * Deactivates the scene with the base behavior, then calls the overridable `onDeactivate` implementation.
    * @internal
    */
-  public _deactivate(context: SceneActivationContext<never>): void {
+  public async _deactivate(context: SceneActivationContext<never>) {
     this._logger.debug('Scene.onDeactivate', this);
-    this.onDeactivate(context);
+    await this.onDeactivate(context);
   }
 
   /**

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -33,6 +33,7 @@ import { OffscreenSystem } from './Graphics/OffscreenSystem';
 import { ExcaliburGraphicsContext } from './Graphics';
 import { PhysicsWorld } from './Collision/PhysicsWorld';
 import { EventEmitter, EventKey, Handler, Subscription } from './EventEmitter';
+import { isAsync } from './Util/Util';
 
 export type SceneEvents = {
   initialize: InitializeEvent<Scene>,
@@ -178,7 +179,7 @@ implements CanInitialize, CanActivate<TActivationData>, CanDeactivate, CanUpdate
    * This is called before the first update of the [[Scene]]. Initializes scene members like the camera. This method is meant to be
    * overridden. This is where initialization of child actors should take place.
    */
-  public async onInitialize(_engine: Engine) {
+  public onInitialize(_engine: Engine) {
     // will be overridden
   }
 
@@ -252,6 +253,7 @@ implements CanInitialize, CanActivate<TActivationData>, CanDeactivate, CanUpdate
     return this._isInitialized;
   }
 
+
   /**
    * It is not recommended that internal excalibur methods be overridden, do so at your own risk.
    *
@@ -269,7 +271,13 @@ implements CanInitialize, CanActivate<TActivationData>, CanDeactivate, CanUpdate
 
       // This order is important! we want to be sure any custom init that add actors
       // fire before the actor init
-      await this.onInitialize.call(this, engine);
+      if (isAsync(this.onInitialize)) {
+        console.log('Async scene init')
+        await this.onInitialize.call(this, engine);
+      } else {
+        console.log('Sync scene init')
+        this.onInitialize.call(this, engine);
+      }
       await this._initializeChildren();
 
       this._logger.debug('Scene.onInitialize', this, engine);

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -178,7 +178,7 @@ implements CanInitialize, CanActivate<TActivationData>, CanDeactivate, CanUpdate
    * This is called before the first update of the [[Scene]]. Initializes scene members like the camera. This method is meant to be
    * overridden. This is where initialization of child actors should take place.
    */
-  public onInitialize(_engine: Engine): void {
+  public async onInitialize(_engine: Engine) {
     // will be overridden
   }
 
@@ -239,9 +239,9 @@ implements CanInitialize, CanActivate<TActivationData>, CanDeactivate, CanUpdate
   /**
    * Initializes actors in the scene
    */
-  private _initializeChildren(): void {
+  private async _initializeChildren() {
     for (const child of this.entities) {
-      child._initialize(this.engine);
+      await child._initialize(this.engine);
     }
   }
 
@@ -259,7 +259,7 @@ implements CanInitialize, CanActivate<TActivationData>, CanDeactivate, CanUpdate
    * Excalibur
    * @internal
    */
-  public _initialize(engine: Engine) {
+  public async _initialize(engine: Engine) {
     if (!this.isInitialized) {
       this.engine = engine;
       // Initialize camera first
@@ -269,8 +269,8 @@ implements CanInitialize, CanActivate<TActivationData>, CanDeactivate, CanUpdate
 
       // This order is important! we want to be sure any custom init that add actors
       // fire before the actor init
-      this.onInitialize.call(this, engine);
-      this._initializeChildren();
+      await this.onInitialize.call(this, engine);
+      await this._initializeChildren();
 
       this._logger.debug('Scene.onInitialize', this, engine);
       this.events.emit('initialize', new InitializeEvent(engine, this));

--- a/src/engine/ScreenElement.ts
+++ b/src/engine/ScreenElement.ts
@@ -36,9 +36,9 @@ export class ScreenElement extends Actor {
     }
   }
 
-  public _initialize(engine: Engine) {
+  public async _initialize(engine: Engine) {
     this._engine = engine;
-    super._initialize(engine);
+    await super._initialize(engine);
   }
 
   public contains(x: number, y: number, useWorld: boolean = true) {

--- a/src/engine/TileMap/TileMap.ts
+++ b/src/engine/TileMap/TileMap.ts
@@ -274,8 +274,8 @@ export class TileMap extends Entity {
     });
   }
 
-  public _initialize(engine: Engine) {
-    super._initialize(engine);
+  public async _initialize(engine: Engine) {
+    await super._initialize(engine);
     this._engine = engine;
   }
 

--- a/src/engine/Trigger.ts
+++ b/src/engine/Trigger.ts
@@ -122,8 +122,8 @@ export class Trigger extends Actor {
     return this._target;
   }
 
-  public _initialize(engine: Engine) {
-    super._initialize(engine);
+  public async _initialize(engine: Engine) {
+    await super._initialize(engine);
   }
 
   private _dispatchAction() {

--- a/src/engine/Util/Util.ts
+++ b/src/engine/Util/Util.ts
@@ -90,3 +90,7 @@ export function delay(milliseconds: number, clock?: Clock): Promise<void> {
   }, milliseconds);
   return future.promise;
 }
+
+export function isAsync(func: Function): boolean {
+  return func.constructor.name === 'AsyncFunction';
+}


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

This PR changes up the onInitialize to be async, this is currently and experiment to see if this is the direction we want to take.

This is inline with our roadmap desire to allow loading scene specific resources

We will hold this type of breaking change until v0.29.0