### PR TITLE
fix: Empty label constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where an empty constructor on `new ex.Label()` would crash
 - Fixed issue where pointer events did not work properly when using [[ScreenElement]]s
 - Fixed issue where debug draw was not accurate when using *AndFill suffixed [[DisplayMode]]s
 

--- a/src/engine/Label.ts
+++ b/src/engine/Label.ts
@@ -99,7 +99,7 @@ export class Label extends Actor {
    */
   constructor(options?: LabelOptions & ActorArgs) {
     super(options);
-    const {text, pos, x, y, spriteFont, font, color} = options;
+    const {text, pos, x, y, spriteFont, font, color} = { text: '', ...options };
 
     this.pos = pos ?? (x && y ? vec(x, y) : this.pos);
     this.text = text ?? this.text;

--- a/src/spec/LabelSpec.ts
+++ b/src/spec/LabelSpec.ts
@@ -24,6 +24,12 @@ describe('A label', () => {
     expect(sut).not.toBeNull();
   });
 
+  it('can construct with empty text', () => {
+    expect(() => {
+      const sut = new ex.Label();
+    }).not.toThrow();
+  });
+
   it('can be constructed with a font', () => {
     const sut = new ex.Label({
       text: 'some text',


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Fixes an issue where an empty label constructor would crash `new ex.Label()` brought on the discord