### PR TITLE
fix: Rename delta to elapsedMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 
+- `PreDrawEvent`, `PostDrawEvent`, `PreTransformDrawEvent`, `PostTransformDrawEvent`, `PreUpdateEvent`, `PostUpdateEvent` now use `elapsedMs` instead of `delta` for the elapsed milliseconds between the last frame.460696
 - `Trigger` API has been slightly changed:
   - `action` now returns the triggering entity: `(entity: Entity) => void`
   - `target` now works in conjunction with `filter` instead of overwriting it.
@@ -119,6 +120,7 @@ are doing mtv adjustments during precollision.
 
 ### Updates
 
+- Non-breaking parameters that reference `delta` to `elapsedMs` to better communicate intent and units
 - Perf improvements to `ex.ParticleEmitter` 
   * Use the same integrator as the MotionSystem in the tight loop
   * Leverage object pools to increase performance and reduce allocations

--- a/src/engine/Actions/Action.ts
+++ b/src/engine/Actions/Action.ts
@@ -5,7 +5,7 @@ import { Entity } from '../EntityComponentSystem/Entity';
  */
 export interface Action {
   id: number;
-  update(delta: number): void;
+  update(elapsedMs: number): void;
   isComplete(entity: Entity): boolean;
   reset(): void;
   stop(): void;

--- a/src/engine/Actions/Action/ActionSequence.ts
+++ b/src/engine/Actions/Action/ActionSequence.ts
@@ -20,8 +20,8 @@ export class ActionSequence implements Action {
     this._sequenceBuilder(this._sequenceContext);
   }
 
-  public update(delta: number): void {
-    this._actionQueue.update(delta);
+  public update(elapsedMs: number): void {
+    this._actionQueue.update(elapsedMs);
   }
 
   public isComplete(): boolean {

--- a/src/engine/Actions/Action/Blink.ts
+++ b/src/engine/Actions/Action/Blink.ts
@@ -19,7 +19,7 @@ export class Blink implements Action {
     this._duration = (timeVisible + timeNotVisible) * numBlinks;
   }
 
-  public update(delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._started) {
       this._started = true;
       this._elapsedTime = 0;
@@ -29,8 +29,8 @@ export class Blink implements Action {
       return;
     }
 
-    this._elapsedTime += delta;
-    this._totalTime += delta;
+    this._elapsedTime += elapsedMs;
+    this._totalTime += elapsedMs;
     if (this._graphics.visible && this._elapsedTime >= this._timeVisible) {
       this._graphics.visible = false;
       this._elapsedTime = 0;

--- a/src/engine/Actions/Action/CallMethod.ts
+++ b/src/engine/Actions/Action/CallMethod.ts
@@ -8,7 +8,7 @@ export class CallMethod implements Action {
     this._method = method;
   }
 
-  public update(_delta: number) {
+  public update(elapsedMs: number) {
     this._method();
     this._hasBeenCalled = true;
   }

--- a/src/engine/Actions/Action/Delay.ts
+++ b/src/engine/Actions/Action/Delay.ts
@@ -10,12 +10,12 @@ export class Delay implements Action {
     this._delay = delay;
   }
 
-  public update(delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._started) {
       this._started = true;
     }
 
-    this._elapsedTime += delta;
+    this._elapsedTime += elapsedMs;
   }
 
   isComplete(): boolean {

--- a/src/engine/Actions/Action/Die.ts
+++ b/src/engine/Actions/Action/Die.ts
@@ -11,7 +11,7 @@ export class Die implements Action {
     this._entity = entity;
   }
 
-  public update(_delta: number): void {
+  public update(elapsedMs: number): void {
     this._entity.get(ActionsComponent).clearActions();
     this._entity.kill();
     this._stopped = true;

--- a/src/engine/Actions/Action/EaseBy.ts
+++ b/src/engine/Actions/Action/EaseBy.ts
@@ -33,14 +33,14 @@ export class EaseBy implements Action {
     this._lerpEnd = this._lerpStart.add(this._offset);
   }
 
-  public update(delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._initialized) {
       this._initialize();
       this._initialized = true;
     }
 
     // Need to update lerp time first, otherwise the first update will always be zero
-    this._currentLerpTime += delta;
+    this._currentLerpTime += elapsedMs;
     let newX = this._tx.pos.x;
     let newY = this._tx.pos.y;
     if (this._currentLerpTime < this._lerpDuration) {
@@ -60,7 +60,7 @@ export class EaseBy implements Action {
         newY = this.easingFcn(this._currentLerpTime, this._lerpStart.y, this._lerpEnd.y, this._lerpDuration);
       }
       // Given the lerp position figure out the velocity in pixels per second
-      this._motion.vel = vec((newX - this._tx.pos.x) / (delta / 1000), (newY - this._tx.pos.y) / (delta / 1000));
+      this._motion.vel = vec((newX - this._tx.pos.x) / (elapsedMs / 1000), (newY - this._tx.pos.y) / (elapsedMs / 1000));
     } else {
       this._tx.pos = vec(this._lerpEnd.x, this._lerpEnd.y);
       this._motion.vel = Vector.Zero;

--- a/src/engine/Actions/Action/EaseTo.ts
+++ b/src/engine/Actions/Action/EaseTo.ts
@@ -31,14 +31,14 @@ export class EaseTo implements Action {
     this._currentLerpTime = 0;
   }
 
-  public update(delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._initialized) {
       this._initialize();
       this._initialized = true;
     }
 
     // Need to update lerp time first, otherwise the first update will always be zero
-    this._currentLerpTime += delta;
+    this._currentLerpTime += elapsedMs;
     let newX = this._tx.pos.x;
     let newY = this._tx.pos.y;
     if (this._currentLerpTime < this._lerpDuration) {
@@ -58,7 +58,7 @@ export class EaseTo implements Action {
         newY = this.easingFcn(this._currentLerpTime, this._lerpStart.y, this._lerpEnd.y, this._lerpDuration);
       }
       // Given the lerp position figure out the velocity in pixels per second
-      this._motion.vel = vec((newX - this._tx.pos.x) / (delta / 1000), (newY - this._tx.pos.y) / (delta / 1000));
+      this._motion.vel = vec((newX - this._tx.pos.x) / (elapsedMs / 1000), (newY - this._tx.pos.y) / (elapsedMs / 1000));
     } else {
       this._tx.pos = vec(this._lerpEnd.x, this._lerpEnd.y);
       this._motion.vel = Vector.Zero;

--- a/src/engine/Actions/Action/Fade.ts
+++ b/src/engine/Actions/Action/Fade.ts
@@ -11,7 +11,7 @@ export class Fade implements Action {
 
   private _endOpacity: number;
   private _speed: number;
-  private _ogspeed: number;
+  private _originalSpeed: number;
   private _multiplier: number = 1;
   private _started = false;
   private _stopped = false;
@@ -19,17 +19,17 @@ export class Fade implements Action {
   constructor(entity: Entity, endOpacity: number, speed: number) {
     this._graphics = entity.get(GraphicsComponent);
     this._endOpacity = endOpacity;
-    this._speed = this._ogspeed = speed;
+    this._speed = this._originalSpeed = speed;
   }
 
-  public update(delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._graphics) {
       return;
     }
 
     if (!this._started) {
       this._started = true;
-      this._speed = this._ogspeed;
+      this._speed = this._originalSpeed;
 
       // determine direction when we start
       if (this._endOpacity < this._graphics.opacity) {
@@ -40,10 +40,10 @@ export class Fade implements Action {
     }
 
     if (this._speed > 0) {
-      this._graphics.opacity += (this._multiplier * (Math.abs(this._graphics.opacity - this._endOpacity) * delta)) / this._speed;
+      this._graphics.opacity += (this._multiplier * (Math.abs(this._graphics.opacity - this._endOpacity) * elapsedMs)) / this._speed;
     }
 
-    this._speed -= delta;
+    this._speed -= elapsedMs;
 
     if (this.isComplete()) {
       this._graphics.opacity = this._endOpacity;

--- a/src/engine/Actions/Action/Flash.ts
+++ b/src/engine/Actions/Action/Flash.ts
@@ -42,7 +42,7 @@ export class Flash implements Action {
     this._total = duration;
   }
 
-  public update(delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._started) {
       this._started = true;
       this._total = this._duration;
@@ -53,7 +53,7 @@ export class Flash implements Action {
       return;
     }
 
-    this._currentDuration -= delta;
+    this._currentDuration -= elapsedMs;
 
     if (this._graphics) {
       this._material?.update((shader: Shader) => {

--- a/src/engine/Actions/Action/Follow.ts
+++ b/src/engine/Actions/Action/Follow.ts
@@ -33,7 +33,7 @@ export class Follow implements Action {
     this._speed = 0;
   }
 
-  public update(_delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._started) {
       this._started = true;
       this._distanceBetween = this._current.distance(this._end);

--- a/src/engine/Actions/Action/Meet.ts
+++ b/src/engine/Actions/Action/Meet.ts
@@ -35,7 +35,7 @@ export class Meet implements Action {
     }
   }
 
-  public update(_delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._started) {
       this._started = true;
       this._distanceBetween = this._current.distance(this._end);

--- a/src/engine/Actions/Action/MoveBy.ts
+++ b/src/engine/Actions/Action/MoveBy.ts
@@ -34,7 +34,7 @@ export class MoveBy implements Action {
     }
   }
 
-  public update(_delta: number) {
+  public update(elapsedMs: number) {
     if (!this._started) {
       this._started = true;
       this._start = new Vector(this._tx.pos.x, this._tx.pos.y);

--- a/src/engine/Actions/Action/MoveTo.ts
+++ b/src/engine/Actions/Action/MoveTo.ts
@@ -29,7 +29,7 @@ export class MoveTo implements Action {
     this._speed = speed;
   }
 
-  public update(_delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._started) {
       this._started = true;
       this._start = new Vector(this._tx.pos.x, this._tx.pos.y);

--- a/src/engine/Actions/Action/ParallelActions.ts
+++ b/src/engine/Actions/Action/ParallelActions.ts
@@ -12,9 +12,9 @@ export class ParallelActions implements Action {
     this._actions = parallelActions;
   }
 
-  update(delta: number): void {
+  update(elapsedMs: number): void {
     for (let i = 0; i < this._actions.length; i++) {
-      this._actions[i].update(delta);
+      this._actions[i].update(elapsedMs);
     }
   }
   isComplete(entity: Entity): boolean {

--- a/src/engine/Actions/Action/Repeat.ts
+++ b/src/engine/Actions/Action/Repeat.ts
@@ -23,13 +23,13 @@ export class Repeat implements Action {
     this._repeat--; // current execution is the first repeat
   }
 
-  public update(delta: number): void {
+  public update(elapsedMs: number): void {
     if (this._actionQueue.isComplete()) {
       this._actionQueue.clearActions();
       this._repeatBuilder(this._repeatContext);
       this._repeat--;
     }
-    this._actionQueue.update(delta);
+    this._actionQueue.update(elapsedMs);
   }
 
   public isComplete(): boolean {

--- a/src/engine/Actions/Action/RepeatForever.ts
+++ b/src/engine/Actions/Action/RepeatForever.ts
@@ -23,7 +23,7 @@ export class RepeatForever implements Action {
     this._repeatBuilder(this._repeatContext);
   }
 
-  public update(delta: number): void {
+  public update(elapsedMs: number): void {
     if (this._stopped) {
       return;
     }
@@ -33,7 +33,7 @@ export class RepeatForever implements Action {
       this._repeatBuilder(this._repeatContext);
     }
 
-    this._actionQueue.update(delta);
+    this._actionQueue.update(elapsedMs);
   }
 
   public isComplete(): boolean {

--- a/src/engine/Actions/Action/RotateBy.ts
+++ b/src/engine/Actions/Action/RotateBy.ts
@@ -33,7 +33,7 @@ export class RotateBy implements Action {
     this._rotationType = rotationType || RotationType.ShortestPath;
   }
 
-  public update(_delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._started) {
       this._started = true;
       this._start = this._tx.rotation;
@@ -89,7 +89,7 @@ export class RotateBy implements Action {
     }
 
     this._motion.angularVelocity = this._direction * this._speed;
-    this._currentNonCannonAngle += this._direction * this._speed * (_delta / 1000);
+    this._currentNonCannonAngle += this._direction * this._speed * (elapsedMs / 1000);
 
     if (this.isComplete()) {
       this._tx.rotation = this._end;

--- a/src/engine/Actions/Action/RotateTo.ts
+++ b/src/engine/Actions/Action/RotateTo.ts
@@ -31,7 +31,7 @@ export class RotateTo implements Action {
     this._rotationType = rotationType || RotationType.ShortestPath;
   }
 
-  public update(_delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._started) {
       this._started = true;
       this._start = this._tx.rotation;
@@ -85,7 +85,7 @@ export class RotateTo implements Action {
     }
 
     this._motion.angularVelocity = this._direction * this._speed;
-    this._currentNonCannonAngle += this._direction * this._speed * (_delta / 1000);
+    this._currentNonCannonAngle += this._direction * this._speed * (elapsedMs / 1000);
 
     if (this.isComplete()) {
       this._tx.rotation = this._end;

--- a/src/engine/Actions/Action/ScaleBy.ts
+++ b/src/engine/Actions/Action/ScaleBy.ts
@@ -28,7 +28,7 @@ export class ScaleBy implements Action {
     this._speedX = this._speedY = speed;
   }
 
-  public update(_delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._started) {
       this._started = true;
       this._startScale = this._tx.scale.clone();

--- a/src/engine/Actions/Action/ScaleTo.ts
+++ b/src/engine/Actions/Action/ScaleTo.ts
@@ -29,7 +29,7 @@ export class ScaleTo implements Action {
     this._speedY = speedY;
   }
 
-  public update(_delta: number): void {
+  public update(elapsedMs: number): void {
     if (!this._started) {
       this._started = true;
       this._startX = this._tx.scale.x;

--- a/src/engine/Actions/ActionsSystem.ts
+++ b/src/engine/Actions/ActionsSystem.ts
@@ -21,10 +21,10 @@ export class ActionsSystem extends System {
       }
     });
   }
-  update(delta: number): void {
+  update(elapsedMs: number): void {
     for (let i = 0; i < this._actions.length; i++) {
       const action = this._actions[i];
-      action.update(delta);
+      action.update(elapsedMs);
     }
   }
 }

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -980,12 +980,12 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
    * Called by the Engine, updates the state of the actor
    * @internal
    * @param engine The reference to the current game engine
-   * @param delta  The time elapsed since the last update in milliseconds
+   * @param elapsedMs  The time elapsed since the last update in milliseconds
    */
-  public update(engine: Engine, delta: number) {
+  public update(engine: Engine, elapsedMs: number) {
     this._initialize(engine);
-    this._preupdate(engine, delta);
-    this._postupdate(engine, delta);
+    this._preupdate(engine, elapsedMs);
+    this._postupdate(engine, elapsedMs);
   }
 
   /**
@@ -993,7 +993,7 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
    *
    * `onPreUpdate` is called directly before an actor is updated.
    */
-  public onPreUpdate(engine: Engine, delta: number): void {
+  public onPreUpdate(engine: Engine, elapsedMs: number): void {
     // Override me
   }
 
@@ -1002,7 +1002,7 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
    *
    * `onPostUpdate` is called directly after an actor is updated.
    */
-  public onPostUpdate(engine: Engine, delta: number): void {
+  public onPostUpdate(engine: Engine, elapsedMs: number): void {
     // Override me
   }
 
@@ -1057,9 +1057,9 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
    * Internal _preupdate handler for {@apilink onPreUpdate} lifecycle event
    * @internal
    */
-  public _preupdate(engine: Engine, delta: number): void {
-    this.events.emit('preupdate', new PreUpdateEvent(engine, delta, this));
-    this.onPreUpdate(engine, delta);
+  public _preupdate(engine: Engine, elapsedMs: number): void {
+    this.events.emit('preupdate', new PreUpdateEvent(engine, elapsedMs, this));
+    this.onPreUpdate(engine, elapsedMs);
   }
 
   /**
@@ -1068,9 +1068,9 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
    * Internal _preupdate handler for {@apilink onPostUpdate} lifecycle event
    * @internal
    */
-  public _postupdate(engine: Engine, delta: number): void {
-    this.events.emit('postupdate', new PostUpdateEvent(engine, delta, this));
-    this.onPostUpdate(engine, delta);
+  public _postupdate(engine: Engine, elapsedMs: number): void {
+    this.events.emit('postupdate', new PostUpdateEvent(engine, elapsedMs, this));
+    this.onPostUpdate(engine, elapsedMs);
   }
 
   // endregion

--- a/src/engine/Collision/Detection/CollisionProcessor.ts
+++ b/src/engine/Collision/Detection/CollisionProcessor.ts
@@ -50,7 +50,7 @@ export interface CollisionProcessor {
   /**
    * Detect potential collision pairs given a list of colliders
    */
-  broadphase(targets: Collider[], delta: number, stats?: FrameStats): Pair[];
+  broadphase(targets: Collider[], elapsedMs: number, stats?: FrameStats): Pair[];
 
   /**
    * Identify actual collisions from those pairs, and calculate collision impulse
@@ -60,10 +60,10 @@ export interface CollisionProcessor {
   /**
    * Update the internal structures to track colliders
    */
-  update(targets: Collider[], delta: number): number;
+  update(targets: Collider[], elapsedMs: number): number;
 
   /**
    * Draw any debug information
    */
-  debug(ex: ExcaliburGraphicsContext, delta: number): void;
+  debug(ex: ExcaliburGraphicsContext, elapsedMs: number): void;
 }

--- a/src/engine/Collision/Detection/DynamicTreeCollisionProcessor.ts
+++ b/src/engine/Collision/Detection/DynamicTreeCollisionProcessor.ts
@@ -173,8 +173,8 @@ export class DynamicTreeCollisionProcessor implements CollisionProcessor {
   /**
    * Detects potential collision pairs in a broadphase approach with the dynamic AABB tree strategy
    */
-  public broadphase(targets: Collider[], delta: number, stats?: FrameStats): Pair[] {
-    const seconds = delta / 1000;
+  public broadphase(targets: Collider[], elapsedMs: number, stats?: FrameStats): Pair[] {
+    const seconds = elapsedMs / 1000;
 
     // Retrieve the list of potential colliders, exclude killed, prevented, and self
     const potentialColliders = targets.filter((other) => {

--- a/src/engine/Collision/Detection/SparseHashGrid.ts
+++ b/src/engine/Collision/Detection/SparseHashGrid.ts
@@ -264,7 +264,7 @@ export class SparseHashGrid<TObject extends { bounds: BoundingBox }, TProxy exte
     return updated;
   }
 
-  debug(ex: ExcaliburGraphicsContext, delta: number): void {
+  debug(ex: ExcaliburGraphicsContext, elapsedMs: number): void {
     const transparent = Color.Transparent;
     const color = Color.White;
     for (const cell of this.sparseHashGrid.values()) {

--- a/src/engine/Collision/Detection/SparseHashGridCollisionProcessor.ts
+++ b/src/engine/Collision/Detection/SparseHashGridCollisionProcessor.ts
@@ -319,9 +319,9 @@ export class SparseHashGridCollisionProcessor implements CollisionProcessor {
   /**
    * Runs the broadphase sweep over tracked colliders and returns possible collision pairs
    * @param targets
-   * @param delta
+   * @param elapsedMs
    */
-  broadphase(targets: Collider[], delta: number): Pair[] {
+  broadphase(targets: Collider[], elapsedMs: number): Pair[] {
     const pairs: Pair[] = [];
     this._pairs.clear();
     this._nonPairs.clear();
@@ -390,16 +390,16 @@ export class SparseHashGridCollisionProcessor implements CollisionProcessor {
   /**
    * Perform data structure maintenance, returns number of colliders updated
    */
-  update(targets: Collider[], delta: number): number {
+  update(targets: Collider[], elapsedMs: number): number {
     return this.hashGrid.update(targets);
   }
 
   /**
    * Draws the internal data structure
    * @param ex
-   * @param delta
+   * @param elapsedMs
    */
-  debug(ex: ExcaliburGraphicsContext, delta: number): void {
-    this.hashGrid.debug(ex, delta);
+  debug(ex: ExcaliburGraphicsContext, elapsedMs: number): void {
+    this.hashGrid.debug(ex, elapsedMs);
   }
 }

--- a/src/engine/Debug/DebugConfig.ts
+++ b/src/engine/Debug/DebugConfig.ts
@@ -24,7 +24,7 @@ export interface FrameStatistics {
   /**
    * Gets the frame's delta (time since last frame scaled by {@apilink Engine.timescale}) (in ms)
    */
-  delta: number;
+  elapsedMs: number;
 
   /**
    * Gets the frame's frames-per-second (FPS)
@@ -380,7 +380,7 @@ export class DebugConfig {
  */
 export class FrameStats implements FrameStatistics {
   private _id: number = 0;
-  private _delta: number = 0;
+  private _elapsedMs: number = 0;
   private _fps: number = 0;
   private _actorStats: FrameActorStats = {
     alive: 0,
@@ -415,7 +415,7 @@ export class FrameStats implements FrameStatistics {
   public reset(otherStats?: FrameStatistics) {
     if (otherStats) {
       this.id = otherStats.id;
-      this.delta = otherStats.delta;
+      this.elapsedMs = otherStats.elapsedMs;
       this.fps = otherStats.fps;
       this.actors.alive = otherStats.actors.alive;
       this.actors.killed = otherStats.actors.killed;
@@ -426,7 +426,7 @@ export class FrameStats implements FrameStatistics {
       this.graphics.drawCalls = otherStats.graphics.drawCalls;
       this.graphics.drawnImages = otherStats.graphics.drawnImages;
     } else {
-      this.id = this.delta = this.fps = 0;
+      this.id = this.elapsedMs = this.fps = 0;
       this.actors.alive = this.actors.killed = this.actors.ui = 0;
       this.duration.update = this.duration.draw = 0;
       this._physicsStats.reset();
@@ -462,16 +462,16 @@ export class FrameStats implements FrameStatistics {
   /**
    * Gets the frame's delta (time since last frame)
    */
-  public get delta() {
-    return this._delta;
+  public get elapsedMs() {
+    return this._elapsedMs;
   }
 
   /**
    * Sets the frame's delta (time since last frame). Internal use only.
    * @internal
    */
-  public set delta(value: number) {
-    this._delta = value;
+  public set elapsedMs(value: number) {
+    this._elapsedMs = value;
   }
 
   /**

--- a/src/engine/Director/Transition.ts
+++ b/src/engine/Director/Transition.ts
@@ -111,14 +111,14 @@ export class Transition extends Entity {
    *
    * **WARNING BE SURE** to call `super.updateTransition()` if overriding in your own custom implementation
    * @param engine
-   * @param delta
+   * @param elapsedMs
    */
-  public updateTransition(engine: Engine, delta: number): void {
+  public updateTransition(engine: Engine, elapsedMs: number): void {
     if (this.complete) {
       return;
     }
 
-    this._currentDistance += clamp(delta / this.duration, 0, 1);
+    this._currentDistance += clamp(elapsedMs / this.duration, 0, 1);
     if (this._currentDistance >= 1) {
       this._currentDistance = 1;
     }

--- a/src/engine/EntityComponentSystem/Entity.ts
+++ b/src/engine/EntityComponentSystem/Entity.ts
@@ -541,9 +541,9 @@ export class Entity<TKnownComponents extends Component = any> implements OnIniti
    * Internal _preupdate handler for {@apilink onPreUpdate} lifecycle event
    * @internal
    */
-  public _preupdate(engine: Engine, delta: number): void {
-    this.events.emit('preupdate', new PreUpdateEvent(engine, delta, this));
-    this.onPreUpdate(engine, delta);
+  public _preupdate(engine: Engine, elapsedMs: number): void {
+    this.events.emit('preupdate', new PreUpdateEvent(engine, elapsedMs, this));
+    this.onPreUpdate(engine, elapsedMs);
   }
 
   /**
@@ -552,9 +552,9 @@ export class Entity<TKnownComponents extends Component = any> implements OnIniti
    * Internal _preupdate handler for {@apilink onPostUpdate} lifecycle event
    * @internal
    */
-  public _postupdate(engine: Engine, delta: number): void {
-    this.events.emit('postupdate', new PostUpdateEvent(engine, delta, this));
-    this.onPostUpdate(engine, delta);
+  public _postupdate(engine: Engine, elapsedMs: number): void {
+    this.events.emit('postupdate', new PostUpdateEvent(engine, elapsedMs, this));
+    this.onPostUpdate(engine, elapsedMs);
   }
 
   /**
@@ -572,7 +572,7 @@ export class Entity<TKnownComponents extends Component = any> implements OnIniti
    *
    * `onPreUpdate` is called directly before an entity is updated.
    */
-  public onPreUpdate(engine: Engine, delta: number): void {
+  public onPreUpdate(engine: Engine, elapsedMs: number): void {
     // Override me
   }
 
@@ -581,7 +581,7 @@ export class Entity<TKnownComponents extends Component = any> implements OnIniti
    *
    * `onPostUpdate` is called directly after an entity is updated.
    */
-  public onPostUpdate(engine: Engine, delta: number): void {
+  public onPostUpdate(engine: Engine, elapsedMs: number): void {
     // Override me
   }
 
@@ -590,15 +590,15 @@ export class Entity<TKnownComponents extends Component = any> implements OnIniti
    * Entity update lifecycle, called internally
    * @internal
    * @param engine
-   * @param delta
+   * @param elapsedMs
    */
-  public update(engine: Engine, delta: number): void {
+  public update(engine: Engine, elapsedMs: number): void {
     this._initialize(engine);
-    this._preupdate(engine, delta);
+    this._preupdate(engine, elapsedMs);
     for (const child of this.children) {
-      child.update(engine, delta);
+      child.update(engine, elapsedMs);
     }
-    this._postupdate(engine, delta);
+    this._postupdate(engine, elapsedMs);
   }
 
   public emit<TEventName extends EventKey<EntityEvents>>(eventName: TEventName, event: EntityEvents[TEventName]): void;

--- a/src/engine/EntityComponentSystem/SystemManager.ts
+++ b/src/engine/EntityComponentSystem/SystemManager.ts
@@ -83,23 +83,23 @@ export class SystemManager {
    * Updates all systems
    * @param type whether this is an update or draw system
    * @param scene context reference
-   * @param delta time in milliseconds
+   * @param elapsedMs time in milliseconds
    */
-  public updateSystems(type: SystemType, scene: Scene, delta: number) {
+  public updateSystems(type: SystemType, scene: Scene, elapsedMs: number) {
     const systems = this.systems.filter((s) => s.systemType === type);
     for (const s of systems) {
       if (s.preupdate) {
-        s.preupdate(scene, delta);
+        s.preupdate(scene, elapsedMs);
       }
     }
 
     for (const s of systems) {
-      s.update(delta);
+      s.update(elapsedMs);
     }
 
     for (const s of systems) {
       if (s.postupdate) {
-        s.postupdate(scene, delta);
+        s.postupdate(scene, elapsedMs);
       }
     }
   }

--- a/src/engine/EntityComponentSystem/World.ts
+++ b/src/engine/EntityComponentSystem/World.ts
@@ -37,11 +37,11 @@ export class World {
   /**
    * Update systems by type and time elapsed in milliseconds
    */
-  update(type: SystemType, delta: number) {
+  update(type: SystemType, elapsedMs: number) {
     if (type === SystemType.Update) {
-      this.entityManager.updateEntities(this.scene, delta);
+      this.entityManager.updateEntities(this.scene, elapsedMs);
     }
-    this.systemManager.updateSystems(type, this.scene, delta);
+    this.systemManager.updateSystems(type, this.scene, elapsedMs);
     this.entityManager.findEntitiesForRemoval();
     this.entityManager.processComponentRemovals();
     this.entityManager.processEntityRemovals();

--- a/src/engine/Events.ts
+++ b/src/engine/Events.ts
@@ -249,7 +249,7 @@ export class GameStopEvent extends GameEvent<Engine> {
 export class PreDrawEvent extends GameEvent<Entity | Scene | Engine | TileMap> {
   constructor(
     public ctx: ExcaliburGraphicsContext,
-    public delta: number,
+    public elapsedMs: number,
     public target: Entity | Scene | Engine | TileMap
   ) {
     super();
@@ -264,7 +264,7 @@ export class PreDrawEvent extends GameEvent<Entity | Scene | Engine | TileMap> {
 export class PostDrawEvent extends GameEvent<Entity | Scene | Engine | TileMap> {
   constructor(
     public ctx: ExcaliburGraphicsContext,
-    public delta: number,
+    public elapsedMs: number,
     public target: Entity | Scene | Engine | TileMap
   ) {
     super();
@@ -280,7 +280,7 @@ export class PostDrawEvent extends GameEvent<Entity | Scene | Engine | TileMap> 
 export class PreTransformDrawEvent extends GameEvent<Entity> {
   constructor(
     public ctx: ExcaliburGraphicsContext,
-    public delta: number,
+    public elapsedMs: number,
     public target: Entity
   ) {
     super();
@@ -295,7 +295,7 @@ export class PreTransformDrawEvent extends GameEvent<Entity> {
 export class PostTransformDrawEvent extends GameEvent<Entity> {
   constructor(
     public ctx: ExcaliburGraphicsContext,
-    public delta: number,
+    public elapsedMs: number,
     public target: Entity
   ) {
     super();
@@ -332,7 +332,7 @@ export class PostDebugDrawEvent extends GameEvent<Entity | Actor | Scene | Engin
 export class PreUpdateEvent<T extends OnPreUpdate = Entity> extends GameEvent<T> {
   constructor(
     public engine: Engine,
-    public delta: number,
+    public elapsedMs: number,
     public target: T
   ) {
     super();
@@ -345,7 +345,7 @@ export class PreUpdateEvent<T extends OnPreUpdate = Entity> extends GameEvent<T>
 export class PostUpdateEvent<T extends OnPostUpdate = Entity> extends GameEvent<T> {
   constructor(
     public engine: Engine,
-    public delta: number,
+    public elapsedMs: number,
     public target: T
   ) {
     super();

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContext.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContext.ts
@@ -357,10 +357,10 @@ export interface ExcaliburGraphicsContext {
    * Updates all post processors in the graphics context
    *
    * Called internally by Excalibur
-   * @param delta
+   * @param elapsedMs
    * @internal
    */
-  updatePostProcessors(delta: number): void;
+  updatePostProcessors(elapsedMs: number): void;
 
   /**
    * Gets or sets the material to be used in the current context's drawings

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContext2DCanvas.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContext2DCanvas.ts
@@ -329,7 +329,7 @@ export class ExcaliburGraphicsContext2DCanvas implements ExcaliburGraphicsContex
     // pass
   }
 
-  public updatePostProcessors(delta: number) {
+  public updatePostProcessors(elapsedMs: number) {
     // pass
   }
 

--- a/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
+++ b/src/engine/Graphics/Context/ExcaliburGraphicsContextWebGL.ts
@@ -592,25 +592,25 @@ export class ExcaliburGraphicsContextWebGL implements ExcaliburGraphicsContext {
   }
 
   private _totalPostProcessorTime = 0;
-  public updatePostProcessors(delta: number) {
+  public updatePostProcessors(elapsedMs: number) {
     for (const postprocessor of this._postprocessors) {
       const shader = postprocessor.getShader();
       shader.use();
       const uniforms = shader.getUniforms();
-      this._totalPostProcessorTime += delta;
+      this._totalPostProcessorTime += elapsedMs;
 
       if (uniforms.find((u) => u.name === 'u_time_ms')) {
         shader.setUniformFloat('u_time_ms', this._totalPostProcessorTime);
       }
       if (uniforms.find((u) => u.name === 'u_elapsed_ms')) {
-        shader.setUniformFloat('u_elapsed_ms', delta);
+        shader.setUniformFloat('u_elapsed_ms', elapsedMs);
       }
       if (uniforms.find((u) => u.name === 'u_resolution')) {
         shader.setUniformFloatVector('u_resolution', vec(this.width, this.height));
       }
 
       if (postprocessor.onUpdate) {
-        postprocessor.onUpdate(delta);
+        postprocessor.onUpdate(elapsedMs);
       }
     }
   }

--- a/src/engine/Graphics/GraphicsSystem.ts
+++ b/src/engine/Graphics/GraphicsSystem.ts
@@ -71,7 +71,7 @@ export class GraphicsSystem extends System {
     }
   }
 
-  public update(delta: number): void {
+  public update(elapsedMs: number): void {
     this._token++;
     let graphics: GraphicsComponent;
     FontCache.checkAndClearCache();
@@ -99,9 +99,9 @@ export class GraphicsSystem extends System {
 
       // Optionally run the onPreTransformDraw graphics lifecycle draw
       if (graphics.onPreTransformDraw) {
-        graphics.onPreTransformDraw(this._graphicsContext, delta);
+        graphics.onPreTransformDraw(this._graphicsContext, elapsedMs);
       }
-      entity.events.emit('pretransformdraw', new PreTransformDrawEvent(this._graphicsContext, delta, entity));
+      entity.events.emit('pretransformdraw', new PreTransformDrawEvent(this._graphicsContext, elapsedMs, entity));
 
       // This optionally sets our camera based on the entity coord plan (world vs. screen)
       if (transform.coordPlane === CoordPlane.Screen) {
@@ -114,7 +114,7 @@ export class GraphicsSystem extends System {
       }
 
       // Tick any graphics state (but only once) for animations and graphics groups
-      graphics.update(delta, this._token);
+      graphics.update(elapsedMs, this._token);
 
       // Apply parallax
       const parallax = entity.get(ParallaxComponent);
@@ -137,9 +137,9 @@ export class GraphicsSystem extends System {
 
       // Optionally run the onPreDraw graphics lifecycle draw
       if (graphics.onPreDraw) {
-        graphics.onPreDraw(this._graphicsContext, delta);
+        graphics.onPreDraw(this._graphicsContext, elapsedMs);
       }
-      entity.events.emit('predraw', new PreDrawEvent(this._graphicsContext, delta, entity));
+      entity.events.emit('predraw', new PreDrawEvent(this._graphicsContext, elapsedMs, entity));
 
       this._graphicsContext.opacity *= graphics.opacity;
 
@@ -148,9 +148,9 @@ export class GraphicsSystem extends System {
 
       // Optionally run the onPostDraw graphics lifecycle draw
       if (graphics.onPostDraw) {
-        graphics.onPostDraw(this._graphicsContext, delta);
+        graphics.onPostDraw(this._graphicsContext, elapsedMs);
       }
-      entity.events.emit('postdraw', new PostDrawEvent(this._graphicsContext, delta, entity));
+      entity.events.emit('postdraw', new PostDrawEvent(this._graphicsContext, elapsedMs, entity));
 
       this._graphicsContext.restore();
 
@@ -164,9 +164,9 @@ export class GraphicsSystem extends System {
 
       // Optionally run the onPreTransformDraw graphics lifecycle draw
       if (graphics.onPostTransformDraw) {
-        graphics.onPostTransformDraw(this._graphicsContext, delta);
+        graphics.onPostTransformDraw(this._graphicsContext, elapsedMs);
       }
-      entity.events.emit('posttransformdraw', new PostTransformDrawEvent(this._graphicsContext, delta, entity));
+      entity.events.emit('posttransformdraw', new PostTransformDrawEvent(this._graphicsContext, elapsedMs, entity));
     }
     this._graphicsContext.restore();
   }

--- a/src/engine/Graphics/PostProcessor/PostProcessor.ts
+++ b/src/engine/Graphics/PostProcessor/PostProcessor.ts
@@ -25,7 +25,7 @@ export interface PostProcessor {
    * Use the onUpdate hook to update any uniforms in the postprocessors shader
    *
    * The shader has already been bound so there is no need to call shader.use();
-   * @param delta
+   * @param elapsedMs
    */
-  onUpdate?(delta: number): void;
+  onUpdate?(elapsedMs: number): void;
 }

--- a/src/engine/Interfaces/LifecycleEvents.ts
+++ b/src/engine/Interfaces/LifecycleEvents.ts
@@ -30,7 +30,7 @@ export function hasOnInitialize(a: any): a is OnInitialize {
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface _preupdate {
-  _preupdate(engine: Engine, delta: number): void;
+  _preupdate(engine: Engine, elapsedMs: number): void;
 }
 
 /**
@@ -41,7 +41,7 @@ export function has_preupdate(a: any): a is _preupdate {
 }
 
 export interface OnPreUpdate {
-  onPreUpdate(engine: Engine, delta: number): void;
+  onPreUpdate(engine: Engine, elapsedMs: number): void;
 }
 
 /**
@@ -53,7 +53,7 @@ export function hasOnPreUpdate(a: any): a is OnPreUpdate {
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface _postupdate {
-  _postupdate(engine: Engine, delta: number): void;
+  _postupdate(engine: Engine, elapsedMs: number): void;
 }
 
 /**
@@ -64,7 +64,7 @@ export function has_postupdate(a: any): a is _postupdate {
 }
 
 export interface OnPostUpdate {
-  onPostUpdate(engine: Engine, delta: number): void;
+  onPostUpdate(engine: Engine, elapsedMs: number): void;
 }
 
 /**
@@ -127,7 +127,7 @@ export interface CanUpdate {
   /**
    * Overridable implementation
    */
-  onPreUpdate(engine: Engine, delta: number): void;
+  onPreUpdate(engine: Engine, elapsedMs: number): void;
 
   /**
    * Event signature
@@ -139,7 +139,7 @@ export interface CanUpdate {
   /**
    * Overridable implementation
    */
-  onPostUpdate(engine: Engine, delta: number): void;
+  onPostUpdate(engine: Engine, elapsedMs: number): void;
 
   /**
    * Event signatures
@@ -153,7 +153,7 @@ export interface OnPreDraw {
   /**
    * Overridable implementation
    */
-  onPreDraw(ctx: ExcaliburGraphicsContext, delta: number): void;
+  onPreDraw(ctx: ExcaliburGraphicsContext, elapsedMs: number): void;
 
   /**
    * Event signatures
@@ -167,7 +167,7 @@ export interface OnPostDraw {
   /**
    * Overridable implementation
    */
-  onPostDraw(ctx: ExcaliburGraphicsContext, delta: number): void;
+  onPostDraw(ctx: ExcaliburGraphicsContext, elapsedMs: number): void;
 
   /**
    * Event signatures

--- a/src/engine/Particles/ParticleEmitter.ts
+++ b/src/engine/Particles/ParticleEmitter.ts
@@ -158,11 +158,11 @@ export class ParticleEmitter extends Actor {
     return p;
   }
 
-  public update(engine: Engine, delta: number) {
-    super.update(engine, delta);
+  public update(engine: Engine, elapsedMs: number) {
+    super.update(engine, elapsedMs);
 
     if (this.isEmitting) {
-      this._particlesToEmit += this.emitRate * (delta / 1000);
+      this._particlesToEmit += this.emitRate * (elapsedMs / 1000);
       if (this._particlesToEmit > 1.0) {
         this.emitParticles(Math.floor(this._particlesToEmit));
         this._particlesToEmit = this._particlesToEmit - Math.floor(this._particlesToEmit);

--- a/src/engine/Particles/Particles.ts
+++ b/src/engine/Particles/Particles.ts
@@ -130,8 +130,8 @@ export class Particle extends Entity {
     }
   }
 
-  public update(engine: Engine, delta: number) {
-    this.life = this.life - delta;
+  public update(engine: Engine, elapsedMs: number) {
+    this.life = this.life - elapsedMs;
 
     if (this.life < 0) {
       this.kill();
@@ -142,12 +142,16 @@ export class Particle extends Entity {
     }
 
     if (this.startSize && this.endSize && this.startSize > 0 && this.endSize > 0) {
-      this.size = clamp(this.sizeRate * delta + this.size, Math.min(this.startSize, this.endSize), Math.max(this.startSize, this.endSize));
+      this.size = clamp(
+        this.sizeRate * elapsedMs + this.size,
+        Math.min(this.startSize, this.endSize),
+        Math.max(this.startSize, this.endSize)
+      );
     }
 
-    this._currentColor.r = clamp(this._currentColor.r + this._rRate * delta, 0, 255);
-    this._currentColor.g = clamp(this._currentColor.g + this._gRate * delta, 0, 255);
-    this._currentColor.b = clamp(this._currentColor.b + this._bRate * delta, 0, 255);
+    this._currentColor.r = clamp(this._currentColor.r + this._rRate * elapsedMs, 0, 255);
+    this._currentColor.g = clamp(this._currentColor.g + this._gRate * elapsedMs, 0, 255);
+    this._currentColor.b = clamp(this._currentColor.b + this._bRate * elapsedMs, 0, 255);
     this._currentColor.a = this.graphics.opacity;
 
     let accel = this.motion.acc;
@@ -156,10 +160,10 @@ export class Particle extends Entity {
         .sub(this.transform.pos)
         .normalize()
         .scale(this.focusAccel || 0)
-        .scale(delta / 1000);
+        .scale(elapsedMs / 1000);
     }
     // Update transform and motion based on Euler linear algebra
-    EulerIntegrator.integrate(this.transform, this.motion, accel, delta);
+    EulerIntegrator.integrate(this.transform, this.motion, accel, elapsedMs);
   }
 }
 

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -259,7 +259,7 @@ export class Scene<TActivationData = unknown> implements CanInitialize, CanActiv
    *
    * `onPreUpdate` is called directly before a scene is updated.
    */
-  public onPreUpdate(engine: Engine, delta: number): void {
+  public onPreUpdate(engine: Engine, elapsedMs: number): void {
     // will be overridden
   }
 
@@ -268,7 +268,7 @@ export class Scene<TActivationData = unknown> implements CanInitialize, CanActiv
    *
    * `onPostUpdate` is called directly after a scene is updated.
    */
-  public onPostUpdate(engine: Engine, delta: number): void {
+  public onPostUpdate(engine: Engine, elapsedMs: number): void {
     // will be overridden
   }
 
@@ -278,7 +278,7 @@ export class Scene<TActivationData = unknown> implements CanInitialize, CanActiv
    * `onPreDraw` is called directly before a scene is drawn.
    *
    */
-  public onPreDraw(ctx: ExcaliburGraphicsContext, delta: number): void {
+  public onPreDraw(ctx: ExcaliburGraphicsContext, elapsedMs: number): void {
     // will be overridden
   }
 
@@ -288,7 +288,7 @@ export class Scene<TActivationData = unknown> implements CanInitialize, CanActiv
    * `onPostDraw` is called directly after a scene is drawn.
    *
    */
-  public onPostDraw(ctx: ExcaliburGraphicsContext, delta: number): void {
+  public onPostDraw(ctx: ExcaliburGraphicsContext, elapsedMs: number): void {
     // will be overridden
   }
 
@@ -381,9 +381,9 @@ export class Scene<TActivationData = unknown> implements CanInitialize, CanActiv
    * Internal _preupdate handler for {@apilink onPreUpdate} lifecycle event
    * @internal
    */
-  public _preupdate(engine: Engine, delta: number): void {
-    this.emit('preupdate', new PreUpdateEvent(engine, delta, this));
-    this.onPreUpdate(engine, delta);
+  public _preupdate(engine: Engine, elapsedMs: number): void {
+    this.emit('preupdate', new PreUpdateEvent(engine, elapsedMs, this));
+    this.onPreUpdate(engine, elapsedMs);
   }
 
   /**
@@ -392,9 +392,9 @@ export class Scene<TActivationData = unknown> implements CanInitialize, CanActiv
    * Internal _preupdate handler for {@apilink onPostUpdate} lifecycle event
    * @internal
    */
-  public _postupdate(engine: Engine, delta: number): void {
-    this.emit('postupdate', new PostUpdateEvent(engine, delta, this));
-    this.onPostUpdate(engine, delta);
+  public _postupdate(engine: Engine, elapsedMs: number): void {
+    this.emit('postupdate', new PostUpdateEvent(engine, elapsedMs, this));
+    this.onPostUpdate(engine, elapsedMs);
   }
 
   /**
@@ -403,9 +403,9 @@ export class Scene<TActivationData = unknown> implements CanInitialize, CanActiv
    * Internal _predraw handler for {@apilink onPreDraw} lifecycle event
    * @internal
    */
-  public _predraw(ctx: ExcaliburGraphicsContext, delta: number): void {
-    this.emit('predraw', new PreDrawEvent(ctx, delta, this));
-    this.onPreDraw(ctx, delta);
+  public _predraw(ctx: ExcaliburGraphicsContext, elapsedMs: number): void {
+    this.emit('predraw', new PreDrawEvent(ctx, elapsedMs, this));
+    this.onPreDraw(ctx, elapsedMs);
   }
 
   /**
@@ -414,22 +414,22 @@ export class Scene<TActivationData = unknown> implements CanInitialize, CanActiv
    * Internal _postdraw handler for {@apilink onPostDraw} lifecycle event
    * @internal
    */
-  public _postdraw(ctx: ExcaliburGraphicsContext, delta: number): void {
-    this.emit('postdraw', new PostDrawEvent(ctx, delta, this));
-    this.onPostDraw(ctx, delta);
+  public _postdraw(ctx: ExcaliburGraphicsContext, elapsedMs: number): void {
+    this.emit('postdraw', new PostDrawEvent(ctx, elapsedMs, this));
+    this.onPostDraw(ctx, elapsedMs);
   }
 
   /**
    * Updates all the actors and timers in the scene. Called by the {@apilink Engine}.
    * @param engine  Reference to the current Engine
-   * @param delta   The number of milliseconds since the last update
+   * @param elapsedMs   The number of milliseconds since the last update
    */
-  public update(engine: Engine, delta: number) {
+  public update(engine: Engine, elapsedMs: number) {
     if (!this.isInitialized) {
       this._logger.warnOnce(`Scene update called before initialize for scene ${engine.director?.getSceneName(this)}!`);
       return;
     }
-    this._preupdate(engine, delta);
+    this._preupdate(engine, elapsedMs);
 
     // TODO differed entity removal for timers
     let i: number, len: number;
@@ -441,19 +441,19 @@ export class Scene<TActivationData = unknown> implements CanInitialize, CanActiv
 
     // Cycle through timers updating timers
     for (const timer of this._timers) {
-      timer.update(delta);
+      timer.update(elapsedMs);
     }
 
-    this.world.update(SystemType.Update, delta);
+    this.world.update(SystemType.Update, elapsedMs);
 
     // Camera last keeps renders smooth that are based on entity/actor
     if (this.camera) {
-      this.camera.update(engine, delta);
+      this.camera.update(engine, elapsedMs);
     }
 
     this._collectActorStats(engine);
 
-    this._postupdate(engine, delta);
+    this._postupdate(engine, elapsedMs);
 
     this.input.update();
   }
@@ -461,21 +461,21 @@ export class Scene<TActivationData = unknown> implements CanInitialize, CanActiv
   /**
    * Draws all the actors in the Scene. Called by the {@apilink Engine}.
    * @param ctx    The current rendering context
-   * @param delta  The number of milliseconds since the last draw
+   * @param elapsedMs  The number of milliseconds since the last draw
    */
-  public draw(ctx: ExcaliburGraphicsContext, delta: number) {
+  public draw(ctx: ExcaliburGraphicsContext, elapsedMs: number) {
     if (!this.isInitialized) {
       this._logger.warnOnce(`Scene draw called before initialize!`);
       return;
     }
-    this._predraw(ctx, delta);
+    this._predraw(ctx, elapsedMs);
 
-    this.world.update(SystemType.Draw, delta);
+    this.world.update(SystemType.Draw, elapsedMs);
 
     if (this.engine?.isDebug) {
       this.debugDraw(ctx);
     }
-    this._postdraw(ctx, delta);
+    this._postdraw(ctx, elapsedMs);
   }
 
   /**

--- a/src/engine/TileMap/TileMap.ts
+++ b/src/engine/TileMap/TileMap.ts
@@ -255,7 +255,7 @@ export class TileMap extends Entity {
     );
     this.addComponent(
       new GraphicsComponent({
-        onPostDraw: (ctx, delta) => this.draw(ctx, delta)
+        onPostDraw: (ctx, elapsedMs) => this.draw(ctx, elapsedMs)
       })
     );
     this.addComponent(new DebugGraphicsComponent((ctx, debugFlags) => this.debug(ctx, debugFlags), false));
@@ -545,10 +545,10 @@ export class TileMap extends Entity {
     return tiles;
   }
 
-  public update(engine: Engine, delta: number) {
+  public update(engine: Engine, elapsedMs: number) {
     this._initialize(engine);
-    this.onPreUpdate(engine, delta);
-    this.emit('preupdate', new PreUpdateEvent(engine, delta, this));
+    this.onPreUpdate(engine, elapsedMs);
+    this.emit('preupdate', new PreUpdateEvent(engine, elapsedMs, this));
     if (!this._oldPos.equals(this.pos) || this._oldRotation !== this.rotation || !this._oldScale.equals(this.scale)) {
       this.flagCollidersDirty();
       this.flagTilesDirty();
@@ -564,20 +564,20 @@ export class TileMap extends Entity {
     this._oldRotation = this.rotation;
     this.scale.clone(this._oldScale);
     this.transform.pos = this.pos;
-    this.onPostUpdate(engine, delta);
-    this.emit('postupdate', new PostUpdateEvent(engine, delta, this));
+    this.onPostUpdate(engine, elapsedMs);
+    this.emit('postupdate', new PostUpdateEvent(engine, elapsedMs, this));
   }
 
   /**
    * Draws the tile map to the screen. Called by the {@apilink Scene}.
    * @param ctx ExcaliburGraphicsContext
-   * @param delta  The number of milliseconds since the last draw
+   * @param elapsedMs  The number of milliseconds since the last draw
    */
-  public draw(ctx: ExcaliburGraphicsContext, delta: number): void {
+  public draw(ctx: ExcaliburGraphicsContext, elapsedMs: number): void {
     if (!this.isInitialized) {
       return;
     }
-    this.emit('predraw', new PreDrawEvent(ctx as any, delta, this)); // TODO fix event
+    this.emit('predraw', new PreDrawEvent(ctx as any, elapsedMs, this)); // TODO fix event
 
     let graphics: readonly Graphic[], graphicsIndex: number, graphicsLen: number;
 
@@ -594,14 +594,14 @@ export class TileMap extends Entity {
         const offset = offsets[graphicsIndex];
         if (graphic) {
           if (hasGraphicsTick(graphic)) {
-            graphic?.tick(delta, this._token);
+            graphic?.tick(elapsedMs, this._token);
           }
           const offsetY = this.renderFromTopOfGraphic ? 0 : graphic.height - this.tileHeight;
           graphic.draw(ctx, tile.x * this.tileWidth + offset.x, tile.y * this.tileHeight - offsetY + offset.y);
         }
       }
     }
-    this.emit('postdraw', new PostDrawEvent(ctx as any, delta, this));
+    this.emit('postdraw', new PostDrawEvent(ctx as any, elapsedMs, this));
   }
 
   public debug(gfx: ExcaliburGraphicsContext, debugFlags: DebugConfig) {

--- a/src/engine/Timer.ts
+++ b/src/engine/Timer.ts
@@ -119,12 +119,12 @@ export class Timer {
   }
   /**
    * Updates the timer after a certain number of milliseconds have elapsed. This is used internally by the engine.
-   * @param delta  Number of elapsed milliseconds since the last update.
+   * @param elapsedMs  Number of elapsed milliseconds since the last update.
    */
-  public update(delta: number) {
+  public update(elapsedMs: number) {
     if (this._running) {
-      this._totalTimeAlive += delta;
-      this._elapsedTime += delta;
+      this._totalTimeAlive += elapsedMs;
+      this._elapsedTime += elapsedMs;
 
       if (this.maxNumberOfRepeats > -1 && this._numberOfTicks >= this.maxNumberOfRepeats) {
         this._complete = true;

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -1383,9 +1383,9 @@ describe('A game actor', () => {
     });
 
     it('can have onPostUpdate overridden safely', () => {
-      actor.onPostUpdate = (engine, delta) => {
+      actor.onPostUpdate = (engine, elapsedMs) => {
         expect(engine).not.toBe(null);
-        expect(delta).toBe(100);
+        expect(elapsedMs).toBe(100);
       };
 
       spyOn(actor, 'onPostUpdate').and.callThrough();
@@ -1398,9 +1398,9 @@ describe('A game actor', () => {
     });
 
     it('can have onPreUpdate overridden safely', () => {
-      actor.onPreUpdate = (engine, delta) => {
+      actor.onPreUpdate = (engine, elapsedMs) => {
         expect(engine).not.toBe(null);
-        expect(delta).toBe(100);
+        expect(elapsedMs).toBe(100);
       };
 
       spyOn(actor, 'onPreUpdate').and.callThrough();

--- a/src/spec/CameraSpec.ts
+++ b/src/spec/CameraSpec.ts
@@ -421,9 +421,9 @@ describe('A camera', () => {
     });
 
     it('can have onPostUpdate overridden safely', () => {
-      camera.onPostUpdate = (engine, delta) => {
+      camera.onPostUpdate = (engine, elapsedMs) => {
         expect(engine).not.toBe(null);
-        expect(delta).toBe(100);
+        expect(elapsedMs).toBe(100);
       };
 
       spyOn(camera, 'onPostUpdate').and.callThrough();
@@ -437,9 +437,9 @@ describe('A camera', () => {
     });
 
     it('can have onPreUpdate overridden safely', () => {
-      camera.onPreUpdate = (engine, delta) => {
+      camera.onPreUpdate = (engine, elapsedMs) => {
         expect(engine).not.toBe(null);
-        expect(delta).toBe(100);
+        expect(elapsedMs).toBe(100);
       };
 
       spyOn(camera, 'onPreUpdate').and.callThrough();

--- a/src/spec/EngineSpec.ts
+++ b/src/spec/EngineSpec.ts
@@ -976,9 +976,9 @@ describe('The engine', () => {
       const clock = engine.clock as ex.TestClock;
       expect(engine.clock.isRunning()).toBe(true);
 
-      engine.onPostUpdate = (engine, delta) => {
+      engine.onPostUpdate = (engine, elapsedMs) => {
         expect(engine).not.toBe(null);
-        expect(delta).toBe(100);
+        expect(elapsedMs).toBe(100);
       };
 
       spyOn(engine, 'onPostUpdate').and.callThrough();
@@ -996,9 +996,9 @@ describe('The engine', () => {
       const clock = engine.clock as ex.TestClock;
       expect(engine.clock.isRunning()).toBe(true);
 
-      engine.onPreUpdate = (engine, delta) => {
+      engine.onPreUpdate = (engine, elapsedMs) => {
         expect(engine).not.toBe(null);
-        expect(delta).toBe(100);
+        expect(elapsedMs).toBe(100);
       };
 
       spyOn(engine, 'onPreUpdate').and.callThrough();
@@ -1017,9 +1017,9 @@ describe('The engine', () => {
       expect(engine.clock.isRunning()).toBe(true);
 
       engine.currentScene._initialize(engine);
-      engine.onPreDraw = (ctx, delta) => {
+      engine.onPreDraw = (ctx, elapsedMs) => {
         expect(<any>ctx).not.toBe(null);
-        expect(delta).toBe(100);
+        expect(elapsedMs).toBe(100);
       };
       spyOn(engine, 'onPreDraw').and.callThrough();
       spyOn(engine, '_predraw').and.callThrough();
@@ -1037,9 +1037,9 @@ describe('The engine', () => {
       expect(engine.clock.isRunning()).toBe(true);
 
       engine.currentScene._initialize(engine);
-      engine.onPostDraw = (ctx, delta) => {
+      engine.onPostDraw = (ctx, elapsedMs) => {
         expect(<any>ctx).not.toBe(null);
-        expect(delta).toBe(100);
+        expect(elapsedMs).toBe(100);
       };
 
       spyOn(engine, 'onPostDraw').and.callThrough();

--- a/src/spec/FrameStatsSpec.ts
+++ b/src/spec/FrameStatsSpec.ts
@@ -39,8 +39,8 @@ describe('The engine', () => {
   });
 
   describe('after frame is ended', () => {
-    it('should collect frame delta', () => {
-      expect(stats.delta).withContext('Frame stats delta should be ~16ms').toBeCloseTo(16.6, 0);
+    it('should collect frame elapsedMs', () => {
+      expect(stats.elapsedMs).withContext('Frame stats elapsedMs should be ~16ms').toBeCloseTo(16.6, 0);
     });
 
     it('should collect frame fps', () => {
@@ -73,7 +73,7 @@ describe('FrameStats', () => {
   it('can be cloned', () => {
     sut.id = 10;
     sut.fps = 10;
-    sut.delta = 10;
+    sut.elapsedMs = 10;
     sut.actors.alive = 3;
     sut.actors.killed = 1;
     sut.actors.ui = 1;

--- a/src/spec/SceneSpec.ts
+++ b/src/spec/SceneSpec.ts
@@ -804,9 +804,9 @@ describe('A scene', () => {
 
     it('can have onPostUpdate overridden safely', async () => {
       await scene._initialize(engine);
-      scene.onPostUpdate = (engine, delta) => {
+      scene.onPostUpdate = (engine, elapsedMs) => {
         expect(engine).not.toBe(null);
-        expect(delta).toBe(100);
+        expect(elapsedMs).toBe(100);
       };
 
       spyOn(scene, 'onPostUpdate').and.callThrough();
@@ -821,9 +821,9 @@ describe('A scene', () => {
 
     it('can have onPreUpdate overridden safely', async () => {
       await scene._initialize(engine);
-      scene.onPreUpdate = (engine, delta) => {
+      scene.onPreUpdate = (engine, elapsedMs) => {
         expect(engine).not.toBe(null);
-        expect(delta).toBe(100);
+        expect(elapsedMs).toBe(100);
       };
 
       spyOn(scene, 'onPreUpdate').and.callThrough();
@@ -839,9 +839,9 @@ describe('A scene', () => {
     it('can have onPreDraw overridden safely', async () => {
       await scene._initialize(engine);
       engine.screen.setCurrentCamera(engine.currentScene.camera);
-      scene.onPreDraw = (ctx, delta) => {
+      scene.onPreDraw = (ctx, elapsedMs) => {
         expect(<any>ctx).not.toBe(null);
-        expect(delta).toBe(100);
+        expect(elapsedMs).toBe(100);
       };
 
       spyOn(scene, 'onPreDraw').and.callThrough();
@@ -857,9 +857,9 @@ describe('A scene', () => {
     it('can have onPostDraw overridden safely', async () => {
       await scene._initialize(engine);
       engine.screen.setCurrentCamera(engine.currentScene.camera);
-      scene.onPostDraw = (ctx, delta) => {
+      scene.onPostDraw = (ctx, elapsedMs) => {
         expect(<any>ctx).not.toBe(null);
-        expect(delta).toBe(100);
+        expect(elapsedMs).toBe(100);
       };
 
       spyOn(scene, 'onPostDraw').and.callThrough();

--- a/src/spec/SystemManagerSpec.ts
+++ b/src/spec/SystemManagerSpec.ts
@@ -17,7 +17,7 @@ class FakeSystem extends ex.System {
     super();
     this.query = this.world.query(types);
   }
-  update(delta: number): void {
+  update(elapsedMs: number): void {
     // fake
   }
 }

--- a/src/spec/TileMapSpec.ts
+++ b/src/spec/TileMapSpec.ts
@@ -4,12 +4,12 @@ import { TestUtils } from './util/TestUtils';
 import { BodyComponent } from '@excalibur';
 import { ColliderComponent } from '../engine/Collision/ColliderComponent';
 
-const drawWithTransform = (ctx: ex.ExcaliburGraphicsContext, tm: ex.TileMap, delta: number = 1) => {
+const drawWithTransform = (ctx: ex.ExcaliburGraphicsContext, tm: ex.TileMap, elapsedMs: number = 1) => {
   ctx.save();
   ctx.translate(tm.pos.x, tm.pos.y);
   ctx.rotate(tm.rotation);
   ctx.scale(tm.scale.x, tm.scale.y);
-  tm.draw(ctx, delta);
+  tm.draw(ctx, elapsedMs);
   ctx.restore();
 };
 


### PR DESCRIPTION
Switches `delta` to `elapsedMs` for greater readability and communication of units
