### PR TITLE
doc config tweak

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -74,7 +74,11 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl: 'https://github.com/excaliburjs/Excalibur/tree/main/site/blog/',
-          rehypePlugins: [[rehypeRaw, rehypeRawOptions]]
+          rehypePlugins: [[rehypeRaw, rehypeRawOptions]],
+          postsPerPage: 'ALL',
+          blogSidebarTitle: 'All posts',
+          blogSidebarCount: 'ALL',
+          
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css')


### PR DESCRIPTION
Tweaking the docusaurus configuration file, adding

```ts
blog: {
          showReadingTime: true,
          // Please change this to your repo.
          // Remove this to remove the "edit this page" links.
          editUrl: 'https://github.com/excaliburjs/Excalibur/tree/main/site/blog/',
          rehypePlugins: [[rehypeRaw, rehypeRawOptions]],
          postsPerPage: 'ALL',     //-----------------------------------------new
          blogSidebarTitle: 'All posts',//-----------------------------------------new
          blogSidebarCount: 'ALL',//-----------------------------------------new
          
        },
```