### PR TITLE
feat: add Jetbrains .idea dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ Thumbs.db
 
 # Build
 .vs/
+.idea/
 build/
 build-storybook/
 bld/


### PR DESCRIPTION
Jetbrains IDEs create a `.idea` dir in each repository to store configurations (like `.vs` and `.vscode`).

I'm aware that `.git/info/exclude` can be used as a localized .gitignore file or `~/..config/git/ignore` for global ignores, so I'll leave it up to the maintainers if this solution is ok.

## Changes:

- Added `.idea` to `.gitignore` to prevent this dir from accidentally being committed.
