### PR TITLE
feat: Add  `ex.Engine.version` to report the current excalibur version build string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
--
+- Added `ex.Engine.version` to report the current excalibur version build string
 
 ### Fixed
 

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -280,6 +280,13 @@ export interface EngineOptions {
  */
 export class Engine implements CanInitialize, CanUpdate, CanDraw {
   /**
+   * Current Excalibur version string
+   *
+   * Useful for plugins or other tools that need to know what features are available
+   */
+  public readonly version = EX_VERSION;
+
+  /**
    * Listen to and emit events on the Engine
    */
   public events = new EventEmitter<EngineEvents>();


### PR DESCRIPTION
Add `ex.Engine.version` build string to engine