### PR TITLE
docs: polyfill css :has with postcss plugin

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -173,7 +173,11 @@ const config: Config = {
               })
             ]
           };
-        }
+        },
+        configurePostCss(postcssOptions) {
+          postcssOptions.plugins.push(require('css-has-pseudo'));
+          return postcssOptions;
+        },
       };
     },
     [

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -311,7 +311,11 @@ const config: Config = {
        */
       playgroundPosition: 'bottom'
     }
-  } as ClassicPresetThemeConfig
+  } as ClassicPresetThemeConfig,
+
+  clientModules: [
+    './src/polyfills/css-has.js'
+  ]
 };
 
 export default config;

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -29,6 +29,7 @@
         "@docusaurus/module-type-aliases": "3.0.0",
         "@docusaurus/tsconfig": "^3.0.0",
         "@types/react": "^18.2.29",
+        "css-has-pseudo": "^6.0.3",
         "micromark-extension-mdxjs": "^3.0.0",
         "patch-package": "^8.0.0",
         "ts-loader": "^9.5.1",
@@ -2147,6 +2148,28 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.3.tgz",
+      "integrity": "sha512-KEPNw4+WW5AVEIyzC80rTbWEUatTW2lXpN8+8ILC8PiPeWPjwUzrPZDIOZ2wwqDmeqOYTdSGyL3+vE5GC3FB3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -5298,6 +5321,33 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/css-has-pseudo": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-6.0.3.tgz",
+      "integrity": "sha512-qIsDxK/z0byH/mpNsv5hzQ5NOl8m1FRmOLgZpx4bG5uYHnOlO2XafeMI4mFIgNSViHwoUWcxSJZyyijaAmbs+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/selector-specificity": "^3.0.3",
+        "postcss-selector-parser": "^6.0.13",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
       }
     },
     "node_modules/css-loader": {
@@ -17519,6 +17569,13 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "optional": true
     },
+    "@csstools/selector-specificity": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.3.tgz",
+      "integrity": "sha512-KEPNw4+WW5AVEIyzC80rTbWEUatTW2lXpN8+8ILC8PiPeWPjwUzrPZDIOZ2wwqDmeqOYTdSGyL3+vE5GC3FB3Q==",
+      "dev": true,
+      "requires": {}
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -19907,6 +19964,17 @@
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
       "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
       "requires": {}
+    },
+    "css-has-pseudo": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-6.0.3.tgz",
+      "integrity": "sha512-qIsDxK/z0byH/mpNsv5hzQ5NOl8m1FRmOLgZpx4bG5uYHnOlO2XafeMI4mFIgNSViHwoUWcxSJZyyijaAmbs+A==",
+      "dev": true,
+      "requires": {
+        "@csstools/selector-specificity": "^3.0.3",
+        "postcss-selector-parser": "^6.0.13",
+        "postcss-value-parser": "^4.2.0"
+      }
     },
     "css-loader": {
       "version": "6.8.1",

--- a/site/package.json
+++ b/site/package.json
@@ -36,6 +36,7 @@
     "@docusaurus/module-type-aliases": "3.0.0",
     "@docusaurus/tsconfig": "^3.0.0",
     "@types/react": "^18.2.29",
+    "css-has-pseudo": "^6.0.3",
     "micromark-extension-mdxjs": "^3.0.0",
     "patch-package": "^8.0.0",
     "ts-loader": "^9.5.1",

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -5,6 +5,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 
+
 import styles from './index.module.css';
 
 function HomepageHeader() {

--- a/site/src/polyfills/css-has.js
+++ b/site/src/polyfills/css-has.js
@@ -1,0 +1,5 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+if (ExecutionEnvironment.canUseDOM) {
+  require('css-has-pseudo/browser').cssHasPseudo(document);
+}


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

Polyfills CSS :has using the [css-has-pseudo](https://www.npmjs.com/package/css-has-pseudo) postcss plugin. It also involves a JS polyfill (~12kb). Theoretically solves #2981 ... but I haven't tested this on an affected browser. 

There's potential for it to not be perfect (see "Known Shortcomings" section in its readme), but initially it seems OK, but given the CSS+JS size increase + potential issues with docusaurus pages, we'll have to consider if it's worth it or not.

Highlighted section is the polyfill I believe

![CleanShot 2024-04-07 at 18 32 17@2x](https://github.com/excaliburjs/Excalibur/assets/8703090/fd4b633a-d6d3-4e8c-b9cc-ef1b5966b194)

