### PR TITLE
chore: ensure consistent toEqualImage() resolution when running on hidpi displays

### DIFF
--- a/src/spec/_boot.ts
+++ b/src/spec/_boot.ts
@@ -4,6 +4,9 @@ ex.Flags.enable('suppress-obsolete-message');
 const testsContext = require.context('.', true, /Spec$/);
 testsContext.keys().forEach(testsContext);
 
+// ensure consistent toEqualImage() resolution when running on hidpi displays
+window.devicePixelRatio = 1;
+
 const MemoryReporter = {
   previousMemory: (window.performance as any).memory,
   largeMemory: [],


### PR DESCRIPTION

<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

Some tests were failing when running on my macbook because the resolution of images from `toEqualImage()` were 2x what they should be. Simple fix was to set the devicePixelRatio of the browser to 1 at the start of the tests.