### PR TITLE
feat: Allow coroutine lifecycles + support thisArg + remove engine requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added simplified `ex.coroutine` overloads, you need not pass engine as long as you are in an Excalibur lifecycle
+  ```typescript
+  const result = ex.coroutine(function* () {...});
+  ```
+- Added way to bind 'this' to `ex.coroutine` overloads, you need not pass engine as long as you are in an Excalibur lifecycle
+  ```typescript
+  const result = ex.coroutine({myThis: 'cool'}, function* () {...});
+  ```
 - Added optional `ex.coroutine` timing parameter to schedule when they are updated
   ```typescript
   const result = ex.coroutine(engine, function * () {...}, { timing: 'postupdate' })

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added optional `ex.coroutine` timing parameter to schedule when they are updated
+  ```typescript
+  const result = ex.coroutine(engine, function * () {...}, { timing: 'postupdate' })
+  ```
 - Added `GraphicsComponent.bounds` which will report the world bounds of the graphic if applicable!
 - Added `ex.Vector.EQUALS_EPSILON` to configure the `ex.Vector.equals(v)` threshold
 - Added way to add custom WebGL context lost/recovered handlers for your game

--- a/src/engine/Context.ts
+++ b/src/engine/Context.ts
@@ -4,14 +4,7 @@ export interface Context<TValue> {
    * @param value
    * @param cb
    */
-  scope: (value: TValue, cb: () => any) => any;
-  /**
-   * Wait for async cb to finish before popping the context value
-   * @param value
-   * @param cb
-   * @returns
-   */
-  scopeAsync: (value: TValue, cb: () => Promise<any>) => Promise<any>;
+  scope: <TReturn>(value: TValue, cb: () => TReturn) => TReturn;
   value: TValue;
 }
 
@@ -29,24 +22,13 @@ export interface Context<TValue> {
  *
  * ```
  */
-export function createContext<TValue>(defaultValue: TValue) {
-  const currentValue = defaultValue;
+export function createContext<TValue>() {
   const ctx: Context<TValue> = {
     scope: (value, cb) => {
-      const old = ctx.value;
       ctx.value = value;
-      const val = cb();
-      ctx.value = old;
-      return val;
+      return cb();
     },
-    scopeAsync: async (value, cb) => {
-      const old = ctx.value;
-      ctx.value = value;
-      const val = await cb();
-      ctx.value = old;
-      return val;
-    },
-    value: currentValue
+    value: undefined
   };
   return ctx;
 }

--- a/src/engine/Context.ts
+++ b/src/engine/Context.ts
@@ -1,0 +1,40 @@
+export interface Context<TValue> {
+  scope: (value: TValue, cb: () => any) => any;
+  value: TValue;
+}
+
+
+/**
+ * Creates a injectable context that can be retrieved later with `useContext(context)`
+ *
+ * Example
+ * ```typescript
+ *
+ * const AppContext = createContext({some: 'value'});
+ * context.scope(val, () => {
+ *    const value = useContext(AppContext);
+ * })
+ *
+ * ```
+ */
+export function createContext<TValue>(defaultValue: TValue) {
+  const currentValue = defaultValue;
+  const ctx: Context<TValue> = {
+    scope: (value, cb) => {
+      const old = ctx.value;
+      ctx.value = value;
+      const val = cb();
+      ctx.value = old;
+      return val;
+    },
+    value: currentValue
+  };
+  return ctx;
+}
+
+/**
+ * Retrieves the value from the current context
+ */
+export function useContext<TValue>(context: Context<TValue>): TValue {
+  return context.value;
+}

--- a/src/engine/Context.ts
+++ b/src/engine/Context.ts
@@ -1,5 +1,17 @@
 export interface Context<TValue> {
+  /**
+   * Run the callback before popping the context value
+   * @param value
+   * @param cb
+   */
   scope: (value: TValue, cb: () => any) => any;
+  /**
+   * Wait for async cb to finish before popping the context value
+   * @param value
+   * @param cb
+   * @returns
+   */
+  scopeAsync: (value: TValue, cb: () => Promise<any>) => Promise<any>;
   value: TValue;
 }
 
@@ -24,6 +36,13 @@ export function createContext<TValue>(defaultValue: TValue) {
       const old = ctx.value;
       ctx.value = value;
       const val = cb();
+      ctx.value = old;
+      return val;
+    },
+    scopeAsync: async (value, cb) => {
+      const old = ctx.value;
+      ctx.value = value;
+      const val = await cb();
       ctx.value = old;
       return val;
     },

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -355,7 +355,7 @@ export interface EngineOptions<TKnownScenes extends string = any> {
  * loading resources, and managing the scene.
  */
 export class Engine<TKnownScenes extends string = any> implements CanInitialize, CanUpdate, CanDraw {
-  static Context: Context<Engine | null> = createContext<Engine | null>(null);
+  static Context: Context<Engine | null> = createContext<Engine | null>();
   static useEngine(): Engine {
     const value = useContext(Engine.Context);
 
@@ -370,8 +370,7 @@ export class Engine<TKnownScenes extends string = any> implements CanInitialize,
    * Anything run under scope can use `useEngine()` to inject the current engine
    * @param cb
    */
-  scope = (cb: () => any) => Engine.Context.scope(this, cb);
-  scopeAsync = async (cb: () => Promise<any>) => await Engine.Context.scopeAsync(this, cb);
+  scope = <TReturn>(cb: () => TReturn) => Engine.Context.scope(this, cb);
 
   /**
    * Current Excalibur version string
@@ -1333,7 +1332,7 @@ O|===|* >________________>\n\
    * @deprecated use goToScene, it now behaves the same as goto
    */
   public async goto(destinationScene: WithRoot<TKnownScenes>, options?: GoToOptions) {
-    await this.scopeAsync(async () => {
+    await this.scope(async () => {
       await this.director.goto(destinationScene, options);
     });
   }
@@ -1369,7 +1368,7 @@ O|===|* >________________>\n\
    * @param options
    */
   public async goToScene<TData = undefined>(destinationScene: WithRoot<TKnownScenes>, options?: GoToOptions<TData>): Promise<void> {
-    await this.scopeAsync(async () => {
+    await this.scope(async () => {
       await this.director.goto(destinationScene, options);
     });
   }
@@ -1640,7 +1639,7 @@ O|===|* >________________>\n\
    */
   public async start(loader?: DefaultLoader): Promise<void>;
   public async start(sceneNameOrLoader?: WithRoot<TKnownScenes> | DefaultLoader, options?: StartOptions): Promise<void> {
-    await this.scopeAsync(async () => {
+    await this.scope(async () => {
       if (!this._compatible) {
         throw new Error('Excalibur is incompatible with your browser');
       }
@@ -1787,7 +1786,7 @@ O|===|* >________________>\n\
    * @param loader  Some [[Loadable]] such as a [[Loader]] collection, [[Sound]], or [[Texture]].
    */
   public async load(loader: DefaultLoader, hideLoader = false): Promise<void> {
-    await this.scopeAsync(async () => {
+    await this.scope(async () => {
       try {
         // early exit if loaded
         if (loader.isLoaded()) {

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1459,6 +1459,7 @@ O|===|* >________________>\n\
     }
 
     // Publish preupdate events
+    this.clock.__runScheduledCbs('preupdate');
     this._preupdate(delta);
 
     // process engine level events
@@ -1468,6 +1469,7 @@ O|===|* >________________>\n\
     this.graphicsContext.updatePostProcessors(delta);
 
     // Publish update event
+    this.clock.__runScheduledCbs('postupdate');
     this._postupdate(delta);
 
     // Update input listeners
@@ -1505,12 +1507,14 @@ O|===|* >________________>\n\
   private _draw(delta: number) {
     this.graphicsContext.beginDrawLifecycle();
     this.graphicsContext.clear();
+    this.clock.__runScheduledCbs('predraw');
     this._predraw(this.graphicsContext, delta);
 
     // Drawing nothing else while loading
     if (this._isLoading) {
       if (!this._hideLoader) {
         this._loader?.canvas.draw(this.graphicsContext, 0, 0);
+        this.clock.__runScheduledCbs('postdraw');
         this.graphicsContext.flush();
         this.graphicsContext.endDrawLifecycle();
       }
@@ -1522,6 +1526,7 @@ O|===|* >________________>\n\
 
     this.currentScene.draw(this.graphicsContext, delta);
 
+    this.clock.__runScheduledCbs('postdraw');
     this._postdraw(this.graphicsContext, delta);
 
     // Flush any pending drawings

--- a/src/engine/Util/Coroutine.ts
+++ b/src/engine/Util/Coroutine.ts
@@ -2,8 +2,25 @@ import { Engine } from '../Engine';
 import { ScheduledCallbackTiming } from './Clock';
 export type CoroutineGenerator = () => Generator<number | Promise<any> | undefined, void, number>;
 
+const generatorFunctionDeclaration = /^\s*(?:function)?\*/;
+/**
+ *
+ */
+function isCoroutineGenerator(x: any): x is CoroutineGenerator {
+  if (typeof x !== 'function') {
+    return false;
+  }
+  if (generatorFunctionDeclaration.test(Function.prototype.toString.call(x))) {
+    return true;
+  }
+  if (!Object.getPrototypeOf) {
+    return false;
+  }
+  return Object.getPrototypeOf(x) === Object.getPrototypeOf(new Function('return function * () {}')());
+}
+
 export interface CoroutineOptions {
-  timing?: ScheduledCallbackTiming
+  timing?: ScheduledCallbackTiming;
 }
 
 /**
@@ -14,14 +31,101 @@ export interface CoroutineOptions {
  *
  * If you yield a promise it will be awaited before resumed
  * If you yield a number it will wait that many ms before resumed
- * @param engine
- * @param coroutineGenerator
+ * @param thisArg set the "this" context of the generator, by default is globalThis
+ * @param engine pass a specific engine to use for running the coroutine
+ * @param coroutineGenerator coroutine generator function
  * @param {CoroutineOptions} options optionally schedule coroutine pre/post update
  */
-export function coroutine(engine: Engine, coroutineGenerator: CoroutineGenerator, options?: CoroutineOptions): Promise<void> {
+export function coroutine(thisArg: any, engine: Engine, coroutineGenerator: CoroutineGenerator, options?: CoroutineOptions): Promise<void>;
+/**
+ * Excalibur coroutine helper, returns a promise when complete. Coroutines run before frame update.
+ *
+ * Each coroutine yield is 1 excalibur frame. Coroutines get passed the elapsed time our of yield. Coroutines
+ * run internally on the excalibur clock.
+ *
+ * If you yield a promise it will be awaited before resumed
+ * If you yield a number it will wait that many ms before resumed
+ * @param engine pass a specific engine to use for running the coroutine
+ * @param coroutineGenerator coroutine generator function
+ * @param {CoroutineOptions} options optionally schedule coroutine pre/post update
+ */
+export function coroutine(engine: Engine, coroutineGenerator: CoroutineGenerator, options?: CoroutineOptions): Promise<void>;
+/**
+ * Excalibur coroutine helper, returns a promise when complete. Coroutines run before frame update.
+ *
+ * Each coroutine yield is 1 excalibur frame. Coroutines get passed the elapsed time our of yield. Coroutines
+ * run internally on the excalibur clock.
+ *
+ * If you yield a promise it will be awaited before resumed
+ * If you yield a number it will wait that many ms before resumed
+ * @param coroutineGenerator coroutine generator function
+ * @param {CoroutineOptions} options optionally schedule coroutine pre/post update
+ */
+export function coroutine(coroutineGenerator: CoroutineGenerator, options?: CoroutineOptions): Promise<void>;
+/**
+ * Excalibur coroutine helper, returns a promise when complete. Coroutines run before frame update.
+ *
+ * Each coroutine yield is 1 excalibur frame. Coroutines get passed the elapsed time our of yield. Coroutines
+ * run internally on the excalibur clock.
+ *
+ * If you yield a promise it will be awaited before resumed
+ * If you yield a number it will wait that many ms before resumed
+ * @param thisArg set the "this" context of the generator, by default is globalThis
+ * @param coroutineGenerator coroutine generator function
+ * @param {CoroutineOptions} options optionally schedule coroutine pre/post update
+ */
+export function coroutine(thisArg: any, coroutineGenerator: CoroutineGenerator, options?: CoroutineOptions): Promise<void>;
+/**
+ *
+ */
+export function coroutine(...args: any[]): Promise<void> {
+  let coroutineGenerator: CoroutineGenerator;
+  let thisArg: any;
+  let options: CoroutineOptions | undefined;
+  let passedEngine: Engine | undefined;
+
+  // coroutine(coroutineGenerator: CoroutineGenerator, options?: CoroutineOptions): Promise<void>;
+  if (isCoroutineGenerator(args[0])) {
+    thisArg = globalThis;
+    coroutineGenerator = args[0];
+    options = args[1];
+  }
+
+  // coroutine(thisArg: any, coroutineGenerator: CoroutineGenerator, options?: CoroutineOptions): Promise<void>;
+  if (isCoroutineGenerator(args[1])) {
+    thisArg = args[0];
+    coroutineGenerator = args[1];
+    options = args[2];
+  }
+
+  // coroutine(thisArg: any, engine: Engine, coroutineGenerator: CoroutineGenerator, options?: CoroutineOptions): Promise<void>;
+  if (args[1] instanceof Engine) {
+    thisArg = args[0];
+    passedEngine = args[1];
+    coroutineGenerator = args[2];
+    options = args[3];
+  }
+
+  // coroutine(engine: Engine, coroutineGenerator: CoroutineGenerator, options?: CoroutineOptions): Promise<void>;
+  if (args[0] instanceof Engine) {
+    thisArg = globalThis;
+    passedEngine = args[0];
+    coroutineGenerator = args[1];
+    options = args[2];
+  }
+
   const schedule = options?.timing;
+  let engine: Engine;
+  try {
+    engine = passedEngine ?? Engine.useEngine();
+  } catch (_) {
+    throw Error(
+      'Cannot run coroutine without engine parameter outside of an excalibur lifecycle method.\n' +
+      'Pass an engine parameter to ex.coroutine(engine, function * {...})');
+  }
+  const generatorFcn = coroutineGenerator.bind(thisArg);
   return new Promise<void>((resolve, reject) => {
-    const generator = coroutineGenerator();
+    const generator = generatorFcn();
     const loop = (elapsedMs: number) => {
       try {
         const { done, value } = generator.next(elapsedMs);

--- a/src/spec/ContextSpec.ts
+++ b/src/spec/ContextSpec.ts
@@ -1,0 +1,60 @@
+import { createContext, useContext } from '../../src/engine/Context';
+
+describe('A Context', () => {
+  it('creates a context', () => {
+    expect(createContext()).toBeDefined();
+  });
+
+  describe('useContext', () => {
+    it('returns undefined outside of scope', () => {
+      const ctx = createContext();
+      expect(useContext(ctx)).toBeUndefined();
+    });
+
+    it('returns scoped value', () => {
+      const ctx = createContext();
+      ctx.scope('value', () => {
+        expect(useContext(ctx)).toBe('value');
+      });
+    });
+
+    it('returns scoped value in sequential scopes', () => {
+      const ctx = createContext();
+      ctx.scope('value', () => {
+        expect(useContext(ctx)).toBe('value');
+      });
+      ctx.scope('value2', () => {
+        expect(useContext(ctx)).toBe('value2');
+      });
+    });
+
+    it('returns scoped value in nested scopes', () => {
+      const ctx = createContext();
+      ctx.scope('value', () => {
+        expect(useContext(ctx)).toBe('value');
+        ctx.scope('value2', () => {
+          expect(useContext(ctx)).toBe('value2');
+        });
+      });
+    });
+
+    it('persists value reference after a nested context', () => {
+      const ctx = createContext();
+      ctx.scope([], () => {
+        const value = useContext(ctx);
+        expect(value).toEqual([]);
+        ctx.scope([1], () => null);
+        expect(value).toEqual([]);
+      });
+    });
+
+    it('returns value in an async callback', async () => {
+      const ctx = createContext();
+      await ctx.scope('value', async () => {
+        const value = useContext(ctx);
+        await Promise.resolve();
+        expect(value).toBe('value');
+      });
+    });
+  });
+});

--- a/src/spec/CoroutineSpec.ts
+++ b/src/spec/CoroutineSpec.ts
@@ -26,8 +26,6 @@ describe('A Coroutine', () => {
 
   it('can should throw without engine outside scope ', () => {
     const engine = TestUtils.engine({ width: 100, height: 100 });
-    const clock = engine.clock as ex.TestClock;
-    clock.start();
     expect(() => {
       const result = ex.coroutine(function* () {
         const elapsed = yield;

--- a/src/spec/CoroutineSpec.ts
+++ b/src/spec/CoroutineSpec.ts
@@ -7,144 +7,231 @@ describe('A Coroutine', () => {
   });
 
   it('can be run', async () => {
-    const engine = TestUtils.engine({ width: 100, height: 100});
+    const engine = TestUtils.engine({ width: 100, height: 100 });
+    await engine.scope(async () => {
+      const clock = engine.clock as ex.TestClock;
+      clock.start();
+      const result = ex.coroutine(function* () {
+        const elapsed = yield;
+        expect(this).toBe(globalThis);
+        expect(elapsed).toBe(100);
+        yield;
+      });
+      clock.step(100);
+      clock.step(100);
+      await expectAsync(result).toBeResolved();
+      engine.dispose();
+    });
+  });
+
+  it('can should throw without engine outside scope ', () => {
+    const engine = TestUtils.engine({ width: 100, height: 100 });
     const clock = engine.clock as ex.TestClock;
     clock.start();
-    const result = ex.coroutine(engine, function * () {
-      const elapsed = yield;
-      expect(elapsed).toBe(100);
-      yield;
+    expect(() => {
+      const result = ex.coroutine(function* () {
+        const elapsed = yield;
+        expect(this).toBe(globalThis);
+        expect(elapsed).toBe(100);
+        yield;
+      });
+    }).toThrowError(
+      'Cannot run coroutine without engine parameter outside of an excalibur lifecycle method.\n' +
+      'Pass an engine parameter to ex.coroutine(engine, function * {...})'
+    );
+  });
+
+  it('can bind a this arg overload 1', async () => {
+    const engine = TestUtils.engine({ width: 100, height: 100 });
+    await engine.scope(async () => {
+      const clock = engine.clock as ex.TestClock;
+      clock.start();
+      const myThis = { super: 'cool' };
+      const result = ex.coroutine(myThis, function* () {
+        const elapsed = yield;
+        expect(this).toBe(myThis);
+        expect(elapsed).toBe(100);
+        yield;
+      });
+      clock.step(100);
+      clock.step(100);
+      await expectAsync(result).toBeResolved();
+      engine.dispose();
     });
-    clock.step(100);
-    clock.step(100);
-    await expectAsync(result).toBeResolved();
+  });
+
+  it('can bind a this arg overload 2', async () => {
+    const engine = TestUtils.engine({ width: 100, height: 100 });
+    await engine.scope(async () => {
+      const clock = engine.clock as ex.TestClock;
+      clock.start();
+      const myThis = { super: 'cool' };
+      const result = ex.coroutine(myThis, engine, function* () {
+        const elapsed = yield;
+        expect(this).toBe(myThis);
+        expect(elapsed).toBe(100);
+        yield;
+      });
+      clock.step(100);
+      clock.step(100);
+      await expectAsync(result).toBeResolved();
+      engine.dispose();
+    });
+  });
+
+
+  it('can run overload 2', async () => {
+    const engine = TestUtils.engine({ width: 100, height: 100 });
+    await engine.scope(async () => {
+      const clock = engine.clock as ex.TestClock;
+      clock.start();
+      const result = ex.coroutine(engine, function* () {
+        const elapsed = yield;
+        expect(this).toBe(globalThis);
+        expect(elapsed).toBe(100);
+        yield;
+      });
+      clock.step(100);
+      clock.step(100);
+      await expectAsync(result).toBeResolved();
+      engine.dispose();
+    });
   });
 
   it('can be run on scheduled timing', async () => {
-    const engine = TestUtils.engine({ width: 100, height: 100});
-    const clock = engine.clock as ex.TestClock;
-    clock.start();
+    const engine = TestUtils.engine({ width: 100, height: 100 });
+    await engine.scope(async () => {
+      const clock = engine.clock as ex.TestClock;
+      clock.start();
 
-    const calls = jasmine.createSpy('calls');
+      const calls = jasmine.createSpy('calls');
 
-    const preframe = ex.coroutine(engine, function * () {
-      const elapsed = yield;
-      calls('preframe');
-      expect(elapsed).toBe(100);
-      yield;
-    }, { timing: 'preframe'});
+      const preframe = ex.coroutine(function* () {
+        const elapsed = yield;
+        calls('preframe');
+        expect(elapsed).toBe(100);
+        yield;
+      }, { timing: 'preframe' });
 
-    const postframe = ex.coroutine(engine, function * () {
-      const elapsed = yield;
-      calls('postframe');
-      expect(elapsed).toBe(100);
-      yield;
-    }, { timing: 'postframe'});
+      const postframe = ex.coroutine(function* () {
+        const elapsed = yield;
+        calls('postframe');
+        expect(elapsed).toBe(100);
+        yield;
+      }, { timing: 'postframe' });
 
-    const preupdate = ex.coroutine(engine, function * () {
-      const elapsed = yield;
-      calls('preupdate');
-      expect(elapsed).toBe(100);
-      yield;
-    }, { timing: 'preupdate'});
+      const preupdate = ex.coroutine(function* () {
+        const elapsed = yield;
+        calls('preupdate');
+        expect(elapsed).toBe(100);
+        yield;
+      }, { timing: 'preupdate' });
 
-    const postupdate = ex.coroutine(engine, function * () {
-      const elapsed = yield;
-      calls('postupdate');
-      expect(elapsed).toBe(100);
-      yield;
-    }, { timing: 'postupdate'});
+      const postupdate = ex.coroutine(function* () {
+        const elapsed = yield;
+        calls('postupdate');
+        expect(elapsed).toBe(100);
+        yield;
+      }, { timing: 'postupdate' });
 
-    const predraw = ex.coroutine(engine, function * () {
-      const elapsed = yield;
-      calls('predraw');
-      expect(elapsed).toBe(100);
-      yield;
-    }, { timing: 'predraw'});
+      const predraw = ex.coroutine(function* () {
+        const elapsed = yield;
+        calls('predraw');
+        expect(elapsed).toBe(100);
+        yield;
+      }, { timing: 'predraw' });
 
-    const postdraw = ex.coroutine(engine, function * () {
-      const elapsed = yield;
-      calls('postdraw');
-      expect(elapsed).toBe(100);
-      yield;
-    }, { timing: 'postdraw'});
+      const postdraw = ex.coroutine(function* () {
+        const elapsed = yield;
+        calls('postdraw');
+        expect(elapsed).toBe(100);
+        yield;
+      }, { timing: 'postdraw' });
 
-    clock.step(100);
-    clock.step(100);
-    expect(calls.calls.allArgs()).toEqual([
-      ['preframe'],
-      ['preupdate'],
-      ['postupdate'],
-      ['predraw'],
-      ['postdraw'],
-      ['postframe']
-    ]);
-    await expectAsync(preframe).toBeResolved();
-    await expectAsync(preupdate).toBeResolved();
-    await expectAsync(postupdate).toBeResolved();
-    await expectAsync(predraw).toBeResolved();
-    await expectAsync(postdraw).toBeResolved();
-    await expectAsync(postframe).toBeResolved();
+      clock.step(100);
+      clock.step(100);
+      expect(calls.calls.allArgs()).toEqual([
+        ['preframe'],
+        ['preupdate'],
+        ['postupdate'],
+        ['predraw'],
+        ['postdraw'],
+        ['postframe']
+      ]);
+      await expectAsync(preframe).toBeResolved();
+      await expectAsync(preupdate).toBeResolved();
+      await expectAsync(postupdate).toBeResolved();
+      await expectAsync(predraw).toBeResolved();
+      await expectAsync(postdraw).toBeResolved();
+      await expectAsync(postframe).toBeResolved();
+    });
   });
 
 
   it('can wait for given ms', async () => {
-    const engine = TestUtils.engine({ width: 100, height: 100});
+    const engine = TestUtils.engine({ width: 100, height: 100 });
     const clock = engine.clock as ex.TestClock;
     clock.start();
-    const result = ex.coroutine(engine, function * () {
-      const elapsed = yield 200;
-      expect(elapsed).toBe(200);
-      yield;
+    await engine.scope(async () => {
+      const result = ex.coroutine(function* () {
+        const elapsed = yield 200;
+        expect(elapsed).toBe(200);
+        yield;
 
+      });
+      // wait 200 ms
+      clock.step(200);
+      // 1 more yield
+      clock.step(100);
+      await expectAsync(result).toBeResolved();
     });
-    // wait 200 ms
-    clock.step(200);
-    // 1 more yield
-    clock.step(100);
-    await expectAsync(result).toBeResolved();
   });
 
   it('can wait for a promise', async () => {
-    const engine = TestUtils.engine({ width: 100, height: 100});
-    const clock = engine.clock as ex.TestClock;
-    clock.start();
-    const result = ex.coroutine(engine, function * () {
-      const elapsed = yield ex.Util.delay(1000, clock);
-      expect(elapsed).toBe(1);
-      yield;
+    const engine = TestUtils.engine({ width: 100, height: 100 });
+    await engine.scope(async () => {
+      const clock = engine.clock as ex.TestClock;
+      clock.start();
+      const result = ex.coroutine(function* () {
+        const elapsed = yield ex.Util.delay(1000, clock);
+        expect(elapsed).toBe(1);
+        yield;
+      });
+      // wait 200 ms
+      clock.step(1000);
+
+      // flush
+      await Promise.resolve();
+      clock.step(0);
+
+      // 1 more yield
+      clock.step(100);
+      await expectAsync(result).toBeResolved();
     });
-    // wait 200 ms
-    clock.step(1000);
-
-    // flush
-    await Promise.resolve();
-    clock.step(0);
-
-    // 1 more yield
-    clock.step(100);
-    await expectAsync(result).toBeResolved();
   });
 
   it('can throw error', async () => {
-    const engine = TestUtils.engine({ width: 100, height: 100});
-    const clock = engine.clock as ex.TestClock;
-    clock.start();
-    const result = ex.coroutine(engine, function * () {
-      const elapsed = yield ex.Util.delay(1000, clock);
-      expect(elapsed).toBe(1);
-      yield;
-      throw Error('error');
+    const engine = TestUtils.engine({ width: 100, height: 100 });
+    await engine.scope(async () => {
+      const clock = engine.clock as ex.TestClock;
+      clock.start();
+      const result = ex.coroutine(function* () {
+        const elapsed = yield ex.Util.delay(1000, clock);
+        expect(elapsed).toBe(1);
+        yield;
+        throw Error('error');
+      });
+      // wait 200 ms
+      clock.step(1000);
+
+      // flush
+      await Promise.resolve();
+      clock.step(0);
+
+      // 1 more yield
+      clock.step(100);
+      await expectAsync(result).toBeRejectedWithError('error');
+      engine.dispose();
     });
-    // wait 200 ms
-    clock.step(1000);
-
-    // flush
-    await Promise.resolve();
-    clock.step(0);
-
-    // 1 more yield
-    clock.step(100);
-    await expectAsync(result).toBeRejectedWithError('error');
   });
 });

--- a/src/spec/CoroutineSpec.ts
+++ b/src/spec/CoroutineSpec.ts
@@ -25,17 +25,19 @@ describe('A Coroutine', () => {
   });
 
   it('can should throw without engine outside scope ', () => {
-    expect(() => {
-      const result = ex.coroutine(function* () {
-        const elapsed = yield;
-        expect(this).toBe(globalThis);
-        expect(elapsed).toBe(100);
-        yield;
-      });
-    }).toThrowError(
-      'Cannot run coroutine without engine parameter outside of an excalibur lifecycle method.\n' +
-      'Pass an engine parameter to ex.coroutine(engine, function * {...})'
-    );
+    ex.Engine.Context.scope(null, () => {
+      expect(() => {
+        const result = ex.coroutine(function* () {
+          const elapsed = yield;
+          expect(this).toBe(globalThis);
+          expect(elapsed).toBe(100);
+          yield;
+        });
+      }).toThrowError(
+        'Cannot run coroutine without engine parameter outside of an excalibur lifecycle method.\n' +
+        'Pass an engine parameter to ex.coroutine(engine, function * {...})'
+      );
+    });
   });
 
   it('can bind a this arg overload 1', async () => {

--- a/src/spec/CoroutineSpec.ts
+++ b/src/spec/CoroutineSpec.ts
@@ -25,7 +25,6 @@ describe('A Coroutine', () => {
   });
 
   it('can should throw without engine outside scope ', () => {
-    const engine = TestUtils.engine({ width: 100, height: 100 });
     expect(() => {
       const result = ex.coroutine(function* () {
         const elapsed = yield;

--- a/src/spec/CoroutineSpec.ts
+++ b/src/spec/CoroutineSpec.ts
@@ -20,6 +20,74 @@ describe('A Coroutine', () => {
     await expectAsync(result).toBeResolved();
   });
 
+  it('can be run on scheduled timing', async () => {
+    const engine = TestUtils.engine({ width: 100, height: 100});
+    const clock = engine.clock as ex.TestClock;
+    clock.start();
+
+    const calls = jasmine.createSpy('calls');
+
+    const preframe = ex.coroutine(engine, function * () {
+      const elapsed = yield;
+      calls('preframe');
+      expect(elapsed).toBe(100);
+      yield;
+    }, { timing: 'preframe'});
+
+    const postframe = ex.coroutine(engine, function * () {
+      const elapsed = yield;
+      calls('postframe');
+      expect(elapsed).toBe(100);
+      yield;
+    }, { timing: 'postframe'});
+
+    const preupdate = ex.coroutine(engine, function * () {
+      const elapsed = yield;
+      calls('preupdate');
+      expect(elapsed).toBe(100);
+      yield;
+    }, { timing: 'preupdate'});
+
+    const postupdate = ex.coroutine(engine, function * () {
+      const elapsed = yield;
+      calls('postupdate');
+      expect(elapsed).toBe(100);
+      yield;
+    }, { timing: 'postupdate'});
+
+    const predraw = ex.coroutine(engine, function * () {
+      const elapsed = yield;
+      calls('predraw');
+      expect(elapsed).toBe(100);
+      yield;
+    }, { timing: 'predraw'});
+
+    const postdraw = ex.coroutine(engine, function * () {
+      const elapsed = yield;
+      calls('postdraw');
+      expect(elapsed).toBe(100);
+      yield;
+    }, { timing: 'postdraw'});
+
+    clock.step(100);
+    clock.step(100);
+    expect(calls.calls.allArgs()).toEqual([
+      ['preframe'],
+      ['preupdate'],
+      ['postupdate'],
+      ['predraw'],
+      ['postdraw'],
+      ['postframe']
+    ]);
+    await expectAsync(preframe).toBeResolved();
+    await expectAsync(preupdate).toBeResolved();
+    await expectAsync(postupdate).toBeResolved();
+    await expectAsync(predraw).toBeResolved();
+    await expectAsync(postdraw).toBeResolved();
+    await expectAsync(postframe).toBeResolved();
+  });
+
+
   it('can wait for given ms', async () => {
     const engine = TestUtils.engine({ width: 100, height: 100});
     const clock = engine.clock as ex.TestClock;

--- a/src/spec/FadeInOutSpec.ts
+++ b/src/spec/FadeInOutSpec.ts
@@ -45,7 +45,7 @@ describe('A FadeInOut transition', () => {
     engine.addScene('newScene', { scene, transitions: { in: sut } });
 
     const goto = engine.goto('newScene');
-    await TestUtils.flushMicrotasks(clock, 13);
+    await TestUtils.flushMicrotasks(clock, 15);
     clock.step(500);
     await Promise.resolve();
     expect(onDeactivateSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

This PR adds an optional `ex.coroutine` timing parameter as an option bag to schedule when they are updated

  ```typescript
  const result = ex.coroutine(engine, function * () {...}, { timing: 'postupdate' })
  ```

This PR also adds a way to set the `this` parameter for a generator

  ```typescript
  const result = ex.coroutine({myThis: 'value'}, engine, function * () {...})
  ```

Additionally this PR removes the requirement to pass engine if done so under an Excalibur lifecycle

```typescript
  const result = ex.coroutine(function * () {...});
```
