### PR TITLE
fix: getSceneName use scenes  #3022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
--
+- `actor.getGlobalPos()` - use `actor.globalPos` instead
+- `actor.getGlobalRotation()` - use `actor.globalRotation` instead
+- `actor.getGlobalScale()` - use `actor.globalScale` instead
 
 ### Added
 
--
+- `actor.oldGlobalPos` returns the globalPosition from the previous frame
 
 ### Fixed
 
@@ -41,7 +43,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
--
+- `
 
 ### Added
 

--- a/sandbox/tests/sprite/sprite.ts
+++ b/sandbox/tests/sprite/sprite.ts
@@ -28,8 +28,9 @@ var sprite = new ex.Sprite({
     height: 1000
   }
 });
-var actor = new ex.Actor({ 
-  x: 0, y: 0, 
+var actor = new ex.Actor({
+  x: 0,
+  y: 0,
   anchor: ex.vec(0, 0),
   coordPlane: ex.CoordPlane.Screen,
   z: -10
@@ -38,8 +39,8 @@ actor.onInitialize = () => {
   actor.graphics.add(sprite);
 };
 actor.onPostUpdate = (engine, delta) => {
-  sprite.sourceView.x += .05 * delta;
-}
+  sprite.sourceView.x += 0.05 * delta;
+};
 game.add(actor);
 game.start(loader);
 

--- a/sandbox/tests/sprite/sprite.ts
+++ b/sandbox/tests/sprite/sprite.ts
@@ -9,24 +9,38 @@ var game = new ex.Engine({
   // antialiasing: false
 });
 
-var tex = new ex.ImageSource('https://cdn.rawgit.com/excaliburjs/Excalibur/7dd48128/assets/sword.png');
+var tex = new ex.ImageSource('https://cdn.rawgit.com/excaliburjs/Excalibur/7dd48128/assets/sword.png', {
+  wrapping: ex.ImageWrapping.Repeat
+});
 
 var loader = new ex.Loader([tex]);
 
-var actor = new ex.Actor({ x: 100, y: 100, width: 50, height: 50 });
+var sprite = new ex.Sprite({
+  image: tex,
+  sourceView: {
+    x: 0,
+    y: 0,
+    width: 500,
+    height: 500
+  },
+  destSize: {
+    width: 1000,
+    height: 1000
+  }
+});
+var actor = new ex.Actor({ 
+  x: 0, y: 0, 
+  anchor: ex.vec(0, 0),
+  coordPlane: ex.CoordPlane.Screen,
+  z: -10
+});
 actor.onInitialize = () => {
-  var sprite = new ex.Sprite({
-    image: tex,
-    destSize: {
-      width: 100,
-      height: 100
-    }
-  });
   actor.graphics.add(sprite);
 };
+actor.onPostUpdate = (engine, delta) => {
+  sprite.sourceView.x += .05 * delta;
+}
 game.add(actor);
 game.start(loader);
 
 game.currentScene.camera.pos = actor.pos;
-game.currentScene.camera.zoom = 7;
-actor.angularVelocity = 0.1;

--- a/site/docs/05-entity-component-system/05.1-entities.mdx
+++ b/site/docs/05-entity-component-system/05.1-entities.mdx
@@ -8,7 +8,7 @@ An [[Entity]] in is an empty container for [[Component|Components]] which store 
 
 They are useful for defining bare bones game objects with custom behavior.
 
-If you want a batteries included prebuilt Entity use an [[Actor]], read more [here](/docs/actor). Remember an Excalibur [[Actor]] is just an Entity with a list of prebuilt components and some useful apis built over them.
+If you want a batteries included prebuilt Entity use an [[Actor]], read more [here](/docs/actors). Remember an Excalibur [[Actor]] is just an Entity with a list of prebuilt components and some useful apis built over them.
 
 ## Entity
 

--- a/site/docs/05-entity-component-system/05.3-systems.mdx
+++ b/site/docs/05-entity-component-system/05.3-systems.mdx
@@ -123,7 +123,7 @@ class SearchSystem extends ex.System {
 }
 
 const scene = new ex.Scene();
-scene.world.add(new SearchSystem());
+scene.world.add(SearchSystem);
 
 // Actors come with batteries included built in features
 const actor = new ex.Actor({

--- a/site/docs/11-input/10.1-input.mdx
+++ b/site/docs/11-input/10.1-input.mdx
@@ -23,7 +23,7 @@ class Player extends ex.Actor {
       engine.input.keyboard.isHeld(ex.Input.Keys.W) ||
       engine.input.gamepads.at(0).getAxes(ex.Input.Axes.LeftStickY) > 0.5
     ) {
-      player._moveForward()
+      // implement the code to move the player forward
     }
   }
 }

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -259,6 +259,15 @@ const config: Config = {
           title: 'Community',
           items: [
             {
+              label: 'Mastodon',
+              href: 'https://mastodon.gamedev.place/@excaliburjs',
+              rel: 'me'
+            },
+            {
+              label: 'Threads',
+              href: 'https://www.threads.net/@excalibur.js'
+            },
+            {
               label: 'Twitter',
               href: 'https://twitter.com/excaliburjs'
             },
@@ -269,8 +278,7 @@ const config: Config = {
             {
               label: 'Discussions',
               href: 'https://github.com/excaliburjs/Excalibur/discussions'
-            },
-            
+            }
           ]
         },
         {

--- a/site/src/pages/showcase/_data.ts
+++ b/site/src/pages/showcase/_data.ts
@@ -20,8 +20,8 @@ export default [
     image: sumMonstersImage,
     description:
       'Play the mathimagical game where you arrange monsters to complete the dungeon’s sum-mons. May Trix the Witch is doing all she can to bring the dungeon to order!',
-    url: 'https://excaliburjs.com/ludum-55/',
-    source: 'https://github.com/excaliburjs/ludum-55',
+    url: 'https://excaliburjs.com/sum-monsters/',
+    source: 'https://github.com/excaliburjs/sum-monsters',
   },
   {
     title: 'Excali-Farm',

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -294,6 +294,13 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
   }
 
   /**
+   * Gets the global position vector of the actor from the last frame
+   */
+  public get oldGlobalPos(): Vector {
+    return this.body.oldGlobalPos;
+  }
+
+  /**
    * Sets the position vector of the actor in the last frame
    */
   public set oldPos(thePos: Vector) {
@@ -833,25 +840,50 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
   /**
    * Gets this actor's rotation taking into account any parent relationships
    * @returns Rotation angle in radians
+   * @deprecated Use [[globalRotation]] instead
    */
   public getGlobalRotation(): number {
     return this.get(TransformComponent).globalRotation;
   }
 
   /**
+   * The actor's rotation (in radians) taking into account any parent relationships
+   */
+  public get globalRotation(): number {
+    return this.get(TransformComponent).globalRotation;
+  }
+
+  /**
    * Gets an actor's world position taking into account parent relationships, scaling, rotation, and translation
    * @returns Position in world coordinates
+   * @deprecated Use [[globalPos]] instead
    */
   public getGlobalPos(): Vector {
     return this.get(TransformComponent).globalPos;
   }
 
   /**
+   * The actor's world position taking into account parent relationships, scaling, rotation, and translation
+   */
+  public get globalPos(): Vector {
+    return this.get(TransformComponent).globalPos;
+  }
+
+  /**
    * Gets the global scale of the Actor
+   * @deprecated Use [[globalScale]] instead
    */
   public getGlobalScale(): Vector {
     return this.get(TransformComponent).globalScale;
   }
+
+  /**
+   * The global scale of the Actor
+   */
+  public get globalScale(): Vector {
+    return this.get(TransformComponent).globalScale;
+  }
+
 
   // #region Collision
 

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -884,7 +884,6 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
     return this.get(TransformComponent).globalScale;
   }
 
-
   // #region Collision
 
   /**

--- a/src/engine/Collision/BodyComponent.ts
+++ b/src/engine/Collision/BodyComponent.ts
@@ -249,7 +249,7 @@ export class BodyComponent extends Component implements Clonable<BodyComponent> 
   }
 
   /**
-   * @deprecated Use globalP0s
+   * @deprecated Use globalPos
    */
   public get center() {
     return this.globalPos;
@@ -284,11 +284,20 @@ export class BodyComponent extends Component implements Clonable<BodyComponent> 
     this.transform.globalPos = val;
   }
 
+  private _oldGlobalPos: Vector = Vector.Zero;
+
   /**
    * The position of the actor last frame (x, y) in pixels
    */
   public get oldPos(): Vector {
     return this.oldTransform.pos;
+  }
+
+  /**
+   * The global position of the actor last frame (x, y) in pixels
+   */
+  public get oldGlobalPos(): Vector {
+    return this._oldGlobalPos;
   }
 
   /**
@@ -470,6 +479,7 @@ export class BodyComponent extends Component implements Clonable<BodyComponent> 
     this.oldTransform.parent = tx.parent; // also grab parent
     this.oldVel.setTo(this.vel.x, this.vel.y);
     this.oldAcc.setTo(this.acc.x, this.acc.y);
+    this.oldGlobalPos.setTo(this.globalPos.x, this.globalPos.y);
   }
 
   public clone(): BodyComponent {

--- a/src/engine/Director/Director.ts
+++ b/src/engine/Director/Director.ts
@@ -279,13 +279,35 @@ export class Director<TKnownScenes extends string = any> {
     return undefined;
   }
 
-  getSceneName(scene: Scene) {
-    for (const [name, sceneInstance] of Object.entries(this.scenes)) {
-      if (scene === sceneInstance) {
-        return name;
+  /**
+   * Returns the name of the registered scene, null if none can be found
+   * @param scene
+   */
+  getSceneName(scene: Scene): string | null {
+    for (const [name, maybeScene] of Object.entries(this.scenes)) {
+      if (maybeScene instanceof Scene) {
+        if (scene === maybeScene) {
+          return name;
+        }
+      } else if (!isSceneConstructor(maybeScene)) {
+        if (scene === maybeScene.scene) {
+          return name;
+        }
       }
     }
-    return 'unknown scene name';
+
+    for (const [name, maybeScene] of Object.entries(this.scenes)) {
+      if (isSceneConstructor(maybeScene)) {
+        if (scene.constructor === maybeScene) {
+          return name;
+        }
+      } else if (!(maybeScene instanceof Scene)) {
+        if (scene.constructor === maybeScene.scene) {
+          return name;
+        }
+      }
+    }
+    return null;
   }
 
   /**

--- a/src/engine/EntityComponentSystem/Entity.ts
+++ b/src/engine/EntityComponentSystem/Entity.ts
@@ -67,7 +67,7 @@ export const EntityEvents = {
 
 export interface EntityOptions<TComponents extends Component> {
   name?: string;
-  components: TComponents[];
+  components?: TComponents[];
 }
 
 /**
@@ -122,7 +122,7 @@ export class Entity<TKnownComponents extends Component = any> implements OnIniti
       nameToAdd = name;
     } else if (componentsOrOptions && typeof componentsOrOptions === 'object') {
       const { components, name } = componentsOrOptions;
-      componentsToAdd = components;
+      componentsToAdd = components ?? [];
       nameToAdd = name;
     }
     if (nameToAdd) {

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -223,6 +223,25 @@ describe('A game actor', () => {
     expect(actor.pos.y).toBe(20);
   });
 
+  it('should have an old global position after an update', () => {
+    const parent = new ex.Actor({ pos: ex.vec(10, 10) });
+    const child = new ex.Actor({ name: 'child', pos: ex.vec(10, 10) });
+    scene.add(parent);
+    parent.addChild(child);
+
+    parent.vel = ex.vec(10, 10);
+
+    expect(child.globalPos.x).toBe(20);
+    expect(child.globalPos.y).toBe(20);
+
+    motionSystem.update(1000);
+
+    expect(child.oldGlobalPos.x).toBe(20);
+    expect(child.oldGlobalPos.y).toBe(20);
+    expect(child.globalPos.x).toBe(30);
+    expect(child.globalPos.y).toBe(30);
+  });
+
   it('actors should generate pair hashes in the correct order', () => {
     const id1 = ex.createId('collider', 20);
     const id2 = ex.createId('collider', 40);

--- a/src/spec/DirectorSpec.ts
+++ b/src/spec/DirectorSpec.ts
@@ -96,6 +96,36 @@ describe('A Director', () => {
     engine.dispose();
   });
 
+  it('can get a scene name', () => {
+    const engine = TestUtils.engine();
+    const clock = engine.clock as ex.TestClock;
+    clock.start();
+    const scene1 = new ex.Scene();
+    scene1._initialize(engine);
+    const scene2 = new ex.Scene();
+    scene2._initialize(engine);
+    const scene3 = new ex.Scene();
+    scene3._initialize(engine);
+
+    class SceneCtor1 extends ex.Scene {}
+    class SceneCtor2 extends ex.Scene {}
+
+    const sut = new ex.Director(engine, {
+      scene1,
+      scene2,
+      myScene: { scene: scene3 },
+      sceneWithCtor: { scene: SceneCtor1 },
+      ctor: SceneCtor2
+    });
+
+    expect(sut.getSceneName(scene1)).toBe('scene1');
+    expect(sut.getSceneName(scene2)).toBe('scene2');
+    expect(sut.getSceneName(scene3)).toBe('myScene');
+    expect(sut.getSceneName(new SceneCtor1())).toBe('sceneWithCtor');
+    expect(sut.getSceneName(new SceneCtor2())).toBe('ctor');
+    expect(sut.getSceneName(new ex.Scene())).toBe(null);
+  });
+
   it('will draw a start scene transition', async () => {
     const engine = TestUtils.engine();
     const clock = engine.clock as ex.TestClock;


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #3022

## Changes:

- Fixed `getSceneName` to use `scene`.

I didn't know how to use `_sceneToInstance` cache, so I replaced it with something simpler.