### PR TITLE
fix: Remove multiple handlers if they are registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,15 +23,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where removing handlers by function reference only removed the first registered one
 - Fixed issue where play button was hidden when going fullscreen mode
-- Fix issue where screen resizing caused artifacts on the loading screen
-- Fix bug in `useCanvas2DFallback()` where `antialiasing` settings could be lost
-- Fix bug in `useCanvas2DFallback()` where opacity was not respected in `save
+- Fixed issue where screen resizing caused artifacts on the loading screen
+- Fixed bug in `useCanvas2DFallback()` where `antialiasing` settings could be lost
+- Fixed bug in `useCanvas2DFallback()` where opacity was not respected in `save
 - Fixed typo in trigger event signature `entertrigger` should have been `enter`
 - Fixed typo in trigger event signature `exittrigger` should have been `exit`
 - Fixed typo in animation event signature `ended` should have been `end`
-- Fixed issue where some excalibur `clear()`` implementations modified the collection they were iterating over
-- Fixed async issue where sound could not be stopped if stop()/start() were called in rapid succession
+- Fixed issue where some excalibur `clear()` implementations modified the collection they were iterating over
+- Fixed async issue where sound could not be stopped if `stop()`/`start()` were called in rapid succession
 - Fixed issue with input mapper where `keyboard.wasPressed(...)` did not fire
 - Fixed issue issue where TileMaps would not properly draw Tiles when setup in screen space coordinates
 - Fixed issue where the ex.Line graphics bounds were incorrect causing erroneous offscreen culling

--- a/src/engine/EventEmitter.ts
+++ b/src/engine/EventEmitter.ts
@@ -49,14 +49,11 @@ export class EventEmitter<TEventMap extends EventMap = any> {
   off(eventName: string): void;
   off<TEventName extends EventKey<TEventMap> | string>(eventName: TEventName, handler?: Handler<TEventMap[TEventName]>): void {
     if (handler) {
-      const listenerIndex = this._listeners[eventName]?.indexOf(handler);
-      if (listenerIndex > -1) {
-        this._listeners[eventName]?.splice(listenerIndex, 1);
-      }
-      const onceIndex = this._listenersOnce[eventName]?.indexOf(handler);
-      if (onceIndex > -1) {
-        this._listenersOnce[eventName]?.splice(onceIndex, 1);
-      }
+      const newListeners = this._listeners[eventName]?.filter(h => h !== handler);
+      this._listeners[eventName] = newListeners;
+
+      const newOnceListeners = this._listenersOnce[eventName]?.filter(h => h !== handler);
+      this._listenersOnce[eventName] = newOnceListeners;
     } else {
       delete this._listeners[eventName];
     }

--- a/src/spec/EventEmitterSpec.ts
+++ b/src/spec/EventEmitterSpec.ts
@@ -83,6 +83,34 @@ describe('An EventEmitter', () => {
     expect(handler).toHaveBeenCalledTimes(3);
   });
 
+  it('can be switched off by name and handler for multiple installs', () => {
+    const emitter = new ex.EventEmitter();
+    const handler = jasmine.createSpy('handler');
+
+    emitter.on('myevent2', handler);
+    emitter.on('myevent2', handler);
+
+    emitter.off('myevent2', handler);
+
+    emitter.emit('myevent2');
+
+    expect(handler).toHaveBeenCalledTimes(0);
+  });
+
+  it('can be switched off by name and handler for multiple installs in once', () => {
+    const emitter = new ex.EventEmitter();
+    const handler = jasmine.createSpy('handler');
+
+    emitter.once('myevent2', handler);
+    emitter.once('myevent2', handler);
+
+    emitter.off('myevent2', handler);
+
+    emitter.emit('myevent2');
+
+    expect(handler).toHaveBeenCalledTimes(0);
+  });
+
   it('can be switched off by name and handler for "once"', () => {
     const emitter = new ex.EventEmitter();
     const handler = jasmine.createSpy('handler');


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================


Fixed issue where removing handlers by function reference only removed the first registered one
