### PR TITLE
feat: Added default value to Canvas constructor

### DIFF
--- a/src/engine/Graphics/Canvas.ts
+++ b/src/engine/Graphics/Canvas.ts
@@ -22,7 +22,7 @@ export class Canvas extends Raster {
     return this._ctx;
   }
 
-  constructor(private _options: GraphicOptions & RasterOptions & CanvasOptions) {
+  constructor(private _options: GraphicOptions & RasterOptions & CanvasOptions = {}) {
     super(_options);
   }
 


### PR DESCRIPTION
The combined type for the constructor property has no required fields. This way you don't have to add an empty object to the superclass's constructor when, for example, creating a Canvas subclass
