### PR TITLE
fix: Trigger event signature type was incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed typo in trigger event signature `entertrigger` should have been `enter`
+- Fixed typo in trigger event signature `exittrigger` should have been `exit`
 - Fixed typo in animation event signature `ended` should have been `end`
 - Fixed issue where some excalibur `clear()`` implementations modified the collection they were iterating over
 - Fixed async issue where sound could not be stopped if stop()/start() were called in rapid succession

--- a/src/engine/Trigger.ts
+++ b/src/engine/Trigger.ts
@@ -7,13 +7,13 @@ import { Actor, ActorEvents } from './Actor';
 import { EventEmitter } from './EventEmitter';
 
 export type TriggerEvents = ActorEvents & {
-  exittrigger: ExitTriggerEvent,
-  entertrigger: EnterTriggerEvent
+  exit: ExitTriggerEvent,
+  enter: EnterTriggerEvent
 }
 
 export const TriggerEvents = {
-  ExitTrigger: 'exittrigger',
-  EnterTrigger: 'entertrigger'
+  ExitTrigger: 'exit',
+  EnterTrigger: 'enter'
 };
 
 /**
@@ -56,7 +56,7 @@ const triggerDefaults: Partial<TriggerOptions> = {
  * are invisible, and can only be seen when [[Trigger.visible]] is set to `true`.
  */
 export class Trigger extends Actor {
-  public events = new EventEmitter<TriggerEvents>();
+  public events = new EventEmitter<TriggerEvents & ActorEvents>();
   private _target: Entity;
   /**
    * Action to fire when triggered by collision
@@ -97,7 +97,7 @@ export class Trigger extends Actor {
 
     this.events.on('collisionstart', (evt: CollisionStartEvent<Actor>) => {
       if (this.filter(evt.other)) {
-        this.emit('enter', new EnterTriggerEvent(this, evt.other));
+        this.events.emit('enter', new EnterTriggerEvent(this, evt.other));
         this._dispatchAction();
         // remove trigger if its done, -1 repeat forever
         if (this.repeat === 0) {
@@ -108,7 +108,7 @@ export class Trigger extends Actor {
 
     this.events.on('collisionend', (evt: CollisionEndEvent<Actor>) => {
       if (this.filter(evt.other)) {
-        this.emit('exit', new ExitTriggerEvent(this, evt.other));
+        this.events.emit('exit', new ExitTriggerEvent(this, evt.other));
       }
     });
   }

--- a/src/spec/TriggerSpec.ts
+++ b/src/spec/TriggerSpec.ts
@@ -174,8 +174,8 @@ describe('A Trigger', () => {
 
     const exitSpy = jasmine.createSpy('exit');
     const collisionEnd = jasmine.createSpy('collisionend');
-    trigger.on('exit', exitSpy);
-    trigger.on('collisionend', collisionEnd);
+    trigger.events.on('exit', exitSpy);
+    trigger.events.on('collisionend', collisionEnd);
 
     // Act
     actor.vel = ex.vec(0, 10);


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Fixes issue where the incorrect type was being hinted in excalibur 
