### PR TITLE
feat: removed invalid null as value from Random.shuffle()

### DIFF
--- a/src/engine/Math/Random.ts
+++ b/src/engine/Math/Random.ts
@@ -205,7 +205,7 @@ export class Random {
    */
   public shuffle<T>(array: Array<T>): Array<T> {
     const tempArray = array.slice(0);
-    let swap: T = null;
+    let swap: T;
     for (let i = 0; i < tempArray.length - 2; i++) {
       const randomIndex = this.integer(i, tempArray.length - 1);
       swap = tempArray[i];


### PR DESCRIPTION
Setting `null` on a variable of type `T` isn't valid in the eyes of TS
