### PR TITLE
fix: Adjust font cache to prevent downward spiral on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- 
+- Adjusted the `FontCache` font timeout to 400 ms and makes it configurable as a static `FontCache.FONT_TIMEOUT`. This is to help prevent a downward spiral on mobile devices that might take a long while to render a few starting frames causing the cache to repeatedly clear and never recover.
 
 ### Updates
 

--- a/src/engine/Graphics/FontCache.ts
+++ b/src/engine/Graphics/FontCache.ts
@@ -5,6 +5,7 @@ import { Font } from './Font';
 import { FontTextInstance } from './FontTextInstance';
 
 export class FontCache {
+  public static FONT_TIMEOUT = 500;
   private static _LOGGER = Logger.getInstance();
   private static _TEXT_USAGE = new Map<FontTextInstance, number>();
   private static _TEXT_CACHE = new Map<string, FontTextInstance>();
@@ -41,7 +42,7 @@ export class FontCache {
     const currentHashCodes = new Set<string>();
     for (const [textInstance, time] of FontCache._TEXT_USAGE.entries()) {
       // if bitmap hasn't been used in 100 ms clear it
-      if (time + 100 < performance.now()) {
+      if (time + FontCache.FONT_TIMEOUT < performance.now()) {
         FontCache._LOGGER.debug(`Text cache entry timed out ${textInstance.text}`);
         deferred.push(textInstance);
         textInstance.dispose();


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR fixes a downward spiral that is possible on platforms with a slow couple frames. The `FontCache` font timeout to 500 ms and makes it configurable as a static `FontCache.FONT_TIMEOUT`. This is to help prevent a downward spiral on mobile devices that might take a long while to render a few starting frames causing the cache to repeatedly clear and never recover.