### PR TITLE
feat: add centerDrawPos and centerCanvasPos

### DIFF
--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -506,6 +506,20 @@ export class Engine<TKnownScenes extends string = any> implements CanInitialize,
   }
 
   /**
+   * Returns center pos of the engine's visible drawing surface in pixels including zoom and device pixel ratio.
+   */
+  public get centerDrawPos(): Vector {
+    return new Vector(this.screen.halfDrawWidth, this.screen.halfDrawHeight);
+  }
+
+  /**
+   * Returns center pos of the game canvas in pixels
+   */
+  public get centerCanvasPos(): Vector {
+    return new Vector(this.screen.halfCanvasWidth, this.screen.halfCanvasHeight);
+  }
+
+  /**
    * Returns whether excalibur detects the current screen to be HiDPI
    */
   public get isHiDpi(): boolean {


### PR DESCRIPTION
## Changes:

- add `centerDrawPos` and `centerCanvasPos` properties to get the center pos quickly, no need to calculate pos by halfWidth or halfHeight anymore.
```ts
// before
pos: ex.vec(engine.halfDrawWidth, engine.halfDrawHeight + 200)

// after
pos: engine.centerDrawPos.add(ex.vec(0, 200))
```