### PR TITLE
Add actor.oldGlobalPos, deprecate getGlobalPos in favour of globalPos getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
-- `actor.getGlobalPos()` - use `Actor.globalPos` instead
+- `actor.getGlobalPos()` - use `actor.globalPos` instead
+- `actor.getGlobalRotation()` - use `actor.globalRotation` instead
+- `actor.getGlobalScale()` - use `actor.globalScale` instead
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
--
+- `actor.getGlobalPos()` - use `Actor.globalPos` instead
 
 ### Added
 
--
+- `actor.oldGlobalPos` returns the globalPosition from the previous frame
 
 ### Fixed
 
@@ -41,7 +41,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
--
+- `
 
 ### Added
 

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -842,8 +842,16 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
   /**
    * Gets this actor's rotation taking into account any parent relationships
    * @returns Rotation angle in radians
+   * @deprecated Use [[globalRotation]] instead
    */
   public getGlobalRotation(): number {
+    return this.get(TransformComponent).globalRotation;
+  }
+
+  /**
+   * The actor's rotation (in radians) taking into account any parent relationships
+   */
+  public get globalRotation(): number {
     return this.get(TransformComponent).globalRotation;
   }
 
@@ -865,10 +873,19 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
 
   /**
    * Gets the global scale of the Actor
+   * @deprecated Use [[globalScale]] instead
    */
   public getGlobalScale(): Vector {
     return this.get(TransformComponent).globalScale;
   }
+
+  /**
+   * The global scale of the Actor
+   */
+  public get globalScale(): Vector {
+    return this.get(TransformComponent).globalScale;
+  }
+
 
   // #region Collision
 

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -294,6 +294,13 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
   }
 
   /**
+   * Gets the global position vector of the actor from the last frame
+   */
+  public get oldGlobalPos(): Vector {
+    return this.body.oldGlobalPos;
+  }
+
+  /**
    * Sets the position vector of the actor in the last frame
    */
   public set oldPos(thePos: Vector) {
@@ -843,8 +850,16 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
   /**
    * Gets an actor's world position taking into account parent relationships, scaling, rotation, and translation
    * @returns Position in world coordinates
+   * @deprecated Use [[globalPos]] instead
    */
   public getGlobalPos(): Vector {
+    return this.get(TransformComponent).globalPos;
+  }
+
+  /**
+   * The actor's world position taking into account parent relationships, scaling, rotation, and translation
+   */
+  public get globalPos(): Vector {
     return this.get(TransformComponent).globalPos;
   }
 

--- a/src/engine/Collision/BodyComponent.ts
+++ b/src/engine/Collision/BodyComponent.ts
@@ -249,7 +249,7 @@ export class BodyComponent extends Component implements Clonable<BodyComponent> 
   }
 
   /**
-   * @deprecated Use globalP0s
+   * @deprecated Use globalPos
    */
   public get center() {
     return this.globalPos;
@@ -284,11 +284,20 @@ export class BodyComponent extends Component implements Clonable<BodyComponent> 
     this.transform.globalPos = val;
   }
 
+  private _oldGlobalPos: Vector = Vector.Zero;
+
   /**
    * The position of the actor last frame (x, y) in pixels
    */
   public get oldPos(): Vector {
     return this.oldTransform.pos;
+  }
+
+  /**
+   * The global position of the actor last frame (x, y) in pixels
+   */
+  public get oldGlobalPos(): Vector {
+    return this._oldGlobalPos;
   }
 
   /**
@@ -470,6 +479,7 @@ export class BodyComponent extends Component implements Clonable<BodyComponent> 
     this.oldTransform.parent = tx.parent; // also grab parent
     this.oldVel.setTo(this.vel.x, this.vel.y);
     this.oldAcc.setTo(this.acc.x, this.acc.y);
+    this.oldGlobalPos.setTo(this.globalPos.x, this.globalPos.y);
   }
 
   public clone(): BodyComponent {

--- a/src/engine/Collision/MotionSystem.ts
+++ b/src/engine/Collision/MotionSystem.ts
@@ -1,4 +1,4 @@
-import { Query, SystemPriority, World } from '../EntityComponentSystem';
+import { Entity, Query, SystemPriority, World } from '../EntityComponentSystem';
 import { MotionComponent } from '../EntityComponentSystem/Components/MotionComponent';
 import { TransformComponent } from '../EntityComponentSystem/Components/TransformComponent';
 import { System, SystemType } from '../EntityComponentSystem/System';
@@ -39,11 +39,21 @@ export class MotionSystem extends System {
       if (optionalBody?.collisionType === CollisionType.Active && optionalBody?.useGravity) {
         totalAcc.addEqual(this.physics.config.gravity);
       }
-      optionalBody?.captureOldTransform();
+
+      // capture old transform of this entity and all of its children so that
+      // any transform properties that derived from their parents are properly captured
+      if (!entities[i].parent) {
+        this.captureOldTransformWithChildren(entities[i]);
+      }
 
       // Update transform and motion based on Euler linear algebra
       EulerIntegrator.integrate(transform, motion, totalAcc, elapsedMs);
     }
     this._physicsConfigDirty = false;
+  }
+
+  captureOldTransformWithChildren(entity: Entity) {
+    entity.get(BodyComponent)?.captureOldTransform();
+    entity.children.forEach(child => this.captureOldTransformWithChildren(child));
   }
 }

--- a/src/engine/Collision/MotionSystem.ts
+++ b/src/engine/Collision/MotionSystem.ts
@@ -54,6 +54,9 @@ export class MotionSystem extends System {
 
   captureOldTransformWithChildren(entity: Entity) {
     entity.get(BodyComponent)?.captureOldTransform();
-    entity.children.forEach(child => this.captureOldTransformWithChildren(child));
+
+    for (const child of entity.children) {
+      this.captureOldTransformWithChildren(child);
+    }
   }
 }

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -224,6 +224,25 @@ describe('A game actor', () => {
     expect(actor.pos.y).toBe(20);
   });
 
+  it('should have an old global position after an update', () => {
+    const parent = new ex.Actor({ pos: ex.vec(10, 10) });
+    const child = new ex.Actor({ name: 'child', pos: ex.vec(10, 10) });
+    scene.add(parent);
+    parent.addChild(child);
+
+    parent.vel = ex.vec(10, 10);
+
+    expect(child.globalPos.x).toBe(20);
+    expect(child.globalPos.y).toBe(20);
+
+    motionSystem.update(1000);
+
+    expect(child.oldGlobalPos.x).toBe(20);
+    expect(child.oldGlobalPos.y).toBe(20);
+    expect(child.globalPos.x).toBe(30);
+    expect(child.globalPos.y).toBe(30);
+  });
+
   it('actors should generate pair hashes in the correct order', () => {
     const id1 = ex.createId('collider', 20);
     const id2 = ex.createId('collider', 40);


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #2922

## Changes:

- `actor.oldGlobalPos` returns the globalPosition from the previous frame
- `actor.getGlobalPos()` - use `actor.globalPos` instead
- `actor.getGlobalRotation()` - use `actor.globalRotation` instead
- `actor.getGlobalScale()` - use `actor.globalScale` instead

This required some changes to `MotionSystem` so that `globalPos` could be properly captured. Previously, the parent's transform may have already been updated in the system's update when processing a child entity, leading to an incorrect `oldGlobalPos` value. Now, the MotionSystem update captures the entity & all of its children at the same time, skipping any entities that have parents as to not capture them twice over.

This also deprecates other `getGlobalXYZ()` functions and replaces them with getters for consistency.
