### PR TITLE
fix: Allow CSS transforms on canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where using CSS transforms on the canvas confused Excalibur pointers
 - Fixed issue with *AndFill suffixed [[DisplayModes]]s where content area offset was not accounted for in world space
 - Fixed issue where `ex.Sound.getTotalPlaybackDuration()` would crash if not loaded, now logs friendly warning
 - Fixed issue where an empty constructor on `new ex.Label()` would crash

--- a/sandbox/tests/pointer/index.html
+++ b/sandbox/tests/pointer/index.html
@@ -5,6 +5,14 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Pointer</title>
+  <style>
+    canvas {
+      position: relative;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, 50%);
+    }
+  </style>
 </head>
 <body>
   <p>Click on the squares to see events propagate in z order in the console. The black square cancels the event preventing propagation.</p>

--- a/sandbox/tests/pointer/pointer.ts
+++ b/sandbox/tests/pointer/pointer.ts
@@ -66,7 +66,7 @@ var game2 = new Game2({
   width: 600,
   height: 400,
   antialiasing: false,
-  displayMode: ex.DisplayMode.FitScreenAndFill
+  displayMode: ex.DisplayMode.Fixed
 });
 game2.debug.collider.showBounds = true;
 game2.debug.graphics.showBounds = true;

--- a/src/engine/Util/Util.ts
+++ b/src/engine/Util/Util.ts
@@ -1,4 +1,4 @@
-import { Vector } from '../Math/vector';
+import { Vector, vec } from '../Math/vector';
 import { Clock } from './Clock';
 import { Future } from './Future';
 
@@ -6,27 +6,9 @@ import { Future } from './Future';
  * Find the screen position of an HTML element
  */
 export function getPosition(el: HTMLElement): Vector {
-  let oLeft: number = 0,
-    oTop: number = 0;
-
-  const calcOffsetLeft = (parent: HTMLElement) => {
-    oLeft += parent.offsetLeft;
-
-    if (parent.offsetParent) {
-      calcOffsetLeft(<HTMLElement>parent.offsetParent);
-    }
-  };
-  const calcOffsetTop = (parent: HTMLElement) => {
-    oTop += parent.offsetTop;
-    if (parent.offsetParent) {
-      calcOffsetTop(<HTMLElement>parent.offsetParent);
-    }
-  };
-
-  calcOffsetLeft(el);
-  calcOffsetTop(el);
-
-  return new Vector(oLeft, oTop);
+  // do we need the scroll too? technically the offset method before did that
+  const rect = el.getBoundingClientRect();
+  return vec(rect.x + window.scrollX, rect.y + window.scrollY);
 }
 
 /**


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR fixes an issue where CSS transforms confused the excalibur pointer system and caused clicks to land in the wrong spot