### PR TITLE
fix: Flatten composite colliders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed issue where nesting `ex.CompositeColliders` inside one another would cause a crash on collision
+- Fixed issue where `ex.CompositeColliders` did not respect collider offset
 - Fixed issue where parenting a entity with fixed updates on would cause a drawing flicker, transform interpolation now is aware of changing parents so it interpolates drawing continuously to prevent any flickering
 - `ex.Animation.reset()` did not properly reset all internal state
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where nesting `ex.CompositeColliders` inside one another would cause a crash on collision
 - Fixed issue where parenting a entity with fixed updates on would cause a drawing flicker, transform interpolation now is aware of changing parents so it interpolates drawing continuously to prevent any flickering
 - `ex.Animation.reset()` did not properly reset all internal state
 

--- a/src/engine/Collision/Colliders/CompositeCollider.ts
+++ b/src/engine/Collision/Colliders/CompositeCollider.ts
@@ -39,7 +39,7 @@ export class CompositeCollider extends Collider {
       colliders = [collider];
     }
     // Flatten composites
-    for (let c of colliders) {
+    for (const c of colliders) {
       c.events.pipe(this.events);
       c.__compositeColliderId = this.id;
       this._colliders.push(c);
@@ -252,10 +252,12 @@ export class CompositeCollider extends Collider {
     for (const collider of colliders) {
       collider.debug(ex, color, options);
     }
-    ex.restore()
+    ex.restore();
   }
 
   clone(): Collider {
-    return new CompositeCollider(this._colliders.map((c) => c.clone()));
+    const result = new CompositeCollider(this._colliders.map((c) => c.clone()));
+    result.offset = this.offset.clone();
+    return result;
   }
 }

--- a/src/spec/CompositeColliderSpec.ts
+++ b/src/spec/CompositeColliderSpec.ts
@@ -1,7 +1,7 @@
 import * as ex from '@excalibur';
 import { BoundingBox, GameEvent, LineSegment, Projection, Ray, vec, Vector } from '@excalibur';
 import { ExcaliburAsyncMatchers, ExcaliburMatchers } from 'excalibur-jasmine';
-fdescribe('A CompositeCollider', () => {
+describe('A CompositeCollider', () => {
   beforeAll(() => {
     jasmine.addAsyncMatchers(ExcaliburAsyncMatchers);
     jasmine.addMatchers(ExcaliburMatchers);

--- a/src/spec/CompositeColliderSpec.ts
+++ b/src/spec/CompositeColliderSpec.ts
@@ -1,7 +1,7 @@
 import * as ex from '@excalibur';
 import { BoundingBox, GameEvent, LineSegment, Projection, Ray, vec, Vector } from '@excalibur';
 import { ExcaliburAsyncMatchers, ExcaliburMatchers } from 'excalibur-jasmine';
-describe('A CompositeCollider', () => {
+fdescribe('A CompositeCollider', () => {
   beforeAll(() => {
     jasmine.addAsyncMatchers(ExcaliburAsyncMatchers);
     jasmine.addMatchers(ExcaliburMatchers);
@@ -277,5 +277,27 @@ describe('A CompositeCollider', () => {
 
     dynamicTreeProcessor.untrack(compCollider);
     expect(dynamicTreeProcessor.getColliders().length).toBe(0);
+  });
+
+  it('flattens composite colliders inside composite colliders with adjusted offset', () => {
+    const compCollider = new ex.CompositeCollider([ex.Shape.Circle(50), ex.Shape.Box(200, 10, Vector.Half)]);
+    compCollider.offset = ex.vec(50, 100);
+    expect(compCollider.getColliders()[0].offset).toBeVector(Vector.Zero);
+    expect(compCollider.getColliders()[1].offset).toBeVector(Vector.Zero);
+
+    const sut = new ex.CompositeCollider([]);
+
+    sut.addCollider(compCollider);
+
+    expect(sut.getColliders().length).toBe(2);
+    expect(sut.getColliders()[0].offset).toBeVector(compCollider.offset);
+    expect(sut.getColliders()[1].offset).toBeVector(compCollider.offset);
+  });
+
+  it('has the correct bounds when offset', () => {
+    const compCollider = new ex.CompositeCollider([ex.Shape.Circle(50), ex.Shape.Box(200, 10, Vector.Half)]);
+    expect(compCollider.bounds).toEqual(new ex.BoundingBox({left: -100, right: 100, top: -50, bottom: 50}));
+    compCollider.offset = ex.vec(50, 100);
+    expect(compCollider.bounds).toEqual(new ex.BoundingBox({left: -50, right: 150, top: 50, bottom: 150}));
   });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR fixes an issue where `CompositeColliders` nested inside each other would cause a crash at runtime because the narrowphase doesn't know how to collide with composites, only pieces.

The fix flattens composites so they can only ever be 1 level deep.