### PR TITLE
fix: Update docs, SpriteFont 

### DIFF
--- a/site/docs/04-graphics/04.1-text.mdx
+++ b/site/docs/04-graphics/04.1-text.mdx
@@ -149,41 +149,15 @@ await game.start();
 
 ## SpriteFont
 
-Sometimes you want to use a custom font based on a sprite sheet of character glyphs
+Sometimes you want to use a custom font based on your [spritesheet](#spritesheet) of character glyphs
+
+Example `sprite-font.png` file:
 
 ![Custom pixel art glyphs](debug-font.png)
 
 ```typescript
-const image = new ex.ImageSource('./path/to/sprite-font.png')
+const spriteFontImage = new ex.ImageSource('./path/to/sprite-font.png')
 
-const spriteSheet = SpriteSheet.fromImageSource({
-  image: image,
-  grid: {
-    rows: 3,
-    columns: 16,
-    spriteWidth: 16,
-    spriteHeight: 16,
-  },
-})
-
-const spriteFont = new SpriteFont({
-  alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ,!\'&."?-()+ ',
-  caseInsensitive: true,
-  spriteSheet: this._spriteSheet,
-  spacing: -6,
-})
-
-const text = new ex.Text({
-  text: 'some text with a sprite font!',
-  font: spriteFont,
-})
-```
-
-#### SpriteFont
-
-Sometimes you want to use text of your own creation from a [spritesheet](#spritesheet),
-
-```typescript
 const spriteFontSheet = ex.SpriteSheet.fromImageSource({
   image: spriteFontImage,
   grid: {
@@ -193,14 +167,12 @@ const spriteFontSheet = ex.SpriteSheet.fromImageSource({
     spriteHeight: 16
   }
 });
-
 const spriteFont = new ex.SpriteFont({
     alphabet: '0123456789abcdefghijklmnopqrstuvwxyz,!\'&."?- ',
     caseInsensitive: true,
     spriteSheet: spriteFontSheet
   });
 });
-
 const text = new ex.Text({
   text: 'This is sprite font text!!',
   font: spriteFont


### PR DESCRIPTION
Remove duplicate example of SpriteFont

<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #

## Changes:

- Updated docs section  Graphics -> Text -> SpriteFont
