### PR TITLE
fix: [#2933] Children inherit their coordinate plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixes issue where mis-matched coordinate planes on parent/children caused bizarre issues. Now children are forced to inherit their parent's coordinate plane, it will always be the coordinate plane of the top most parent.
 - Fixed issue with Log ScreenAppender utility where it was not positioned correctly, you can now deeply configure it!
   ```typescript
   export interface ScreenAppenderOptions {

--- a/src/spec/TransformComponentSpec.ts
+++ b/src/spec/TransformComponentSpec.ts
@@ -298,7 +298,8 @@ describe('A TransformComponent', () => {
     // Can't change and logs warning
     child2.get(TransformComponent).coordPlane = ex.CoordPlane.World;
     expect(child2.get(TransformComponent).coordPlane).toBe(ex.CoordPlane.Screen);
-    expect(logger.warn).toHaveBeenCalledOnceWith('Cannot set coordinate plane on child entity Entity#1, children inherit their coordinate plane from their parents.');
+    expect(logger.warn).toHaveBeenCalledOnceWith(
+      'Cannot set coordinate plane on child entity Entity#1, children inherit their coordinate plane from their parents.');
   });
 
   it('can be cloned', () => {

--- a/src/spec/TransformComponentSpec.ts
+++ b/src/spec/TransformComponentSpec.ts
@@ -267,6 +267,40 @@ describe('A TransformComponent', () => {
     expect(child2.get(TransformComponent).get().parent).toBe(null);
   });
 
+  it('children inherit the top most parent coordinate plane', () => {
+    const logger = ex.Logger.getInstance();
+    spyOn(logger, 'warn');
+    const child1 = new ex.Entity([new TransformComponent]);
+    const child2 = new ex.Entity([new TransformComponent]);
+    const parent = new ex.Entity([new TransformComponent]);
+    const grandParent = new ex.Entity([new TransformComponent]);
+
+    parent.addChild(child1);
+    parent.addChild(child2);
+    grandParent.addChild(parent);
+
+    expect(child1.children).toEqual([]);
+    expect(parent.children).toEqual([child1, child2]);
+    expect(grandParent.children).toEqual([parent]);
+
+    // inherits top most parent
+    grandParent.get(TransformComponent).coordPlane = ex.CoordPlane.World;
+    expect(parent.get(TransformComponent).coordPlane).toBe(ex.CoordPlane.World);
+    expect(child1.get(TransformComponent).coordPlane).toBe(ex.CoordPlane.World);
+    expect(child2.get(TransformComponent).coordPlane).toBe(ex.CoordPlane.World);
+
+    // inherits top most parent
+    grandParent.get(TransformComponent).coordPlane = ex.CoordPlane.Screen;
+    expect(parent.get(TransformComponent).coordPlane).toBe(ex.CoordPlane.Screen);
+    expect(child1.get(TransformComponent).coordPlane).toBe(ex.CoordPlane.Screen);
+    expect(child2.get(TransformComponent).coordPlane).toBe(ex.CoordPlane.Screen);
+
+    // Can't change and logs warning
+    child2.get(TransformComponent).coordPlane = ex.CoordPlane.World;
+    expect(child2.get(TransformComponent).coordPlane).toBe(ex.CoordPlane.Screen);
+    expect(logger.warn).toHaveBeenCalledOnceWith('Cannot set coordinate plane on child entity Entity#1, children inherit their coordinate plane from their parents.');
+  });
+
   it('can be cloned', () => {
     const transform = new TransformComponent();
     const owner = new ex.Entity([transform]);

--- a/src/spec/TransformComponentSpec.ts
+++ b/src/spec/TransformComponentSpec.ts
@@ -271,7 +271,7 @@ describe('A TransformComponent', () => {
     const logger = ex.Logger.getInstance();
     spyOn(logger, 'warn');
     const child1 = new ex.Entity([new TransformComponent]);
-    const child2 = new ex.Entity([new TransformComponent]);
+    const child2 = new ex.Entity([new TransformComponent], 'child2');
     const parent = new ex.Entity([new TransformComponent]);
     const grandParent = new ex.Entity([new TransformComponent]);
 
@@ -298,8 +298,8 @@ describe('A TransformComponent', () => {
     // Can't change and logs warning
     child2.get(TransformComponent).coordPlane = ex.CoordPlane.World;
     expect(child2.get(TransformComponent).coordPlane).toBe(ex.CoordPlane.Screen);
-    expect(logger.warn).toHaveBeenCalledOnceWith(
-      'Cannot set coordinate plane on child entity Entity#1, children inherit their coordinate plane from their parents.');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Cannot set coordinate plane on child entity child2, children inherit their coordinate plane from their parents.');
   });
 
   it('can be cloned', () => {


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #2933

This PR forces children to inherit their parent's coordinate plane, it will always be the coordinate plane of the top most parent.
