### PR TITLE
Make Entity Constructor's `components` option optional

### DIFF
--- a/src/engine/EntityComponentSystem/Entity.ts
+++ b/src/engine/EntityComponentSystem/Entity.ts
@@ -67,7 +67,7 @@ export const EntityEvents = {
 
 export interface EntityOptions<TComponents extends Component> {
   name?: string;
-  components: TComponents[];
+  components?: TComponents[];
 }
 
 /**
@@ -122,7 +122,7 @@ export class Entity<TKnownComponents extends Component = any> implements OnIniti
       nameToAdd = name;
     } else if (componentsOrOptions && typeof componentsOrOptions === 'object') {
       const { components, name } = componentsOrOptions;
-      componentsToAdd = components;
+      componentsToAdd = components ?? [];
       nameToAdd = name;
     }
     if (nameToAdd) {


### PR DESCRIPTION
Had a conversation here https://discord.com/channels/1195771303215513671/1232877562804305920

```
From example in https://excaliburjs.com/docs/entities:
const entityWithName = new ex.Entity({name: 'Named Entity'});


No overload matches this call.
  Overload 1 of 2, '(options: EntityOptions<any>): Entity<any>', gave the following error.
    Argument of type '{ name: string; }' is not assignable to parameter of type 'EntityOptions<any>'.
      Property 'components' is missing in type '{ name: string; }' but required in type 'EntityOptions<any>'.
  Overload 2 of 2, '(components?: any[] | undefined, name?: string | undefined): Entity<any>', gave the following error.
    Object literal may only specify known properties, and 'name' does not exist in type 'any[]'.ts(2769)
Entity.d.ts(58, 5): 'components' is declared here.


It seems that components is not optional here

export interface EntityOptions<TComponents extends Component> {
    name?: string;
    components: TComponents[];
}

```

Changes:
- Make `components` options optional here.