### PR TITLE
fix: fit content resizing incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where logo was sometimes not loaded during `ex.Loader`
+- Fixed issue where unbounded containers would grow infinitely when using the following display modes:
+  * `DisplayMode.FillContainer`
+  * `DisplayMode.FitContainer`
+  * `DisplayMode.FitContainerAndFill`
+  * `DisplayMode.FitContainerAndZoom`
 - Fixed issue where `ex.ParticleEmitter` z-index did not propagate to particles
 - Fixed incongruent behavior as small scales when setting `transform.scale = v` and `transform.scale.setTo(x, y)`
 - Fixed `ex.coroutine` TypeScript type to include yielding `undefined`
@@ -34,7 +40,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
--
+- Simplified `ex.Loader` viewport/resolution internal configuration
 
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->
 <!--------------------------------- DO NOT EDIT BELOW THIS LINE --------------------------------->

--- a/src/engine/Director/Loader.ts
+++ b/src/engine/Director/Loader.ts
@@ -319,8 +319,9 @@ export class Loader extends DefaultLoader {
 
   private _configuredPixelRatio: number | null = null;
   public override async onBeforeLoad(): Promise<void> {
+    const image = this._image;
     await this._imageLoaded.promise;
-    await this._image?.decode(); // decode logo if it exists
+    await image?.decode(); // decode logo if it exists
   }
 
   // eslint-disable-next-line require-await

--- a/src/engine/Director/Loader.ts
+++ b/src/engine/Director/Loader.ts
@@ -319,14 +319,6 @@ export class Loader extends DefaultLoader {
 
   private _configuredPixelRatio: number | null = null;
   public override async onBeforeLoad(): Promise<void> {
-    this._configuredPixelRatio = this.screen.pixelRatioOverride;
-    // Push the current user entered resolution/viewport
-    this.screen.pushResolutionAndViewport();
-    // Configure resolution for loader, it expects resolution === viewport
-    this.screen.resolution = this.screen.viewport;
-    this.screen.pixelRatioOverride = 1;
-    this.screen.applyResolutionAndViewport();
-
     await this._imageLoaded.promise;
     await this._image?.decode(); // decode logo if it exists
   }
@@ -341,8 +333,10 @@ export class Loader extends DefaultLoader {
 
   private _positionPlayButton() {
     if (this.engine) {
-      const screenHeight = this.engine.screen.viewport.height;
-      const screenWidth = this.engine.screen.viewport.width;
+      const {
+        width: screenWidth,
+        height: screenHeight
+      } = this.engine.canvas.getBoundingClientRect();
       if (this._playButtonRootElement) {
         const left = this.engine.canvas.offsetLeft;
         const top = this.engine.canvas.offsetTop;

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -517,8 +517,14 @@ export class Screen {
         this._canvas.style.imageRendering = 'crisp-edges';
       }
     }
-    this._canvas.style.width = this.viewport.width + 'px';
-    this._canvas.style.height = this.viewport.height + 'px';
+
+    if (this.displayMode === DisplayMode.FitContainerAndFill) {
+      this._canvas.style.width = '100%';
+      this._canvas.style.height = '100%';
+    } else {
+      this._canvas.style.width = this.viewport.width + 'px';
+      this._canvas.style.height = this.viewport.height + 'px';
+    }
 
     // After messing with the canvas width/height the graphics context is invalidated and needs to have some properties reset
     this.graphicsContext.updateViewport(this.resolution);
@@ -836,6 +842,10 @@ export class Screen {
     };
     this._contentArea = BoundingBox.fromDimension(this.resolution.width, this.resolution.height, Vector.Zero);
     this._unsafeArea = BoundingBox.fromDimension(this.resolution.width, this.resolution.height, Vector.Zero);
+    this.events.emit('resize', {
+      resolution: this.resolution,
+      viewport: this.viewport
+    } satisfies ScreenResizeEvent);
   }
 
   private _computeFitScreenAndFill() {
@@ -844,17 +854,22 @@ export class Screen {
     const vw = window.innerWidth;
     const vh = window.innerHeight;
     this._computeFitAndFill(vw, vh);
+    this.events.emit('resize', {
+      resolution: this.resolution,
+      viewport: this.viewport
+    } satisfies ScreenResizeEvent);
   }
 
 
 
   private _computeFitContainerAndFill() {
-    document.body.style.margin = '0px';
-    document.body.style.overflow = 'hidden';
     const parent = this.canvas.parentElement;
-    const vw = parent.clientWidth;
-    const vh = parent.clientHeight;
-    this._computeFitAndFill(vw, vh);
+    const { width, height } = parent.getBoundingClientRect();
+    this._computeFitAndFill(width, height);
+    this.events.emit('resize', {
+      resolution: this.resolution,
+      viewport: this.viewport
+    } satisfies ScreenResizeEvent);
   }
 
   private _computeFitAndFill(vw: number, vh: number) {
@@ -912,6 +927,10 @@ export class Screen {
     const vh = window.innerHeight;
 
     this._computeFitAndZoom(vw, vh);
+    this.events.emit('resize', {
+      resolution: this.resolution,
+      viewport: this.viewport
+    } satisfies ScreenResizeEvent);
   }
 
   private _computeFitContainerAndZoom() {
@@ -926,6 +945,10 @@ export class Screen {
     const vh = parent.clientHeight;
 
     this._computeFitAndZoom(vw, vh);
+    this.events.emit('resize', {
+      resolution: this.resolution,
+      viewport: this.viewport
+    } satisfies ScreenResizeEvent);
   }
 
   private _computeFitAndZoom(vw: number, vh: number) {
@@ -1004,6 +1027,10 @@ export class Screen {
       height: adjustedHeight
     };
     this._contentArea = BoundingBox.fromDimension(this.resolution.width, this.resolution.height, Vector.Zero);
+    this.events.emit('resize', {
+      resolution: this.resolution,
+      viewport: this.viewport
+    } satisfies ScreenResizeEvent);
   }
 
   private _applyDisplayMode() {

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -440,9 +440,15 @@ export class Screen {
   }
 
   public set resolution(resolution: ScreenDimension) {
+    if (resolution.heightUnit === 'percent' || resolution.widthUnit === 'percent') {
+      throw Error('Screen resolution only supports pixels not percentage sizes');
+    }
     this._resolution = resolution;
   }
 
+  /**
+   * Returns screen dimensions in pixels or percentage
+   */
   public get viewport(): ScreenDimension {
     if (this._viewport) {
       return this._viewport;

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -1068,12 +1068,18 @@ export class Screen {
    */
   private _setResolutionAndViewportByDisplayMode(parent: HTMLElement | Window) {
     if (this.displayMode === DisplayMode.FillContainer) {
+      this.canvas.style.width = '100%';
+      this.canvas.style.height = '100%';
+      this.viewport = {
+        width: 100,
+        widthUnit: 'percent',
+        height: 100,
+        heightUnit: 'percent'
+      }
       this.resolution = {
-        width: (<HTMLElement> parent).clientWidth,
-        height: (<HTMLElement> parent).clientHeight
+        width: this.canvas.offsetWidth,
+        height: this.canvas.offsetHeight
       };
-
-      this.viewport = this.resolution;
     }
 
     if (this.displayMode === DisplayMode.FillScreen) {

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -885,7 +885,7 @@ export class Screen {
   private _computeFitAndFill(vw: number, vh: number, viewport?: ScreenDimension) {
     this.viewport = viewport ?? {
       width: vw,
-      height: vh,
+      height: vh
     };
     // if the current screen aspectRatio is less than the original aspectRatio
     if (vw / vh <= this._contentResolution.width / this._contentResolution.height) {
@@ -1075,7 +1075,7 @@ export class Screen {
         widthUnit: 'percent',
         height: 100,
         heightUnit: 'percent'
-      }
+      };
       this.resolution = {
         width: this.canvas.offsetWidth,
         height: this.canvas.offsetHeight

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -863,9 +863,12 @@ export class Screen {
 
 
   private _computeFitContainerAndFill() {
-    const parent = this.canvas.parentElement;
-    const { width, height } = parent.getBoundingClientRect();
-    this._computeFitAndFill(width, height);
+    // const parent = this.canvas.parentElement;
+    // const { width, height } = parent.getBoundingClientRect();
+    this.canvas.style.width = '100%';
+    this.canvas.style.height = '100%';
+    
+    this._computeFitAndFill(this.canvas.offsetWidth, this.canvas.offsetHeight);
     this.events.emit('resize', {
       resolution: this.resolution,
       viewport: this.viewport

--- a/src/spec/ScreenSpec.ts
+++ b/src/spec/ScreenSpec.ts
@@ -164,8 +164,12 @@ describe('A Screen', () => {
     expect(sut.resolution.height).toBe(800);
     expect(sut.contentArea.width).toBe(800);
     expect(sut.contentArea.height).toBe(600);
-    expect(sut.viewport.width).toBe(1300);
-    expect(sut.viewport.height).toBe(1300);
+    expect(sut.viewport.width).toBe(100);
+    expect(sut.viewport.widthUnit).toBe('percent');
+    expect(sut.viewport.height).toBe(100);
+    expect(sut.viewport.heightUnit).toBe('percent');
+    expect(sut.canvas.offsetWidth).toBe(1300);
+    expect(sut.canvas.offsetHeight).toBe(1300);
 
   });
 
@@ -192,8 +196,12 @@ describe('A Screen', () => {
     expect(sut.resolution.height).toBe(600);
     expect(sut.contentArea.width).toBe(800);
     expect(sut.contentArea.height).toBe(600);
-    expect(sut.viewport.width).toBe(1300);
-    expect(sut.viewport.height).toBe(800);
+    expect(sut.viewport.width).toBe(100);
+    expect(sut.viewport.widthUnit).toBe('percent');
+    expect(sut.viewport.height).toBe(100);
+    expect(sut.viewport.heightUnit).toBe('percent');
+    expect(sut.canvas.offsetWidth).toBe(1300);
+    expect(sut.canvas.offsetHeight).toBe(800);
 
   });
 
@@ -317,7 +325,10 @@ describe('A Screen', () => {
       expect(sut.resolution.width).toBe(800);
       expect(sut.resolution.height).toBe(600);
       expect(sut.viewport.width).toBe(800 * sut.aspectRatio);
-      expect(sut.viewport.height).toBe(800);
+      expect(sut.viewport.height).toBe(100);
+      expect(sut.viewport.heightUnit).toBe('percent');
+      expect(sut.canvas.offsetHeight).toBe(800);
+      expect(sut.canvas.offsetWidth).toBe(Math.ceil(800 * sut.aspectRatio));
     });
 
     it('will adjust to width', () => {
@@ -340,8 +351,11 @@ describe('A Screen', () => {
       expect(sut.parent).toBe(parentEl);
       expect(sut.resolution.width).toBe(800);
       expect(sut.resolution.height).toBe(600);
-      expect(sut.viewport.width).toBe(1000);
+      expect(sut.viewport.width).toBe(100);
+      expect(sut.viewport.widthUnit).toBe('percent');
       expect(sut.viewport.height).toBe(1000 / sut.aspectRatio);
+      expect(sut.canvas.offsetHeight).toBe(1000 / sut.aspectRatio);
+      expect(sut.canvas.offsetWidth).toBe(1000);
     });
   });
 

--- a/src/spec/util/TestUtils.ts
+++ b/src/spec/util/TestUtils.ts
@@ -49,7 +49,6 @@ export namespace TestUtils {
     }
     const clock = engine.clock as ex.TestClock;
     const start = engine.start(loader);
-    // If loader
     if (loader) {
       await loader.areResourcesLoaded();
       clock.step(200);


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================


Fixed issue where unbounded containers would grow infinitely when using the following display modes:
  * `DisplayMode.FillContainer`
  * `DisplayMode.FitContainer`
  * `DisplayMode.FitContainerAndFill`
  * `DisplayMode.FitContainerAndZoom`

This works by using CSS percent to fill the container instead of calculating the size which would cause n+1 resizing when setting the size. Viewport screen dimensions will now support percent based sizes 


