### PR TITLE
fix: incomplete types for options in ex.FontSource.toFont()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed incomplete types for font options in `ex.FontSource().toFont(options)`
 - Fixed issue with `ex.Loader` start button position when using CSS transforms
 - Fixed issue where adding scenes with the same name did not work when it was previously removed
 - Fixed issue when WebGL context lost occurs where there was no friendly output to the user

--- a/src/engine/Resources/Font.ts
+++ b/src/engine/Resources/Font.ts
@@ -70,7 +70,7 @@ export class FontSource implements Loadable<FontFace> {
    * Build a font from this FontSource.
    * @param options {FontOptions} Override the font options
    */
-  toFont(options?: FontOptions): Font {
+  toFont(options?: FontOptions & GraphicOptions & RasterOptions): Font {
     return new Font({ family: this.family, ...this._options, ...options });
   }
 }

--- a/src/spec/FontSourceSpec.ts
+++ b/src/spec/FontSourceSpec.ts
@@ -37,13 +37,15 @@ describe('A FontSource', () => {
 
   it('will use options from FontSource', async () => {
     const fontSource = new ex.FontSource('src/spec/fonts/Gorgeous Pixel.ttf', 'Gorgeous Pixel', {
-      size: 50
+      size: 50,
+      color: ex.Color.Red
     });
 
     await fontSource.load();
     const font = fontSource.toFont();
 
     expect(font.size).toBe(50);
+    expect(font.color.toString()).toBe(ex.Color.Red.toString());
   });
 
   it('will override options when converting to a Font', async () => {
@@ -54,11 +56,13 @@ describe('A FontSource', () => {
 
     await fontSource.load();
     const font = fontSource.toFont({
-      size: 100
+      size: 100,
+      color: ex.Color.Red
     });
 
     expect(font.size).toBe(100);
     expect(font.opacity).toBe(0.5);
+    expect(font.color.toString()).toBe(ex.Color.Red.toString());
   });
 
   it('will resolve the font if already loaded', async () => {


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ x :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #

## Changes:

- Fixed incomplete types for font options in `ex.FontSource().toFont(options)`
