### PR TITLE
fix: Firefox + Linux custom shader issue with glsl compiler attribute optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where Firefox on Linux would throw an error when using custom Materials due to unused attributes caused by glsl compiler optimization. 
 - Fixed issue where start transition did not work properly if deferred
 - Fixed issue where transitions did not cover the whole screen if camera was zoomed
 

--- a/src/engine/Graphics/Context/material.ts
+++ b/src/engine/Graphics/Context/material.ts
@@ -50,6 +50,7 @@ export interface MaterialOptions {
    * Pre-built varyings:
    *
    * * `in vec2 v_uv` - UV coordinate
+   * * `in vec2 v_screenuv` - UV coordinate
    *
    * Pre-built uniforms:
    *

--- a/src/engine/Graphics/Context/webgl-util.ts
+++ b/src/engine/Graphics/Context/webgl-util.ts
@@ -20,6 +20,62 @@ export function getGlTypeSizeBytes(gl: WebGLRenderingContext, type: number): num
   }
 }
 
+/**
+ * Checks if an attribute is present in vertex source
+ */
+export function isAttributeInSource(source: string, variable: string) {
+  const attributeRegexTemplate = `(?<type>[a-z0-9]+)\\s+${variable};`;
+  const regex = new RegExp(attributeRegexTemplate, 'g');
+  const matches = regex.exec(source);
+  return matches?.length > 0;
+}
+
+/**
+ * Attempt to discern the glType of an attribute from vertex source
+ * @param gl
+ * @param source
+ * @param variable
+ */
+export function getGLTypeFromSource(gl: WebGLRenderingContext, source: string, variable: string) {
+  const attributeRegexTemplate = `(?<type>[a-z0-9]+)\\s+${variable};`;
+  const regex = new RegExp(attributeRegexTemplate, 'g');
+  const matches = regex.exec(source);
+  const type = matches?.groups?.type;
+
+  switch (type) {
+    case 'float':
+    case 'vec2':
+    case 'vec3':
+    case 'vec4':
+      return gl.FLOAT;
+    case 'int':
+    case 'ivec2':
+    case 'ivec3':
+    case 'ivec4':
+      return gl.INT;
+    case 'uint':
+    case 'uvec2':
+    case 'uvec3':
+    case 'uvec4':
+      return gl.UNSIGNED_INT;
+    case 'bool':
+    case 'bvec2':
+    case 'bvec3':
+    case 'bvec4':
+      return gl.BOOL;
+    case 'short':
+      return gl.SHORT;
+    case 'ushort':
+      return gl.UNSIGNED_SHORT;
+    case 'ubyte':
+      return gl.UNSIGNED_BYTE;
+    case 'byte':
+      return gl.BYTE;
+    default:
+      return gl.FLOAT;
+  }
+}
+
 
 /**
  * Based on the type return the number of attribute components

--- a/src/spec/VertexLayoutSpec.ts
+++ b/src/spec/VertexLayoutSpec.ts
@@ -210,7 +210,7 @@ describe('A VertexLayout', () => {
     }).toThrowMatching((e: Error) => e.message.includes('VertexLayout size definition for attribute: [a_position, 4]'));
   });
 
-  it('will calculate vertex size and webgl vbo corretly', () => {
+  it('will calculate vertex size and webgl vbo correctly', () => {
     const shader = new ex.Shader({
       gl,
       vertexSource: `


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR fixes an issue where Firefox on Linux would throw an error when using custom Materials due to unused attributes caused by glsl compiler optimization.


Before it would throw and crash excalibur

![image](https://github.com/excaliburjs/Excalibur/assets/612071/6b6a3f55-d260-4663-92d7-39ac8e3aa497)

Now after, it will log a warning because this is potentially a bug, or at minimum something you should look at

![image](https://github.com/excaliburjs/Excalibur/assets/612071/4eb162c2-b559-4923-81e7-8723b758de36)


