### PR TITLE
fix: Handle webgl context lost + Recover from hidpi scale too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `GraphicsComponent.bounds` which will report the world bounds of the graphic if applicable!
 - Added `ex.Vector.EQUALS_EPSILON` to configure the `ex.Vector.equals(v)` threshold
+- Added way to add custom WebGL context lost/recovered handlers for your game
+  ```typescript
+  const game = new ex.Engine({
+    handleContextLost: (e) => {...},
+    handleContextRestored: (e) => {...}
+  })
+  ```
 
 ### Fixed
 
+- Fixed issue when WebGL context lost occurs where there was no friendly output to the user
+- Fixed issue where HiDPI scaling could accidentally scale past the 4k mobile limit, if the context would scale too large it will now attempt to recover by backing off.
 - Fixed issue where `ex.ParticleEmitter` z-index did not propagate to particles
 - Fixed incongruent behavior as small scales when setting `transform.scale = v` and `transform.scale.setTo(x, y)`
 - Fixed `ex.coroutine` TypeScript type to include yielding `undefined`

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -516,15 +516,16 @@ export class Screen {
 
         // Attempt to recover if the user hasn't configured a specific ratio for up scaling
         if (!this.pixelRatioOverride) {
-          let currentPixelRatio = this.pixelRatio - .5;
-          while (!this.graphicsContext.checkIfResolutionSupported({
-            width: this._resolution.width * currentPixelRatio,
-            height: this._resolution.height * currentPixelRatio})) {
-            currentPixelRatio -= .5;
+          let currentPixelRatio = Math.min(1, this.pixelRatio - .5);
+          while (currentPixelRatio > 1 &&
+            !this.graphicsContext.checkIfResolutionSupported({
+              width: this._resolution.width * currentPixelRatio,
+              height: this._resolution.height * currentPixelRatio})) {
+            currentPixelRatio = Math.min(1, this.pixelRatio - .5);
           }
           this.pixelRatioOverride = currentPixelRatio;
           this._logger.warnOnce(
-            'Scaled resolution too big recovery!' +
+            'Scaled resolution too big attempted recovery!' +
             ` Pixel ratio was automatically reduced to (${this.pixelRatio}) to avoid 4k texture limit.` +
             ' Setting `ex.Engine({pixelRatio: ...}) will override any automatic recalculation, do so at your own risk.` ' +
             ' (read more here https://excaliburjs.com/docs/screens#understanding-viewport--resolution).');

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -516,12 +516,13 @@ export class Screen {
 
         // Attempt to recover if the user hasn't configured a specific ratio for up scaling
         if (!this.pixelRatioOverride) {
-          let currentPixelRatio = Math.min(1, this.pixelRatio - .5);
-          while (currentPixelRatio > 1 &&
-            !this.graphicsContext.checkIfResolutionSupported({
-              width: this._resolution.width * currentPixelRatio,
-              height: this._resolution.height * currentPixelRatio})) {
-            currentPixelRatio = Math.min(1, this.pixelRatio - .5);
+          let currentPixelRatio = Math.max(1, this.pixelRatio - .5);
+          let newResolutionSupported = false;
+          while (currentPixelRatio > 1 && !newResolutionSupported) {
+            currentPixelRatio = Math.max(1, currentPixelRatio - .5);
+            const width = this._resolution.width * currentPixelRatio;
+            const height = this._resolution.height * currentPixelRatio;
+            newResolutionSupported = this.graphicsContext.checkIfResolutionSupported({ width, height });
           }
           this.pixelRatioOverride = currentPixelRatio;
           this._logger.warnOnce(

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -489,23 +489,41 @@ export class Screen {
     }
   }
 
-  public applyResolutionAndViewport() {
-    this._canvas.width = this.scaledWidth;
-    this._canvas.height = this.scaledHeight;
 
+
+  public applyResolutionAndViewport() {
     if (this.graphicsContext instanceof ExcaliburGraphicsContextWebGL) {
-      const supported = this.graphicsContext.checkIfResolutionSupported({
+      const scaledResolutionSupported = this.graphicsContext.checkIfResolutionSupported({
         width: this.scaledWidth,
         height: this.scaledHeight
       });
-      if (!supported) {
+      if (!scaledResolutionSupported) {
         this._logger.warnOnce(
           `The currently configured resolution (${this.resolution.width}x${this.resolution.height}) and pixel ratio (${this.pixelRatio})` +
           ' are too large for the platform WebGL implementation, this may work but cause WebGL rendering to behave oddly.' +
           ' Try reducing the resolution or disabling Hi DPI scaling to avoid this' +
           ' (read more here https://excaliburjs.com/docs/screens#understanding-viewport--resolution).');
+
+        // Attempt to recover if the user hasn't configured a specific ratio for up scaling
+        if (!this.pixelRatioOverride) {
+          let currentPixelRatio = this.pixelRatio - .5;
+          while (!this.graphicsContext.checkIfResolutionSupported({
+            width: this._resolution.width * currentPixelRatio,
+            height: this._resolution.height * currentPixelRatio})) {
+            currentPixelRatio -= .5;
+          }
+          this.pixelRatioOverride = currentPixelRatio;
+          this._logger.warnOnce(
+            'Scaled resolution too big recovery!' +
+            ` Pixel ratio was automatically reduced to (${this.pixelRatio}) to avoid 4k texture limit.` +
+            ' Setting `ex.Engine({pixelRatio: ...}) will override any automatic recalculation, do so at your own risk.` ' +
+            ' (read more here https://excaliburjs.com/docs/screens#understanding-viewport--resolution).');
+        }
       }
     }
+
+    this._canvas.width = this.scaledWidth;
+    this._canvas.height = this.scaledHeight;
 
     if (this._canvasImageRendering === 'auto') {
       this._canvas.style.imageRendering = 'auto';


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR addresses some issues with webgl contexts

- Fixed issue when WebGL context lost occurs where there was no friendly output to the user
- Fixed issue where HiDPI scaling could accidentally scale past the 4k mobile limit, if the context would scale too large it will now attempt to recover by backing off.
- Added way to add custom WebGL context lost/recovered handlers for your game
  ```typescript
  const game = new ex.Engine({
    handleContextLost: (e) => {...},
    handleContextRestored: (e) => {...}
  })
  ```

Default context lost screen 

![image](https://github.com/excaliburjs/Excalibur/assets/612071/92b20772-7ce9-4099-86aa-d174d561044e)
