### PR TITLE
Feat: [#3171] normalize zero vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 
+- `ex.Vector.normalize()` return zero-vector (`(0,0)`) instead of `(0,1)` when normalizing a vector with a magnitude of 0
 - `ex.Gif` transparent color constructor arg is removed in favor of the built in Gif file mechanism
 - Remove core-js dependency, it is no longer necessary in modern browsers. Technically a breaking change for older browsers
 - `ex.Particle` and `ex.ParticleEmitter` now have an API that looks like modern Excalibur APIs

--- a/src/engine/Math/vector.ts
+++ b/src/engine/Math/vector.ts
@@ -227,15 +227,15 @@ export class Vector implements Clonable<Vector> {
   }
 
   /**
-   * Normalizes a vector to have a magnitude of 1.
+   * Normalizes a non-zero vector to have a magnitude of 1. Zero vectors return a new zero vector.
    */
   public normalize(): Vector {
-    const d = this.distance();
-    if (d > 0) {
-      return new Vector(this.x / d, this.y / d);
-    } else {
-      return new Vector(0, 1);
+    const distance = this.distance();
+    if (distance === 0) {
+      return Vector.Zero;
     }
+
+    return new Vector(this.x / distance, this.y / distance);
   }
 
   /**


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #3171

## Changes:

- `Vector.normalize()` return zero-vector (`(0,0)`) instead of `(0,1)` when normalizing a vector with a magnitude of 0
