### PR TITLE
fix: Fire collisionend when collider deleted + Composite collision start/end strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added additional data `side` and `lastContact` to `onCollisionEnd` and `collisionend` events
+- Added configuration option to `ex.PhysicsConfig` to configure composite collider onCollisionStart/End behavior
 - Added configuration option to `ex.TileMap({ meshingLookBehind: Infinity })` which allows users to configure how far the TileMap looks behind for matching colliders (default is 10).
 - Added Arcade Collision Solver bias to help mitigate seams in geometry that can cause problems for certain games.
   - `ex.ContactSolveBias.None` No bias, current default behavior collisions are solved in the default distance order
@@ -203,6 +205,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+-  Fixes an issue where a collider that was part of a contact that was deleted did not fire a collision end event, this was unexpected
+- Fixes an issue where you may want to have composite colliders behave as constituent colliders for the purposes of start/end collision events. A new property is added to physics config, the current behavior is the default which is `'together'`, this means the whole composite collider is treated as 1 collider for onCollisionStart/onCollisionEnd. Now you can configure a `separate` which will fire onCollisionStart/onCollisionEnd for every separate collider included in the composite (useful if you are building levels or things with gaps that you need to disambiguate). You can also configure this on a per composite level to mix and match `CompositeCollider.compositeStrategy`
 - Fixed issue where particles would have an errant draw if using a particle sprite
 - Fixed issue where a null/undefined graphics group member graphic would cause a crash, now logs a warning.
 - Fixed issue where Actor built in components could not be extended because of the way the Actor based type was built.

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -53,12 +53,15 @@ var game = new ex.Engine({
   pointerScope: ex.PointerScope.Canvas,
   displayMode: ex.DisplayMode.FitScreenAndFill,
   snapToPixel: false,
-  fixedUpdateFps: 30,
+  fixedUpdateFps: 60,
   maxFps: 60,
   antialiasing: false,
   uvPadding: 0,
   physics: {
-    solver: ex.SolverStrategy.Realistic,
+    colliders: {
+      compositeStrategy: 'together'
+    },
+    solver: ex.SolverStrategy.Arcade,
     gravity: ex.vec(0, 20),
     arcade: {
       contactSolveBias: ex.ContactSolveBias.VerticalFirst
@@ -578,8 +581,8 @@ player.on('collisionstart', () => {
   console.log('collision start');
 });
 
-player.on('collisionend', () => {
-  console.log('collision end');
+player.on('collisionend', (e) => {
+  console.log('collision end', e.other.collider);
 });
 
 // Health bar example

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -973,8 +973,10 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
    * Fires once when 2 entities with a ColliderComponent separate after having been in contact.
    * @param self
    * @param other
+   * @param side
+   * @param lastContact
    */
-  public onCollisionEnd(self: Collider, other: Collider) {
+  public onCollisionEnd(self: Collider, other: Collider, side: Side, lastContact: CollisionContact) {
     // Override me
   }
 

--- a/src/engine/Collision/ColliderComponent.ts
+++ b/src/engine/Collision/ColliderComponent.ts
@@ -58,15 +58,22 @@ export class ColliderComponent extends Component {
     return collider;
   }
 
+  private _collidersToRemove: Collider[] = [];
   /**
    * Remove collider geometry from collider component
    */
   public clear() {
     if (this._collider) {
-      this._collider.events.unpipe(this.events);
-      this.$colliderRemoved.notifyAll(this._collider);
-      this._collider.owner = null;
+      this._collidersToRemove.push(this._collider);
       this._collider = null;
+    }
+  }
+
+  public processColliderRemoval() {
+    for (const collider of this._collidersToRemove) {
+      collider.events.unpipe(this.events);
+      this.$colliderRemoved.notifyAll(collider);
+      collider.owner = null;
     }
   }
 
@@ -187,9 +194,9 @@ export class ColliderComponent extends Component {
     });
     this.events.on('collisionend', (evt: any) => {
       const end = evt as CollisionEndEvent<Collider>;
-      entity.events.emit('collisionend', new CollisionEndEvent(end.target.owner, end.other.owner));
+      entity.events.emit('collisionend', new CollisionEndEvent(end.target.owner, end.other.owner, end.side, end.lastContact));
       if (entity instanceof Actor) {
-        entity.onCollisionEnd(end.target, end.other);
+        entity.onCollisionEnd(end.target, end.other, end.side, end.lastContact);
       }
     });
   }

--- a/src/engine/Collision/Colliders/Collider.ts
+++ b/src/engine/Collision/Colliders/Collider.ts
@@ -12,6 +12,7 @@ import { ExcaliburGraphicsContext } from '../../Graphics/Context/ExcaliburGraphi
 import { Transform } from '../../Math/transform';
 import { EventEmitter } from '../../EventEmitter';
 import { RayCastHit } from '../Detection/RayCastHit';
+import { CompositeCollider } from './CompositeCollider';
 
 /**
  * A collision collider specifies the geometry that can detect when other collision colliders intersect
@@ -21,11 +22,11 @@ export abstract class Collider implements Clonable<Collider> {
   private static _ID = 0;
   public readonly id: Id<'collider'> = createId('collider', Collider._ID++);
   /**
-   * Excalibur uses this to signal to the [[CollisionSystem]] this is part of a composite collider
-   * @internal
-   * @hidden
+   * Composite collider if any this collider is attached to
+   *
+   * **WARNING** do not tamper with this property
    */
-  public __compositeColliderId: Id<'collider'> | null = null;
+  public composite: CompositeCollider | null = null;
   public events = new EventEmitter();
 
   /**

--- a/src/engine/Collision/Colliders/PolygonCollider.ts
+++ b/src/engine/Collision/Colliders/PolygonCollider.ts
@@ -43,16 +43,21 @@ export class PolygonCollider extends Collider {
    */
   public offset: Vector;
 
+  public flagDirty() {
+    this._localBoundsDirty = true;
+    this._localSidesDirty = true;
+    this._sidesDirty = true;
+  }
+
   private _points: Vector[];
+
   /**
    * Points in the polygon in order around the perimeter in local coordinates. These are relative from the body transform position.
    * Excalibur stores these in counter-clockwise order
    */
   public set points(points: Vector[]) {
-    this._localBoundsDirty = true;
-    this._localSidesDirty = true;
-    this._sidesDirty = true;
     this._points = points;
+    this.flagDirty();
   }
 
   /**

--- a/src/engine/Collision/Detection/CollisionContact.ts
+++ b/src/engine/Collision/Detection/CollisionContact.ts
@@ -76,11 +76,11 @@ export class CollisionContact {
     this.localPoints = localPoints;
     this.info = info;
     this.id = Pair.calculatePairHash(colliderA.id, colliderB.id);
-    if (colliderA.__compositeColliderId || colliderB.__compositeColliderId) {
-      // Add on the parent composite pair for start/end contact
-      this.id += '|' + Pair.calculatePairHash(
-        colliderA.__compositeColliderId ?? colliderA.id,
-        colliderB.__compositeColliderId ?? colliderB.id);
+    if (colliderA.composite || colliderB.composite) {
+      // Add on the parent composite pair for start/end contact if 'together
+      const colliderAId = colliderA.composite?.compositeStrategy === 'separate' ? colliderA.id : colliderA.composite?.id ?? colliderA.id;
+      const colliderBId = colliderB.composite?.compositeStrategy === 'separate' ? colliderB.id : colliderB.composite?.id ?? colliderB.id;
+      this.id += '|' + Pair.calculatePairHash(colliderAId, colliderBId);
     }
   }
 

--- a/src/engine/Collision/PhysicsConfig.ts
+++ b/src/engine/Collision/PhysicsConfig.ts
@@ -35,14 +35,16 @@ export interface PhysicsConfig {
    */
   colliders?: {
     /**
-     * Default treat composite collider's individual colliders as either separate colliders for the purposes of onCollisionStart/onCollision
+     * Treat composite collider's member colliders as either separate colliders for the purposes of onCollisionStart/onCollision
      * or as a single collider together.
      *
-     * This property can be overridden on individual composites
+     * This property can be overridden on individual [[CompositeColliders]].
      *
-     * For composites without gaps, you probably want together
+     * For composites without gaps or small groups of colliders, you probably want 'together'
      *
-     * For composites with gaps, like a platforming level layout, you probably want separate treatment
+     * For composites with deliberate gaps, like a platforming level layout, you probably want 'separate'
+     *
+     * Default is 'together' if unset
      */
     compositeStrategy?: 'separate' | 'together'
   }

--- a/src/engine/Collision/PhysicsConfig.ts
+++ b/src/engine/Collision/PhysicsConfig.ts
@@ -31,6 +31,23 @@ export interface PhysicsConfig {
   solver?: SolverStrategy;
 
   /**
+   * Configure colliders
+   */
+  colliders?: {
+    /**
+     * Default treat composite collider's individual colliders as either separate colliders for the purposes of onCollisionStart/onCollision
+     * or as a single collider together.
+     *
+     * This property can be overridden on individual composites
+     *
+     * For composites without gaps, you probably want together
+     *
+     * For composites with gaps, like a platforming level layout, you probably want separate treatment
+     */
+    compositeStrategy?: 'separate' | 'together'
+  }
+
+  /**
    * Configure excalibur continuous collision (WIP)
    */
   continuous?: {
@@ -183,6 +200,9 @@ export const DefaultPhysicsConfig: DeepRequired<PhysicsConfig> = {
   enabled: true,
   gravity: vec(0, 0),
   solver: SolverStrategy.Arcade,
+  colliders: {
+    compositeStrategy: 'together'
+  },
   continuous: {
     checkForFastBodies: true,
     disableMinimumSpeedForFastBody: false,
@@ -223,6 +243,9 @@ export function DeprecatedStaticToConfig(): DeepRequired<PhysicsConfig> {
       checkForFastBodies: Physics.checkForFastBodies,
       disableMinimumSpeedForFastBody: Physics.disableMinimumSpeedForFastBody,
       surfaceEpsilon: Physics.surfaceEpsilon
+    },
+    colliders: {
+      compositeStrategy: 'together'
     },
     bodies: {
       canSleepByDefault: Physics.bodiesCanSleepByDefault,

--- a/src/engine/Events.ts
+++ b/src/engine/Events.ts
@@ -451,7 +451,7 @@ export class ContactStartEvent<T> {
 }
 
 export class ContactEndEvent<T> {
-  constructor(public target: T, public other: T) {}
+  constructor(public target: T, public other: T, public side: Side, public lastContact: CollisionContact) {}
 }
 
 export class CollisionPreSolveEvent<T> {
@@ -494,7 +494,7 @@ export class CollisionEndEvent<T extends BodyComponent | Collider | Entity = Act
   /**
    *
    */
-  constructor(actor: T, public other: T) {
+  constructor(actor: T, public other: T, public side: Side, public lastContact: CollisionContact) {
     super();
     this.target = actor;
   }

--- a/src/spec/ColliderComponentSpec.ts
+++ b/src/spec/ColliderComponentSpec.ts
@@ -97,6 +97,7 @@ describe('A ColliderComponent', () => {
     expect(collider.owner).not.toBeNull();
 
     comp.clear();
+    comp.processColliderRemoval();
 
     expect(comp.get()).toBeNull();
     expect(collider.events.unpipe).toHaveBeenCalled();

--- a/src/spec/CompositeColliderSpec.ts
+++ b/src/spec/CompositeColliderSpec.ts
@@ -158,6 +158,23 @@ describe('A CompositeCollider', () => {
       ex.Pair.calculatePairHash(compCollider.id, circle.id));
   });
 
+  it('creates contacts that have the don\'t have composite collider id when in separate mode', () => {
+    const compCollider = new ex.CompositeCollider([ex.Shape.Circle(50), ex.Shape.Box(200, 10, Vector.Half)]);
+    compCollider.compositeStrategy = 'separate';
+
+    const circle = ex.Shape.Circle(50);
+    const xf = new ex.Transform();
+    xf.pos = vec(149, 0);
+    circle.update(xf);
+
+    const contactBoxCircle = compCollider.collide(circle);
+    // Composite collisions have a special id that appends the "parent" id to the id to accurately track start/end
+    expect(contactBoxCircle[0].id).toBe(
+      ex.Pair.calculatePairHash(compCollider.getColliders()[1].id, circle.id) +
+      '|' +
+      ex.Pair.calculatePairHash(compCollider.getColliders()[1].id, circle.id));
+  });
+
   it('can collide with other composite colliders', () => {
     const compCollider1 = new ex.CompositeCollider([ex.Shape.Circle(50), ex.Shape.Box(200, 10, Vector.Half)]);
 


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

One stealth feature 
* onCollisionEnd events now include the last side and contact which is useful for collision logic

This PR fixes 2 issues:

1. Fixes an issue where a collider that was part of a contact that was deleted did not fire a collision end event, this was unexpected
2. Fixes an issue where you may want to have composite colliders behave as constituent colliders for the purposes of start/end collision events. A new property is added to physics config, the current behavior is the default which is `'together'`, this means the whole composite collider is treated as 1 collider for onCollisionStart/onCollisionEnd. Now you can configure a `separate` which will fire onCollisionStart/onCollisionEnd for every separate collider included in the composite (useful if you are building levels or things with gaps that you need to disambiguate). You can also configure this on a per composite level to mix and match `CompositeCollider.compositeStrategy`
![image](https://github.com/excaliburjs/Excalibur/assets/612071/e1a9c954-8a39-4402-bee6-dad9b42f9c08)

  