### PR TITLE
feat: expose all actor exports

### DIFF
--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -12,7 +12,7 @@ export * from './Flags';
 export * from './Id';
 export * from './Engine';
 export * from './Screen';
-export { Actor, ActorArgs } from './Actor';
+export * from './Actor';
 export * from './Math/Index';
 export * from './Camera';
 export * from './Configurable';


### PR DESCRIPTION
I originally only intended to add `ActorEvents` to the exports, so it's possible to extend it without a dirty import:
 `import {ActorEvents} from "excalibur/build/dist/Actor";`

But I don't see any reason to not export all of the Actor exports, because `isActor` could also be really useful for people extending core EX functionality.