### PR TITLE
fix: rewrite ClosestLine and PolygonPolygonClosestLine logic for improved accuracy on sloped polygons

### DIFF
--- a/src/spec/CollisionShapeSpec.ts
+++ b/src/spec/CollisionShapeSpec.ts
@@ -846,6 +846,18 @@ describe('Collision Shape', () => {
       expect(line.getEdge().dot(ex.Vector.Right)).toBeGreaterThan(0, 'Line from polygon to polygon should be away from polygon');
     });
 
+    it('can calculate the distance to angled edge on polygon', () => {
+      const box = ex.Shape.Box(40, 40, ex.Vector.Zero);
+
+      // triangle, angled edge facing box
+      const poly = ex.Shape.Polygon([new ex.Vector(0, 0), new ex.Vector(0, 40), new ex.Vector(-40, 40)], ex.vec(90, 0));
+
+      const line = box.getClosestLineBetween(poly);
+
+      expect(line.getLength()).toBe(10);
+      expect(line.getEdge().dot(ex.Vector.Right)).toBeGreaterThan(0, 'Line from polygon to polygon should be away from polygon');
+    });
+
     it('can calculate the distance to another edge', () => {
       const poly = ex.Shape.Box(40, 40, ex.Vector.Half, new ex.Vector(100, 100));
 


### PR DESCRIPTION


<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Improves accuracy of PolygonPolygonClosestLine and ClosestLine functions. Big disclaimer, I heavily relied on ChatGPT for the math logic here... extra eyes greatly appreciated. I myself plan to do a deeper review on the math here before merging.

Before:

https://github.com/user-attachments/assets/a0d9d5d5-76e9-4e05-8459-15b6a48b0dcb

After:


https://github.com/user-attachments/assets/85d4410b-2bf2-4f51-90e2-4ee828a9693b


I also think there's a faster way to do the `PolygonPolygonClosestLine` logic. Right now it iterates over each side of the polygon, draws a line, and returns the shortest result. Potentially it could use SAT to determine the closest sides, but I had unexpected results

```ts
PolygonPolygonClosestLine(polygonA: PolygonCollider, polygonB: PolygonCollider) {
    const aSat = SeparatingAxis.findPolygonPolygonSeparation(polygonA, polygonB);
    const bSat = SeparatingAxis.findPolygonPolygonSeparation(polygonB, polygonA);

    return ClosestLine2(aSat.side, bSat.side);
}
```

https://github.com/user-attachments/assets/be6460cb-7786-4864-93aa-d8053478aa53

