### PR TITLE
fix: bug where incorrect track was removed when stop/start in rapid succession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed async issue where sound could not be stopped if stop()/start() were called in rapid succession
 - Fixed issue with input mapper where `keyboard.wasPressed(...)` did not fire
 - Fixed issue issue where TileMaps would not properly draw Tiles when setup in screen space coordinates
 - Fixed issue where the ex.Line graphics bounds were incorrect causing erroneous offscreen culling

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "core:bundle:esm": "webpack --progress --config webpack.config.js --mode production --env output=esm",
     "core:watch": "npm run core:bundle -- --watch",
     "lint": "npm run eslint && npm run eslint:spec",
+    "lint:fix": "npm run eslint --fix && npm run eslint:spec --fix",
     "eslint": "eslint \"src/engine/**/*.ts\"",
     "eslint:sandbox": "eslint \"sandbox/**/*.ts\"",
     "eslint:spec": "eslint \"src/spec/**/*.ts\"",

--- a/sandbox/tests/sound-loop/index.html
+++ b/sandbox/tests/sound-loop/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sound Loop Test</title>
+</head>
+<body>
+  Stopping a looping sounds should stop all running tracks
+  <script src="../../lib/excalibur.js"></script>
+  <script src="index.js"></script>
+</body>
+</html>

--- a/sandbox/tests/sound-loop/index.ts
+++ b/sandbox/tests/sound-loop/index.ts
@@ -1,0 +1,48 @@
+
+
+var game = new ex.Engine({
+  width: 400,
+  height: 400
+});
+
+var sound = new ex.Sound('./gba1complete.mp3');
+sound.volume = .05;
+sound.loop = true;
+
+
+var loader = new ex.Loader();
+loader.addResource(sound)
+
+class BaseScene extends ex.Scene {
+  constructor(public name) {
+    super();
+  }
+  override onActivate(): void {
+    console.log('activate', this.name);
+    sound.play();
+  }
+  override onDeactivate(): void {
+    console.log('deactivate', this.name);
+    sound.stop();
+  }
+}
+
+var scene1 = new BaseScene("scene1");
+var scene22 = new BaseScene("scene2");
+var scene3 = new BaseScene("scene3");
+
+game.add('scene1', scene1);
+game.add('scene2', scene22);
+game.add('scene3', scene3);
+
+game.start(loader).then(() => {
+  game.goToScene('scene1');
+
+  setTimeout(() => {
+    game.goToScene('scene1');
+    sound.stop();
+  }, 1000)
+});
+
+// going to the same scene again causes the sound to become unstoppable?!?!
+

--- a/src/engine/Interfaces/Audio.ts
+++ b/src/engine/Interfaces/Audio.ts
@@ -29,6 +29,11 @@ export interface Audio {
   isPaused(): boolean;
 
   /**
+   * Returns if the audio is stopped
+   */
+  isStopped(): boolean;
+
+  /**
    * Will play the sound or resume if paused
    */
   play(): Promise<any>;

--- a/src/engine/Resources/Sound/Sound.ts
+++ b/src/engine/Resources/Sound/Sound.ts
@@ -361,22 +361,18 @@ export class Sound implements Audio, Loadable<AudioBuffer> {
   private async _startPlayback(): Promise<boolean> {
     const track = this._getTrackInstance(this.data);
 
-    // this._tracks.push(track);
-
     const complete = await track.play(() => {
       this.events.emit('playbackstart', new NativeSoundEvent(this, track));
       this.logger.debug('Playing new instance for sound', this.path);
     });
 
-    // when done, remove track
-    const doneTracks = this._tracks.filter(t => t.isStopped());
-    doneTracks.forEach((track: WebAudioInstance) => {
-      this.events.emit('playbackend', new NativeSoundEvent(this, track));
-    });
-    // this._tracks.splice(this.getTrackId(track), 1);
+    this.events.emit('playbackend', new NativeSoundEvent(this, track));
 
     // cleanup any done tracks
-    this._tracks = this._tracks.filter(t => !t.isStopped());
+    const trackId = this.getTrackId(track);
+    if (trackId !== -1) {
+      this._tracks.splice(this.getTrackId(track), 1);
+    }
 
     return complete;
   }

--- a/src/engine/Resources/Sound/Sound.ts
+++ b/src/engine/Resources/Sound/Sound.ts
@@ -371,7 +371,7 @@ export class Sound implements Audio, Loadable<AudioBuffer> {
     // cleanup any done tracks
     const trackId = this.getTrackId(track);
     if (trackId !== -1) {
-      this._tracks.splice(this.getTrackId(track), 1);
+      this._tracks.splice(trackId, 1);
     }
 
     return complete;

--- a/src/engine/Resources/Sound/Sound.ts
+++ b/src/engine/Resources/Sound/Sound.ts
@@ -228,6 +228,10 @@ export class Sound implements Audio, Loadable<AudioBuffer> {
     return this._tracks.some(t => t.isPaused());
   }
 
+  public isStopped(): boolean {
+    return this._tracks.some(t => t.isStopped());
+  }
+
   /**
    * Play the sound, returns a promise that resolves when the sound is done playing
    * An optional volume argument can be passed in to play the sound. Max volume is 1.0
@@ -355,7 +359,9 @@ export class Sound implements Audio, Loadable<AudioBuffer> {
    * Starts playback, returns a promise that resolves when playback is complete
    */
   private async _startPlayback(): Promise<boolean> {
-    const track = await this._getTrackInstance(this.data);
+    const track = this._getTrackInstance(this.data);
+
+    // this._tracks.push(track);
 
     const complete = await track.play(() => {
       this.events.emit('playbackstart', new NativeSoundEvent(this, track));
@@ -363,8 +369,14 @@ export class Sound implements Audio, Loadable<AudioBuffer> {
     });
 
     // when done, remove track
-    this.events.emit('playbackend', new NativeSoundEvent(this, track));
-    this._tracks.splice(this.getTrackId(track), 1);
+    const doneTracks = this._tracks.filter(t => t.isStopped());
+    doneTracks.forEach((track: WebAudioInstance) => {
+      this.events.emit('playbackend', new NativeSoundEvent(this, track));
+    })
+    // this._tracks.splice(this.getTrackId(track), 1);
+
+    // cleanup any done tracks
+    this._tracks = this._tracks.filter(t => !t.isStopped());
 
     return complete;
   }

--- a/src/engine/Resources/Sound/Sound.ts
+++ b/src/engine/Resources/Sound/Sound.ts
@@ -372,7 +372,7 @@ export class Sound implements Audio, Loadable<AudioBuffer> {
     const doneTracks = this._tracks.filter(t => t.isStopped());
     doneTracks.forEach((track: WebAudioInstance) => {
       this.events.emit('playbackend', new NativeSoundEvent(this, track));
-    })
+    });
     // this._tracks.splice(this.getTrackId(track), 1);
 
     // cleanup any done tracks

--- a/src/engine/Resources/Sound/WebAudioInstance.ts
+++ b/src/engine/Resources/Sound/WebAudioInstance.ts
@@ -41,7 +41,6 @@ export class WebAudioInstance implements Audio {
         onExit: ({to}) => {
           // If you've exited early only resolve if explicitly STOPPED
           if (to === 'STOPPED') {
-            // this._playingResolve(true);
             this._playingFuture.resolve(true);
           }
           // Whenever you're not playing... you stop!
@@ -63,7 +62,6 @@ export class WebAudioInstance implements Audio {
         onEnter: ({data}: {from: string, data: SoundState}) => {
           data.pausedAt = 0;
           data.startedAt = 0;
-          // this._playingResolve(true);
           this._playingFuture.resolve(true);
         },
         transitions: ['PLAYING', 'PAUSED', 'SEEK']
@@ -95,7 +93,6 @@ export class WebAudioInstance implements Audio {
   private _handleEnd() {
     if (!this.loop) {
       this._instance.onended = () => {
-        // this._playingResolve(true);
         this._playingFuture.resolve(true);
       };
     }
@@ -112,7 +109,6 @@ export class WebAudioInstance implements Audio {
       this._instance.loop = value;
       if (!this.loop) {
         this._instance.onended = () => {
-          // this._playingResolve(true);
           this._playingFuture.resolve(true);
         };
       }
@@ -179,7 +175,6 @@ export class WebAudioInstance implements Audio {
   public play(playStarted: () => any = () => {}) {
     this._playStarted = playStarted;
     this._stateMachine.go('PLAYING');
-    // return this._playingPromise;
     return this._playingFuture.promise;
   }
 

--- a/src/engine/Resources/Sound/WebAudioInstance.ts
+++ b/src/engine/Resources/Sound/WebAudioInstance.ts
@@ -2,6 +2,7 @@ import { StateMachine } from '../../Util/StateMachine';
 import { Audio } from '../../Interfaces/Audio';
 import { clamp } from '../../Math/util';
 import { AudioContextFactory } from './AudioContext';
+import { Future } from '../../Util/Future';
 
 interface SoundState {
   startedAt: number;
@@ -16,10 +17,8 @@ export class WebAudioInstance implements Audio {
   private _instance: AudioBufferSourceNode;
   private _audioContext: AudioContext = AudioContextFactory.create();
   private _volumeNode = this._audioContext.createGain();
-  private _playingResolve: (value: boolean) => void;
-  private _playingPromise = new Promise<boolean>((resolve) => {
-    this._playingResolve = resolve;
-  });
+
+  private _playingFuture = new Future<boolean>()
   private _stateMachine = StateMachine.create({
     start: 'STOPPED',
     states: {
@@ -42,7 +41,8 @@ export class WebAudioInstance implements Audio {
         onExit: ({to}) => {
           // If you've exited early only resolve if explicitly STOPPED
           if (to === 'STOPPED') {
-            this._playingResolve(true);
+            // this._playingResolve(true);
+            this._playingFuture.resolve(true);
           }
           // Whenever you're not playing... you stop!
           this._instance.onended = null; // disconnect the wired on-end handler
@@ -63,7 +63,8 @@ export class WebAudioInstance implements Audio {
         onEnter: ({data}: {from: string, data: SoundState}) => {
           data.pausedAt = 0;
           data.startedAt = 0;
-          this._playingResolve(true);
+          // this._playingResolve(true);
+          this._playingFuture.resolve(true);
         },
         transitions: ['PLAYING', 'PAUSED', 'SEEK']
       },
@@ -94,7 +95,8 @@ export class WebAudioInstance implements Audio {
   private _handleEnd() {
     if (!this.loop) {
       this._instance.onended = () => {
-        this._playingResolve(true);
+        // this._playingResolve(true);
+        this._playingFuture.resolve(true);
       };
     }
   }
@@ -110,7 +112,8 @@ export class WebAudioInstance implements Audio {
       this._instance.loop = value;
       if (!this.loop) {
         this._instance.onended = () => {
-          this._playingResolve(true);
+          // this._playingResolve(true);
+          this._playingFuture.resolve(true);
         };
       }
     }
@@ -168,11 +171,16 @@ export class WebAudioInstance implements Audio {
     return this._stateMachine.in('PAUSED') || this._stateMachine.in('SEEK');
   }
 
+  public isStopped() {
+    return this._stateMachine.in('STOPPED');
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   public play(playStarted: () => any = () => {}) {
     this._playStarted = playStarted;
     this._stateMachine.go('PLAYING');
-    return this._playingPromise;
+    // return this._playingPromise;
+    return this._playingFuture.promise;
   }
 
   public pause() {

--- a/src/engine/Resources/Sound/WebAudioInstance.ts
+++ b/src/engine/Resources/Sound/WebAudioInstance.ts
@@ -18,7 +18,7 @@ export class WebAudioInstance implements Audio {
   private _audioContext: AudioContext = AudioContextFactory.create();
   private _volumeNode = this._audioContext.createGain();
 
-  private _playingFuture = new Future<boolean>()
+  private _playingFuture = new Future<boolean>();
   private _stateMachine = StateMachine.create({
     start: 'STOPPED',
     states: {

--- a/src/spec/SoundSpec.ts
+++ b/src/spec/SoundSpec.ts
@@ -469,12 +469,10 @@ describe('Sound resource', () => {
       });
     });
 
-    // FIXME: test times out
-    xit('should resume tracks when game is visible from hidden and pauseAudioWhenHidden is true', (done) => {
+    it('should resume tracks when game is visible from hidden and pauseAudioWhenHidden is true', (done) => {
       sut.load().then(() => {
         engine.pauseAudioWhenHidden = true;
         sut.wireEngine(engine);
-        sut.play();
 
         sut.once('playbackstart', () => {
           expect(sut.isPlaying()).toBe(true, 'should be playing');
@@ -483,6 +481,8 @@ describe('Sound resource', () => {
             engine.emit('hidden', new ex.HiddenEvent(engine));
           }, 100);
         });
+
+        sut.play();
 
         engine.once('hidden', () => {
           setTimeout(() => {

--- a/src/spec/SoundSpec.ts
+++ b/src/spec/SoundSpec.ts
@@ -293,7 +293,8 @@ describe('Sound resource', () => {
     }, 500);
   });
 
-  it('should not have any tracks when stopped', (done) => {
+  // FIXME: test times out
+  xit('should not have any tracks when stopped', (done) => {
     sut.load().then(() => {
       sut.play();
 
@@ -309,7 +310,8 @@ describe('Sound resource', () => {
     });
   });
 
-  it('should not remove instance if paused', (done) => {
+  // FIXME: test times out
+  xit('should not remove instance if paused', (done) => {
     sut.load().then(() => {
       sut.play();
 
@@ -412,7 +414,8 @@ describe('Sound resource', () => {
       engine = null;
     });
 
-    it('should stop all tracks when engine is stopped', (done) => {
+    // FIXME: test times out
+    xit('should stop all tracks when engine is stopped', (done) => {
       sut.load().then(() => {
         sut.wireEngine(engine);
         sut.play();
@@ -429,8 +432,8 @@ describe('Sound resource', () => {
         });
       });
     });
-
-    it('should not allow playing tracks when engine is stopped', (done) => {
+    // FIXME: test times out
+    xit('should not allow playing tracks when engine is stopped', (done) => {
       sut.load().then(() => {
         sut.wireEngine(engine);
         sut.play();
@@ -472,7 +475,8 @@ describe('Sound resource', () => {
       });
     });
 
-    it('should resume tracks when game is visible from hidden and pauseAudioWhenHidden is true', (done) => {
+    // FIXME: test times out
+    xit('should resume tracks when game is visible from hidden and pauseAudioWhenHidden is true', (done) => {
       sut.load().then(() => {
         engine.pauseAudioWhenHidden = true;
         sut.wireEngine(engine);

--- a/src/spec/SoundSpec.ts
+++ b/src/spec/SoundSpec.ts
@@ -428,7 +428,7 @@ describe('Sound resource', () => {
       });
     });
 
-    fit('should not allow playing tracks when engine is stopped', (done) => {
+    it('should not allow playing tracks when engine is stopped', (done) => {
       sut.load().then(() => {
         sut.wireEngine(engine);
         sut.once('playbackstart', () => {

--- a/src/spec/SoundSpec.ts
+++ b/src/spec/SoundSpec.ts
@@ -293,11 +293,8 @@ describe('Sound resource', () => {
     }, 500);
   });
 
-  // FIXME: test times out
-  xit('should not have any tracks when stopped', (done) => {
+  it('should not have any tracks when stopped', (done) => {
     sut.load().then(() => {
-      sut.play();
-
       sut.once('playbackstart', () => {
         expect(sut.instanceCount()).toBe(1, 'should be one track');
 
@@ -307,14 +304,12 @@ describe('Sound resource', () => {
 
         done();
       });
+      sut.play();
     });
   });
 
-  // FIXME: test times out
-  xit('should not remove instance if paused', (done) => {
+  it('should not remove instance if paused', (done) => {
     sut.load().then(() => {
-      sut.play();
-
       sut.once('playbackstart', () => {
         expect(sut.instanceCount()).toBe(1, 'should be one track');
 
@@ -324,6 +319,7 @@ describe('Sound resource', () => {
 
         done();
       });
+      sut.play();
     });
   });
 
@@ -414,11 +410,9 @@ describe('Sound resource', () => {
       engine = null;
     });
 
-    // FIXME: test times out
-    xit('should stop all tracks when engine is stopped', (done) => {
+    it('should stop all tracks when engine is stopped', (done) => {
       sut.load().then(() => {
         sut.wireEngine(engine);
-        sut.play();
 
         sut.once('playbackstart', () => {
           expect(sut.instanceCount()).toBe(1, 'should be one track');
@@ -430,14 +424,13 @@ describe('Sound resource', () => {
 
           done();
         });
+        sut.play();
       });
     });
-    // FIXME: test times out
-    xit('should not allow playing tracks when engine is stopped', (done) => {
+
+    fit('should not allow playing tracks when engine is stopped', (done) => {
       sut.load().then(() => {
         sut.wireEngine(engine);
-        sut.play();
-
         sut.once('playbackstart', () => {
           expect(sut.isPlaying()).toBe(true, 'should be playing');
 
@@ -449,6 +442,7 @@ describe('Sound resource', () => {
 
           done();
         });
+        sut.play();
       });
     });
 

--- a/src/spec/SoundSpec.ts
+++ b/src/spec/SoundSpec.ts
@@ -330,17 +330,17 @@ describe('Sound resource', () => {
       sut.loop = false;
       // start playing first track
       sut.play().then(() => {
-        expect(sut.instanceCount()).toBe(1, 'should be one track');
+        expect(sut.instanceCount()).withContext('should be on track').toBe(1);
       });
 
       // wait 250ms then play 2nd track
       setTimeout(() => {
         sut.on('playbackstart', () => {
-          expect(sut.instanceCount()).toBe(2, 'should be two simultaneous tracks');
+          expect(sut.instanceCount()).withContext('should be two simultaneous tracks').toBe(2);
         });
 
         sut.play().then(() => {
-          expect(sut.instanceCount()).toBe(0, 'should be no tracks');
+          expect(sut.instanceCount()).withContext('should be no tracks').toBe(0);
           done();
         });
       }, 250);


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR fixes a bug that caused looping Sound to be unstoppable when stopped then started in rapid succession. There were two issues, an errant await and not checking the result of an `indexOf` for -1
