### PR TITLE
feat: Animation current time methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
--
+- New property and methods overloads to `ex.Animation`
+  * `ex.Animation.currentFrameTimeLeft` will return the current time in milliseconds left in the current
+  * `ex.Animation.goToFrame(frameNumber: number, duration?: number)` now accepts an optional duration for the target frame
 
 ### Fixed
 
--
+- `ex.Animation.reset()` did not properly reset all internal state
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - New property and methods overloads to `ex.Animation`
   * `ex.Animation.currentFrameTimeLeft` will return the current time in milliseconds left in the current
   * `ex.Animation.goToFrame(frameNumber: number, duration?: number)` now accepts an optional duration for the target frame
+  * `ex.Animation.speed` can set the speed multiplier on an animation 1 = 1x speed, 2 = 2x speed.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "excalibur",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "excalibur",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "BSD-2-Clause",
       "dependencies": {
         "core-js": "3.33.3"

--- a/src/engine/Graphics/Animation.ts
+++ b/src/engine/Graphics/Animation.ts
@@ -71,11 +71,17 @@ export interface AnimationOptions {
    */
   frames: Frame[];
   /**
+   * Optionally set a positive speed multiplier on the animation.
+   *
+   * By default 1, meaning 1x speed. If set to 2, it will play the animation twice as fast.
+   */
+  speed?: number;
+  /**
    * Optionally reverse the direction of play
    */
   reverse?: boolean;
   /**
-   * Optionally specify a default frame duration in ms (Default is 1000)
+   * Optionally specify a default frame duration in ms (Default is 100)
    */
   frameDuration?: number;
   /**
@@ -118,6 +124,12 @@ export interface FromSpriteSheetOptions {
    */
   durationPerFrameMs?: number;
   /**
+   * Optionally set a positive speed multiplier on the animation.
+   *
+   * By default 1, meaning 1x speed. If set to 2, it will play the animation twice as fast.
+   */
+  speed?: number;
+  /**
    * Optionally specify the animation strategy for this animation, by default animations loop [[AnimationStrategy.Loop]]
    */
   strategy?: AnimationStrategy
@@ -138,7 +150,6 @@ export class Animation extends Graphic implements HasTick {
   public frames: Frame[] = [];
   public strategy: AnimationStrategy = AnimationStrategy.Loop;
   public frameDuration: number = 100;
-  public timeScale: number = 1;
 
   private _idempotencyToken = -1;
 
@@ -148,10 +159,12 @@ export class Animation extends Graphic implements HasTick {
   private _pingPongDirection = 1;
   private _done = false;
   private _playing = true;
+  private _speed = 1;
 
   constructor(options: GraphicOptions & AnimationOptions) {
     super(options);
     this.frames = options.frames;
+    this.speed = options.speed ?? this.speed;
     this.strategy = options.strategy ?? this.strategy;
     this.frameDuration = options.totalDuration ? options.totalDuration / this.frames.length : options.frameDuration ?? this.frameDuration;
     if (options.reverse) {
@@ -164,6 +177,7 @@ export class Animation extends Graphic implements HasTick {
     return new Animation({
       frames: this.frames.map((f) => ({ ...f })),
       frameDuration: this.frameDuration,
+      speed: this.speed,
       reverse: this._reversed,
       strategy: this.strategy,
       ...this.cloneGraphicOptions()
@@ -248,7 +262,7 @@ export class Animation extends Graphic implements HasTick {
    * @returns Animation
    */
   public static fromSpriteSheetCoordinates(options: FromSpriteSheetOptions): Animation {
-    const { spriteSheet, frameCoordinates, durationPerFrameMs, strategy, reverse } = options;
+    const { spriteSheet, frameCoordinates, durationPerFrameMs, speed, strategy, reverse } = options;
     const defaultDuration = durationPerFrameMs ?? 100;
     const frames: Frame[] = [];
     for (const coord of frameCoordinates) {
@@ -269,8 +283,29 @@ export class Animation extends Graphic implements HasTick {
     return new Animation({
       frames,
       strategy,
+      speed,
       reverse
     });
+  }
+
+  /**
+   * Current animation speed
+   *
+   * 1 meaning normal 1x speed.
+   * 2 meaning 2x speed and so on.
+   */
+  public get speed(): number {
+    return this._speed;
+  }
+
+  /**
+   * Current animation speed
+   *
+   * 1 meaning normal 1x speed.
+   * 2 meaning 2x speed and so on.
+   */
+  public set speed(val: number) {
+    this._speed = clamp(Math.abs(val), 0, Infinity);
   }
 
   /**
@@ -466,7 +501,7 @@ export class Animation extends Graphic implements HasTick {
       this.events.emit('frame', {...this.currentFrame, frameIndex: this.currentFrameIndex });
     }
 
-    this._timeLeftInFrame -= elapsedMilliseconds * this.timeScale;
+    this._timeLeftInFrame -= elapsedMilliseconds * this._speed;
     if (this._timeLeftInFrame <= 0) {
       this.goToFrame(this._nextFrame());
     }

--- a/src/engine/Graphics/Animation.ts
+++ b/src/engine/Graphics/Animation.ts
@@ -296,6 +296,13 @@ export class Animation extends Graphic implements HasTick {
   }
 
   /**
+   * Returns the amount of time in milliseconds left in the current frame
+   */
+  public get currentFrameTimeLeft(): number {
+    return this._timeLeftInFrame;
+  }
+
+  /**
    * Returns `true` if the animation is playing
    */
   public get isPlaying(): boolean {
@@ -343,7 +350,7 @@ export class Animation extends Graphic implements HasTick {
   public reset(): void {
     this._done = false;
     this._firstTick = true;
-    this._currentFrame = 0;
+    this.goToFrame(0);
   }
 
   /**
@@ -373,14 +380,18 @@ export class Animation extends Graphic implements HasTick {
 
   /**
    * Jump the animation immediately to a specific frame if it exists
+   *
+   * Optionally specify an override for the duration of the frame, useful for
+   * keeping multiple animations in sync with one another.
    * @param frameNumber
+   * @param duration
    */
-  public goToFrame(frameNumber: number) {
+  public goToFrame(frameNumber: number, duration?: number) {
     this._currentFrame = frameNumber;
-    this._timeLeftInFrame = this.frameDuration;
+    this._timeLeftInFrame = duration ?? this.frameDuration;
     const maybeFrame = this.frames[this._currentFrame];
     if (maybeFrame && !this._done) {
-      this._timeLeftInFrame = maybeFrame?.duration || this.frameDuration;
+      this._timeLeftInFrame = duration ?? (maybeFrame?.duration || this.frameDuration);
       this.events.emit('frame', {...maybeFrame, frameIndex: this.currentFrameIndex });
     }
   }

--- a/src/engine/Graphics/Animation.ts
+++ b/src/engine/Graphics/Animation.ts
@@ -385,7 +385,12 @@ export class Animation extends Graphic implements HasTick {
   public reset(): void {
     this._done = false;
     this._firstTick = true;
-    this.goToFrame(0);
+    this._currentFrame = 0;
+    this._timeLeftInFrame = this.frameDuration;
+    const maybeFrame = this.frames[this._currentFrame];
+    if (maybeFrame) {
+      this._timeLeftInFrame = (maybeFrame?.duration || this.frameDuration);
+    }
   }
 
   /**

--- a/src/spec/AnimationSpec.ts
+++ b/src/spec/AnimationSpec.ts
@@ -547,4 +547,124 @@ describe('A Graphics Animation', () => {
     anim.tick(expectedFrameDuration, 2);
     expect(anim.currentFrame).toBe(anim.frames[0]);
   });
+
+  it('has a current time left in a frame', () => {
+
+    const rect = new ex.Rectangle({
+      width: 100,
+      height: 100,
+      color: ex.Color.Blue
+    });
+    const frames: ex.Frame[] = [
+      {
+        graphic: rect,
+        duration: 100
+      },
+      {
+        graphic: rect,
+        duration: 100
+      }
+    ];
+    const anim = new ex.Animation({
+      frames: frames
+    });
+    anim.play();
+    expect(anim.currentFrameIndex).toBe(0);
+    expect(anim.currentFrameTimeLeft).toBe(100);
+    anim.tick(10, 1);
+    expect(anim.currentFrameIndex).toBe(0);
+    expect(anim.currentFrameTimeLeft).toBe(90);
+    anim.tick(10, 2);
+    expect(anim.currentFrameIndex).toBe(0);
+    expect(anim.currentFrameTimeLeft).toBe(80);
+    anim.tick(80, 3);
+    expect(anim.currentFrameIndex).toBe(1);
+    expect(anim.currentFrameTimeLeft).toBe(100);
+  });
+
+  it('can go to a frame with an overridden duration', () => {
+    const rect = new ex.Rectangle({
+      width: 100,
+      height: 100,
+      color: ex.Color.Blue
+    });
+    const frames: ex.Frame[] = [
+      {
+        graphic: rect,
+        duration: 100
+      },
+      {
+        graphic: rect,
+        duration: 100
+      }
+    ];
+    const anim = new ex.Animation({
+      frames: frames
+    });
+    anim.play();
+    expect(anim.currentFrameIndex).toBe(0);
+    expect(anim.currentFrameTimeLeft).toBe(100);
+
+    anim.goToFrame(1, 50);
+    expect(anim.currentFrameIndex).toBe(1);
+    expect(anim.currentFrameTimeLeft).toBe(50);
+  });
+
+  it('can adjust playback speed', () => {
+    const rect = new ex.Rectangle({
+      width: 100,
+      height: 100,
+      color: ex.Color.Blue
+    });
+    const frames: ex.Frame[] = [
+      {
+        graphic: rect,
+        duration: 100
+      },
+      {
+        graphic: rect,
+        duration: 100
+      }
+    ];
+    const anim = new ex.Animation({
+      frames: frames,
+      speed: 2
+    });
+    anim.play();
+    expect(anim.currentFrameIndex).toBe(0);
+    expect(anim.currentFrameTimeLeft).toBe(100);
+
+    anim.tick(20, 1);
+    expect(anim.currentFrameIndex).toBe(0);
+    expect(anim.currentFrameTimeLeft).toBe(60);
+  });
+
+  it('can adjust playback speed (only positive', () => {
+    const rect = new ex.Rectangle({
+      width: 100,
+      height: 100,
+      color: ex.Color.Blue
+    });
+    const frames: ex.Frame[] = [
+      {
+        graphic: rect,
+        duration: 100
+      },
+      {
+        graphic: rect,
+        duration: 100
+      }
+    ];
+    const anim = new ex.Animation({
+      frames: frames
+    });
+    anim.speed = -100;
+    expect(anim.speed).toBe(100);
+
+    anim.speed = 0;
+    expect(anim.speed).toBe(0);
+
+    anim.speed = 100;
+    expect(anim.speed).toBe(100);
+  });
 });

--- a/src/spec/AnimationSpec.ts
+++ b/src/spec/AnimationSpec.ts
@@ -582,6 +582,36 @@ describe('A Graphics Animation', () => {
     expect(anim.currentFrameTimeLeft).toBe(100);
   });
 
+  it('reset will reset time in frame', () => {
+
+    const rect = new ex.Rectangle({
+      width: 100,
+      height: 100,
+      color: ex.Color.Blue
+    });
+    const frames: ex.Frame[] = [
+      {
+        graphic: rect,
+        duration: 100
+      },
+      {
+        graphic: rect,
+        duration: 100
+      }
+    ];
+    const anim = new ex.Animation({
+      frames: frames
+    });
+    anim.play();
+    expect(anim.currentFrameIndex).toBe(0);
+    expect(anim.currentFrameTimeLeft).toBe(100);
+    anim.tick(60, 1);
+    expect(anim.currentFrameIndex).toBe(0);
+    expect(anim.currentFrameTimeLeft).toBe(40);
+    anim.reset();
+    expect(anim.currentFrameTimeLeft).toBe(100);
+  });
+
   it('can go to a frame with an overridden duration', () => {
     const rect = new ex.Rectangle({
       width: 100,

--- a/src/spec/MaterialRendererSpec.ts
+++ b/src/spec/MaterialRendererSpec.ts
@@ -2,7 +2,7 @@ import * as ex from '@excalibur';
 import { TestUtils } from './util/TestUtils';
 import { ExcaliburAsyncMatchers } from 'excalibur-jasmine';
 
-fdescribe('A Material', () => {
+describe('A Material', () => {
   beforeAll(() => {
     jasmine.addAsyncMatchers(ExcaliburAsyncMatchers);
   });

--- a/src/spec/MaterialRendererSpec.ts
+++ b/src/spec/MaterialRendererSpec.ts
@@ -2,7 +2,7 @@ import * as ex from '@excalibur';
 import { TestUtils } from './util/TestUtils';
 import { ExcaliburAsyncMatchers } from 'excalibur-jasmine';
 
-describe('A Material', () => {
+fdescribe('A Material', () => {
   beforeAll(() => {
     jasmine.addAsyncMatchers(ExcaliburAsyncMatchers);
   });


### PR DESCRIPTION

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR adds new property and methods overloads to `ex.Animation`
  * `ex.Animation.currentFrameTimeLeft` will return the current time in milliseconds left in the current
  * `ex.Animation.goToFrame(frameNumber: number, duration?: number)` now accepts an optional duration for the target frame
