### PR TITLE
Feat: [#3157] return target on trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 
+- `Trigger` API has been slightly changed:
+  - `action` now returns the triggering entity: `(entity: Entity) => void`
+  - `target` now works in conjunction with `filter` instead of overwriting it.
+  - `EnterTriggerEvent` and `ExitTriggerEvent` now contain a `entity: Entity` property instead of `actor: Actor`
 - `ex.Vector.normalize()` return zero-vector (`(0,0)`) instead of `(0,1)` when normalizing a vector with a magnitude of 0
 - `ex.Gif` transparent color constructor arg is removed in favor of the built in Gif file mechanism
 - Remove core-js dependency, it is no longer necessary in modern browsers. Technically a breaking change for older browsers

--- a/sandbox/tests/trigger/trigger.ts
+++ b/sandbox/tests/trigger/trigger.ts
@@ -17,12 +17,12 @@ var trigger = new ex.Trigger({
 });
 
 trigger.on('collisionstart', (evt: ex.EnterTriggerEvent) => {
-  evt.actor.color = ex.Color.Green;
+  evt.entity.color = ex.Color.Green;
   console.log(evt);
 });
 
 trigger.on('collisionend', (evt: ex.ExitTriggerEvent) => {
-  evt.actor.color = ex.Color.Red;
+  evt.entity.color = ex.Color.Red;
   console.log(evt);
 });
 

--- a/sandbox/tests/trigger/trigger.ts
+++ b/sandbox/tests/trigger/trigger.ts
@@ -17,12 +17,18 @@ var trigger = new ex.Trigger({
 });
 
 trigger.on('collisionstart', (evt: ex.EnterTriggerEvent) => {
-  evt.entity.color = ex.Color.Green;
+  if (evt.entity instanceof ex.Actor) {
+    evt.entity.color = ex.Color.Green;
+  }
+
   console.log(evt);
 });
 
 trigger.on('collisionend', (evt: ex.ExitTriggerEvent) => {
-  evt.entity.color = ex.Color.Red;
+  if (evt.entity instanceof ex.Actor) {
+    evt.entity.color = ex.Color.Red;
+  }
+
   console.log(evt);
 });
 

--- a/src/engine/Events.ts
+++ b/src/engine/Events.ts
@@ -665,19 +665,19 @@ export class EnterViewPortEvent extends GameEvent<Entity> {
   }
 }
 
-export class EnterTriggerEvent extends GameEvent<Actor> {
+export class EnterTriggerEvent extends GameEvent<Trigger> {
   constructor(
     public target: Trigger,
-    public actor: Actor
+    public entity: Entity
   ) {
     super();
   }
 }
 
-export class ExitTriggerEvent extends GameEvent<Actor> {
+export class ExitTriggerEvent extends GameEvent<Trigger> {
   constructor(
     public target: Trigger,
-    public actor: Actor
+    public entity: Entity
   ) {
     super();
   }

--- a/src/engine/Trigger.ts
+++ b/src/engine/Trigger.ts
@@ -1,4 +1,3 @@
-import { Engine } from './Engine';
 import { Vector } from './Math/vector';
 import { ExitTriggerEvent, EnterTriggerEvent, CollisionEndEvent, CollisionStartEvent } from './Events';
 import { CollisionType } from './Collision/CollisionType';
@@ -38,18 +37,6 @@ export interface TriggerOptions {
   repeat: number;
 }
 
-const triggerDefaults: Partial<TriggerOptions> = {
-  pos: Vector.Zero,
-  width: 10,
-  height: 10,
-  visible: false,
-  action: () => {
-    return;
-  },
-  filter: () => true,
-  repeat: -1
-};
-
 /**
  * Triggers are a method of firing arbitrary code on collision. These are useful
  * as 'buttons', 'switches', or to trigger effects in a game. By default triggers
@@ -57,72 +44,57 @@ const triggerDefaults: Partial<TriggerOptions> = {
  */
 export class Trigger extends Actor {
   public events = new EventEmitter<TriggerEvents & ActorEvents>();
-  private _target: Entity;
+  public target?: Entity;
   /**
    * Action to fire when triggered by collision
    */
-  public action: (entity: Entity) => void = () => {
-    return;
-  };
+  public action: (entity: Entity) => void;
   /**
    * Filter to add additional granularity to action dispatch, if a filter is specified the action will only fire when
    * filter return true for the collided entity.
    */
-  public filter: (entity: Entity) => boolean = () => true;
+  public filter: (entity: Entity) => boolean;
   /**
    * Number of times to repeat before killing the trigger,
    */
-  public repeat: number = -1;
+  public repeat: number;
 
   /**
-   * @param opts Trigger options
+   * @param options Trigger options
    */
-  constructor(opts: Partial<TriggerOptions>) {
-    super({ x: opts.pos.x, y: opts.pos.y, width: opts.width, height: opts.height });
-    opts = {
-      ...triggerDefaults,
-      ...opts
-    };
+  constructor(options: Partial<TriggerOptions>) {
+    super({ x: options.pos?.x, y: options.pos?.y, width: options.width, height: options.height });
 
-    this.filter = opts.filter || this.filter;
-    this.repeat = opts.repeat || this.repeat;
-    this.action = opts.action || this.action;
-    if (opts.target) {
-      this.target = opts.target;
-    }
+    this.filter = options.filter ?? (() => true);
+    this.repeat = options.repeat ?? -1;
+    this.action = options.action ?? (() => undefined);
+    this.target = options.target;
 
-    this.graphics.visible = opts.visible;
+    this.graphics.visible = options.visible ?? false;
     this.body.collisionType = CollisionType.Passive;
 
-    this.events.on('collisionstart', (evt: CollisionStartEvent<Entity>) => {
-      if (this.filter(evt.other)) {
-        this.events.emit('enter', new EnterTriggerEvent(this, evt.other));
-        this._dispatchAction(evt.other);
-        // remove trigger if its done, -1 repeat forever
-        if (this.repeat === 0) {
-          this.kill();
-        }
+    this.events.on('collisionstart', ({ other: collider }: CollisionStartEvent<Entity>) => {
+      if (!this._matchesTarget(collider)) {
+        return;
+      }
+
+      this.events.emit('enter', new EnterTriggerEvent(this, collider));
+      this._dispatchAction(collider);
+      // remove trigger if its done, -1 repeat forever
+      if (this.repeat === 0) {
+        this.kill();
       }
     });
 
-    this.events.on('collisionend', (evt: CollisionEndEvent<Entity>) => {
-      if (this.filter(evt.other)) {
-        this.events.emit('exit', new ExitTriggerEvent(this, evt.other));
+    this.events.on('collisionend', ({ other: collider }: CollisionEndEvent<Entity>) => {
+      if (this._matchesTarget(collider)) {
+        this.events.emit('exit', new ExitTriggerEvent(this, collider));
       }
     });
   }
 
-  public set target(target: Entity) {
-    this._target = target;
-    this.filter = (entity: Entity) => entity === target;
-  }
-
-  public get target() {
-    return this._target;
-  }
-
-  public _initialize(engine: Engine) {
-    super._initialize(engine);
+  private _matchesTarget(entity: Entity): boolean {
+    return this.filter(entity) && (this.target === undefined || this.target === entity);
   }
 
   private _dispatchAction(target: Entity) {


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Couldn't get the [suggested setup](https://github.com/excaliburjs/Excalibur/issues/3157#issuecomment-2266842536) to work without adding a lot of extra (code) complexity. I'd recommend dropping that requirement, because it's a lot easier to implement by the developers themselves by adding the check in their own `filter` callback to assure an entity is of a specific type (and use `as ....` to placate TS if needed).

I'll finish the last 2 points on the checklist after there's a green light on my current implementation.

Closes #3157

## Changes:

- The action callback of Trigger now returns the entity that triggered it.
- General cleanup of Trigger class
  - `target` is now 100% separate from `filter`, because that's what the functionality described in the documentation implied (to me).
  - Converted all the different "default value fallbacks" to a single setup.
  - Trigger used `Entity` and `Actor` interchangeably. Rewrote it to be 100% Entity (Although Entity doesn't have any collision mechanics build in, so an argument could be made to go for 100% Actor)
