### PR TITLE
blogpost: Cellular Automata Typos

### DIFF
--- a/site/blog/2024-6-16-cellular-automata/cellularautonoma.mdx
+++ b/site/blog/2024-6-16-cellular-automata/cellularautonoma.mdx
@@ -171,7 +171,7 @@ To note, this approach to the CA algorithm is for the sake of THIS article. Othe
 tiles = applyCellularAutomataRules(tiles, 7, 7, 'walls', 3, 5);
 ```
 
-With these rules in place, which can be modified and tailored to your liking, we can use them to determine the next interation of the grid by going tile by tile and setting the new grid's values based on each tile's neighbors.
+With these rules in place, which can be modified and tailored to your liking, we can use them to determine the next iteration of the grid by going tile by tile and setting the new grid's values based on each tile's neighbors.
 
 ### Counting Walls
 
@@ -337,8 +337,8 @@ So you see how numbers start to collect together to create natural, organic look
 
 [Link to Repo](https://github.com/jyoung4242/CA-itchdemo)
 
-The demo simply consists of a 36x36 Tilemap of blue and white tiles. Blue tiles represent the walls, and white tiles represent the
-floor tiles. There are two buttons, one that resets the simulation, and the other button triggers the CA algorithm and uses the Tilemap
+The demo simply consists of a 36x36 tilemap of blue and white tiles. Blue tiles represent the walls, and white tiles represent the
+floor tiles. There are two buttons, one that resets the simulation, and the other button triggers the CA algorithm and uses the tilemap
 to demonstrate the results.
 
 Also added to the demo is access to some of the variables that manipulate the simulation. We can now modify the behavior of the OOB
@@ -370,6 +370,6 @@ development. We covered the implementation of the steps to take to perform the s
 walk through example of using the algorithm. Finally, we introduced a demo application hosted on itch, and shared the repository in
 case one is interested in the implementation of it.
 
-This algorithm is one of the easier to implement, as the steps are not that complicated either in congnitive depth or in mathematical
+This algorithm is one of the easier to implement, as the steps are not that complicated either in cognitive depth or in mathematical
 processing. It is one of my favorite simple tools that reach for especially for tilemap generation when I create levels. I urge you to
 give it a try and see what you can generate for yourself!


### PR DESCRIPTION
- fixed typo of 'cognitive' in conclusion
- fixed typo of 'iteration' 
- made the word tilemap more consistent in capitalization