### PR TITLE
fix: wrong hex color values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ will be positioned with the top left of the graphic at the actor's position.
 - Fixed issue where Firefox on Linux would throw an error when using custom Materials due to unused attributes caused by glsl compiler optimization. 
 - Fixed issue where start transition did not work properly if deferred
 - Fixed issue where transitions did not cover the whole screen if camera was zoomed
+- Fixed issue where `Color.toHex()` produced invalid strings if the channel values are negative or fractional, or if the alpha channel was different than 1
 
 ### Updates
 

--- a/src/engine/Color.ts
+++ b/src/engine/Color.ts
@@ -232,8 +232,9 @@ export class Color {
    */
   public toHex() {
     let hexRepresentation = '#' + this._componentToHex(this.r) + this._componentToHex(this.g) + this._componentToHex(this.b);
-    if (this.a != 1)
+    if (this.a !== 1) {
       hexRepresentation += this._componentToHex(this.a * 255);
+    }
     return hexRepresentation;
   }
 

--- a/src/engine/Color.ts
+++ b/src/engine/Color.ts
@@ -231,7 +231,10 @@ export class Color {
    * Return Hex representation of a color.
    */
   public toHex() {
-    return '#' + this._componentToHex(this.r) + this._componentToHex(this.g) + this._componentToHex(this.b);
+    let hexRepresentation = '#' + this._componentToHex(this.r) + this._componentToHex(this.g) + this._componentToHex(this.b);
+    if (this.a != 1)
+      hexRepresentation += this._componentToHex(this.a * 255);
+    return hexRepresentation;
   }
 
   /**

--- a/src/engine/Color.ts
+++ b/src/engine/Color.ts
@@ -222,7 +222,8 @@ export class Color {
    * @see https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
    */
   private _componentToHex(c: number) {
-    const hex = c.toString(16);
+    // Handle negative and fractional numbers
+    const hex = Math.max(Math.round(c), 0).toString(16);
     return hex.length === 1 ? '0' + hex : hex;
   }
 
@@ -413,7 +414,7 @@ export class Color {
  * http://axonflux.com/handy-rgb-to-hsl-and-rgb-to-hsv-color-model-c
  */
 class HSLColor {
-  constructor(public h: number, public s: number, public l: number, public a: number) {}
+  constructor(public h: number, public s: number, public l: number, public a: number) { }
 
   public static hue2rgb(p: number, q: number, t: number): number {
     if (t < 0) {

--- a/src/spec/ColorSpec.ts
+++ b/src/spec/ColorSpec.ts
@@ -108,6 +108,17 @@ describe('A color', () => {
     expect(color.a).toBe(31 / 255);
   });
 
+  it('generate valid hex representation', () => {
+    color = ex.Color.White;
+    expect(color.toHex()).toBe('#ffffff');
+    color = ex.Color.Green;
+    expect(color.toHex()).toBe('#00ff00');
+    color = ex.Color.fromRGB(17,17,17,0.1);
+    expect(color.toHex()).toBe('#1111111a');
+    color = ex.Color.fromRGB(16.9, 16.9, 16.9);
+    expect(color.toHex()).toBe('#111111');
+  });
+
   it('can be darkened', () => {
     color = ex.Color.White.clone();
     color = color.darken();


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

=== :clipboard: PR Checklist :clipboard: ===

- [x] :pushpin: issue exists in github for these changes (#2983)
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #2983

## Changes:

- fix `Color.toHex()` and `Color._componentToHex()` to handle fractional numbers, negative numbers and colors with transparency
- add tests for `Color.toHex()`
