### PR TITLE
fix: Screen to world coord conversion when using fit container

### DIFF
--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -7,7 +7,7 @@ import { polyfill } from './Polyfill';
 polyfill();
 import { CanUpdate, CanDraw, CanInitialize } from './Interfaces/LifecycleEvents';
 import { Vector } from './Math/vector';
-import { Screen, DisplayMode, ScreenDimension, Resolution } from './Screen';
+import { Screen, DisplayMode, Resolution, ViewportDimension } from './Screen';
 import { ScreenElement } from './ScreenElement';
 import { Actor } from './Actor';
 import { Timer } from './Timer';
@@ -121,13 +121,13 @@ export interface EngineOptions<TKnownScenes extends string = any> {
    * Optionally configure the width & height of the viewport in css pixels.
    * Use `viewport` instead of [[EngineOptions.width]] and [[EngineOptions.height]], or vice versa.
    */
-  viewport?: ScreenDimension;
+  viewport?: ViewportDimension;
 
   /**
    * Optionally specify the size the logical pixel resolution, if not specified it will be width x height.
    * See [[Resolution]] for common presets.
    */
-  resolution?: ScreenDimension;
+  resolution?: Resolution;
 
   /**
    * Optionally specify antialiasing (smoothing), by default true (smooth pixels)

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContext.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContext.ts
@@ -1,6 +1,6 @@
 import { Vector } from '../../Math/vector';
 import { Color } from '../../Color';
-import { ScreenDimension } from '../../Screen';
+import { Resolution } from '../../Screen';
 import { PostProcessor } from '../PostProcessor/PostProcessor';
 import { AffineMatrix } from '../../Math/affine-matrix';
 import { Material, MaterialOptions } from './material';
@@ -240,7 +240,7 @@ export interface ExcaliburGraphicsContext {
   /**
    * Update the context with the current viewport dimensions (used in resizing)
    */
-  updateViewport(resolution: ScreenDimension): void;
+  updateViewport(resolution: Resolution): void;
 
   /**
    * Access the debug drawing api

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContext2DCanvas.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContext2DCanvas.ts
@@ -11,7 +11,7 @@ import { Color } from '../../Color';
 import { StateStack } from './state-stack';
 import { GraphicsDiagnostics } from '../GraphicsDiagnostics';
 import { DebugText } from './debug-text';
-import { ScreenDimension } from '../../Screen';
+import { Resolution } from '../../Screen';
 import { PostProcessor } from '../PostProcessor/PostProcessor';
 import { AffineMatrix } from '../../Math/affine-matrix';
 import { Material, MaterialOptions } from './material';
@@ -154,7 +154,7 @@ export class ExcaliburGraphicsContext2DCanvas implements ExcaliburGraphicsContex
     this.__ctx.resetTransform();
   }
 
-  public updateViewport(_resolution: ScreenDimension): void {
+  public updateViewport(_resolution: Resolution): void {
     // pass
   }
 

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
@@ -15,7 +15,7 @@ import { Color } from '../../Color';
 import { StateStack } from './state-stack';
 import { Logger } from '../../Util/Log';
 import { DebugText } from './debug-text';
-import { ScreenDimension } from '../../Screen';
+import { Resolution } from '../../Screen';
 import { RenderTarget } from './render-target';
 import { PostProcessor } from '../PostProcessor/PostProcessor';
 import { TextureLoader } from './texture-loader';
@@ -199,7 +199,7 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
    * Checks the underlying webgl implementation if the requested internal resolution is supported
    * @param dim
    */
-  public checkIfResolutionSupported(dim: ScreenDimension): boolean {
+  public checkIfResolutionSupported(dim: Resolution): boolean {
     // Slight hack based on this thread https://groups.google.com/g/webgl-dev-list/c/AHONvz3oQTo
     let supported = true;
     if (dim.width > 4096 || dim.height > 4096) {
@@ -435,7 +435,7 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
     this._transform.current = AffineMatrix.identity();
   }
 
-  public updateViewport(resolution: ScreenDimension): void {
+  public updateViewport(resolution: Resolution): void {
     const gl = this.__gl;
     this._ortho = this._ortho = Matrix.ortho(0, resolution.width, resolution.height, 0, 400, -400);
 


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

Fix issue caused by recent change to FitContainer where percent units were not accounted for when transforming coordinates
