### PR TITLE
feat: add Anchor class

### DIFF
--- a/src/engine/Anchor.ts
+++ b/src/engine/Anchor.ts
@@ -1,0 +1,58 @@
+import { Vector, vec } from "./excalibur";
+
+export class Anchor {
+  /**
+   * get TopLeft Anchor Vector
+   */
+  public static get TopLeft(): Vector {
+    return vec(0, 0)
+  }
+  /**
+   * get TopCenter Anchor Vector
+   */
+  public static get TopCenter(): Vector {
+    return vec(0.5, 0)
+  }
+  /**
+   * get TopRight Anchor Vector
+   */
+  public static get TopRight(): Vector {
+    return vec(1, 0)
+  }
+  /**
+   * get LeftCenter Anchor Vector
+   */
+  public static get LeftCenter(): Vector {
+    return vec(0, 0.5)
+  }
+  /**
+   * get Center Anchor Vector
+   */
+  public static get Center(): Vector {
+    return vec(0.5, 0.5)
+  }
+   /**
+   * get RightCenter Anchor Vector
+   */
+  public static get RightCenter(): Vector {
+    return vec(1, 0.5)
+  }
+  /**
+   * get BottomLeft Anchor Vector
+   */
+  public static get BottomLeft(): Vector {
+    return vec(0, 1)
+  }
+  /**
+   * get BottomCenter Anchor Vector
+   */
+  public static get BottomCenter(): Vector {
+    return vec(0.5, 1)
+  }
+  /**
+   * get BottomRight Anchor Vector
+   */
+  public static get BottomRight(): Vector {
+    return vec(1, 1)
+  }
+}

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -44,6 +44,7 @@ export * from './EntityComponentSystem/index';
 export * from './Director/index';
 
 export * from './Color';
+export * from './Anchor';
 
 export * from './Graphics/index';
 


### PR DESCRIPTION
## Changes:

- add commonly used anchor vector as Anchor Class, no need to write `ex.vec(x, y)` but use `ex.Anchor.TopLeft`, it makes code more stable.
