### PR TITLE
fix: [#3128] Unused scene loader locks up engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ are doing mtv adjustments during precollision.
 
 ### Fixed
 
+- Fixed issue where `ex.Scene.onPreLoad(loader: ex.DefaultLoader)` would lock up the engine if there was an empty loader
 - Fixed issue where `ex.Scene` scoped input events would preserve state and get stuck causing issues when switching back to the original scene.
 - Fixed issue where not all physical keys from the spec were present in `ex.Keys` including the reported `ex.Keys.Tab`
 - Fixed invalid graphics types around `ex.Graphic.tint`

--- a/sandbox/tests/loader-lockup/index.html
+++ b/sandbox/tests/loader-lockup/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Loader Lockup</title>
+  </head>
+  <body>
+    <script src="../../lib/excalibur.js"></script>
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/sandbox/tests/loader-lockup/index.ts
+++ b/sandbox/tests/loader-lockup/index.ts
@@ -1,0 +1,33 @@
+class SceneX extends ex.Scene {
+  override backgroundColor = ex.Color.DarkGray;
+  override onInitialize() {
+    this.input.pointers.on('down', () => {
+      console.warn('should change scenes');
+      this.engine.goToScene('SceneY');
+    });
+  }
+}
+
+class SceneY extends ex.Scene {
+  override backgroundColor = ex.Color.Viridian;
+  // issue still occurs if onPreLoad is not defined or
+  // if we call super.onPreLoad(loader)
+  override onPreLoad(loader: ex.DefaultLoader) {
+    // un-commenting this call fixes the issue.
+    // loader.addResource({
+    //   data: {},
+    //   isLoaded: () => true,
+    //   load: () => Promise.resolve(),
+    // });
+  }
+}
+
+var gameLoaderLockup = new ex.Engine({
+  scenes: {
+    SceneX,
+    SceneY: { scene: SceneY, loader: ex.Loader }
+  }
+});
+
+gameLoaderLockup.start();
+gameLoaderLockup.goToScene('SceneX');

--- a/src/engine/Director/DefaultLoader.ts
+++ b/src/engine/Director/DefaultLoader.ts
@@ -186,6 +186,10 @@ export class DefaultLoader implements Loadable<Loadable<any>[]> {
 
   private _loadingFuture = new Future<void>();
   public areResourcesLoaded() {
+    if (this._resources.length === 0) {
+      // special case no resources mean loaded;
+      return Promise.resolve();
+    }
     return this._loadingFuture.promise;
   }
 

--- a/src/spec/DefaultLoaderSpec.ts
+++ b/src/spec/DefaultLoaderSpec.ts
@@ -25,6 +25,12 @@ describe('A DefaultLoader', () => {
     expect(sut).toBeDefined();
   });
 
+  it('is loaded when no resources', async () => {
+    const loader = new ex.DefaultLoader();
+    expect(loader.isLoaded()).toBe(true);
+    await expectAsync(loader.areResourcesLoaded()).toBeResolved();
+  });
+
   it('can be constructed with non-defaults', () => {
     const sut = new ex.DefaultLoader({
       loadables: [new ex.ImageSource('./some/image.png')]


### PR DESCRIPTION


<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #3128

* Special case when no resources, consider it "loaded"

