### PR TITLE
feat: add CollisionContact.bias(collider)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - show warning in development when Entity hasn't been added to a scene after a few seconds
 - New `RentalPool` type for sparse object pooling
 - New `ex.SparseHashGridCollisionProcessor` which is a simpler (and faster) implementation for broadphase pair generation. This works by bucketing colliders into uniform sized square buckets and using that to generate pairs.
+- CollisionContact can be biased toward a collider by using `contact.bias(collider)`. This adjusts the contact so that the given collider is colliderA, and is helpful if you 
+are doing mtv adjustments during precollision.
 
 ### Fixed
 

--- a/src/engine/Collision/Detection/CollisionContact.ts
+++ b/src/engine/Collision/Detection/CollisionContact.ts
@@ -118,4 +118,28 @@ export class CollisionContact {
   public cancel(): void {
     this._canceled = true;
   }
+
+  /**
+   * Biases the contact so that the given collider is colliderA
+   */
+  public bias(collider: Collider) {
+    if (collider !== this.colliderA && collider !== this.colliderB) {
+      throw new Error('Collider must be either colliderA or colliderB from this contact');
+    }
+
+    if (collider === this.colliderA) {
+      return this;
+    }
+
+    const colliderA = this.colliderA;
+    const colliderB = this.colliderB;
+
+    this.colliderB = colliderA;
+    this.colliderA = colliderB;
+    this.mtv = this.mtv.negate();
+    this.normal = this.normal.negate();
+    this.tangent = this.tangent.negate();
+
+    return this;
+  }
 }

--- a/src/spec/CollisionContactSpec.ts
+++ b/src/spec/CollisionContactSpec.ts
@@ -3,6 +3,7 @@ import { TransformComponent } from '@excalibur';
 import { EulerIntegrator } from '../engine/Collision/Integrator';
 import { MotionComponent } from '../engine/EntityComponentSystem/Components/MotionComponent';
 import { DefaultPhysicsConfig } from '../engine/Collision/PhysicsConfig';
+import { ExcaliburMatchers } from 'excalibur-jasmine';
 
 describe('A CollisionContact', () => {
   let actorA: ex.Actor;
@@ -12,6 +13,7 @@ describe('A CollisionContact', () => {
   let colliderB: ex.Collider;
 
   beforeEach(() => {
+    jasmine.addMatchers(ExcaliburMatchers);
     actorA = new ex.Actor({ x: 0, y: 0, width: 20, height: 20 });
     actorA.collider.useCircleCollider(10);
     actorA.body.collisionType = ex.CollisionType.Active;
@@ -325,5 +327,26 @@ describe('A CollisionContact', () => {
 
     expect(emittedA).toBe(true);
     expect(emittedB).toBe(true);
+  });
+
+  fit('biases to colliderB', () => {
+    const cc = new ex.CollisionContact(
+      colliderA,
+      colliderB,
+      ex.Vector.Right,
+      ex.Vector.Right,
+      ex.Vector.Right.perpendicular(),
+      [new ex.Vector(10, 0)],
+      [new ex.Vector(10, 0)],
+      null
+    );
+
+    cc.bias(colliderB);
+
+    expect(cc.colliderA).toBe(colliderB);
+    expect(cc.colliderB).toBe(colliderA);
+    expect(cc.mtv).toBeVector(ex.Vector.Left);
+    expect(cc.normal).toBeVector(ex.Vector.Left);
+    expect(cc.tangent).toBeVector(ex.Vector.Left.perpendicular());
   });
 });

--- a/src/spec/CollisionContactSpec.ts
+++ b/src/spec/CollisionContactSpec.ts
@@ -329,7 +329,7 @@ describe('A CollisionContact', () => {
     expect(emittedB).toBe(true);
   });
 
-  fit('biases to colliderB', () => {
+  it('biases to colliderB', () => {
     const cc = new ex.CollisionContact(
       colliderA,
       colliderB,


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Follow up from https://github.com/excaliburjs/Excalibur/issues/3121

## Changes:

- CollisionContact can be biased toward a collider by using `contact.bias(collider)`. This adjusts the contact so that the given collider is colliderA, and is helpful if you 
are doing mtv adjustments during precollision.