### PR TITLE
fix: [#3087] `blockInput: true` blocks input accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ are doing mtv adjustments during precollision.
 
 ### Fixed
 
+- Fixed issue where `blockInput: true` on scene transition only blocked input events, not accessors like `wasHeld(...)` etc.
 - Fixed issue where `ex.Fade` sometimes would not complete depending on the elapsed time
 - Fixed issue where `ex.PolygonColliders` would get trapped in infinite loop for degenerate polygons (< 3 vertices)
 - Fixed issue where certain devices that support large numbers of texture slots exhaust the maximum number of if statements (complexity) in the shader.

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -229,7 +229,11 @@ export class KeyEvent extends Events.GameEvent<any> {
    * @param value The key's typed value the browser detected
    * @param originalEvent The original keyboard event that Excalibur handled
    */
-  constructor(public key: Keys, public value?: string, public originalEvent?: KeyboardEvent) {
+  constructor(
+    public key: Keys,
+    public value?: string,
+    public originalEvent?: KeyboardEvent
+  ) {
     super();
   }
 }

--- a/src/engine/Input/Keyboard.ts
+++ b/src/engine/Input/Keyboard.ts
@@ -229,11 +229,7 @@ export class KeyEvent extends Events.GameEvent<any> {
    * @param value The key's typed value the browser detected
    * @param originalEvent The original keyboard event that Excalibur handled
    */
-  constructor(
-    public key: Keys,
-    public value?: string,
-    public originalEvent?: KeyboardEvent
-  ) {
+  constructor(public key: Keys, public value?: string, public originalEvent?: KeyboardEvent) {
     super();
   }
 }
@@ -417,6 +413,9 @@ export class Keyboard {
    * @param key Test whether a key was just pressed
    */
   public wasPressed(key: Keys): boolean {
+    if (!this._enabled) {
+      return false;
+    }
     return this._keysDown.indexOf(key) > -1;
   }
 
@@ -425,6 +424,9 @@ export class Keyboard {
    * @param key  Test whether a key is held down
    */
   public isHeld(key: Keys): boolean {
+    if (!this._enabled) {
+      return false;
+    }
     return this._keys.indexOf(key) > -1;
   }
 
@@ -433,6 +435,9 @@ export class Keyboard {
    * @param key  Test whether a key was just released
    */
   public wasReleased(key: Keys): boolean {
+    if (!this._enabled) {
+      return false;
+    }
     return this._keysUp.indexOf(key) > -1;
   }
 

--- a/src/engine/Input/PointerEventReceiver.ts
+++ b/src/engine/Input/PointerEventReceiver.ts
@@ -75,7 +75,10 @@ export class PointerEventReceiver {
 
   private _enabled = true;
 
-  constructor(public readonly target: GlobalEventHandlers & EventTarget, public engine: Engine) {}
+  constructor(
+    public readonly target: GlobalEventHandlers & EventTarget,
+    public engine: Engine
+  ) {}
 
   public toggleEnabled(enabled: boolean) {
     this._enabled = enabled;

--- a/src/engine/Input/PointerEventReceiver.ts
+++ b/src/engine/Input/PointerEventReceiver.ts
@@ -75,10 +75,7 @@ export class PointerEventReceiver {
 
   private _enabled = true;
 
-  constructor(
-    public readonly target: GlobalEventHandlers & EventTarget,
-    public engine: Engine
-  ) {}
+  constructor(public readonly target: GlobalEventHandlers & EventTarget, public engine: Engine) {}
 
   public toggleEnabled(enabled: boolean) {
     this._enabled = enabled;
@@ -124,6 +121,9 @@ export class PointerEventReceiver {
    * @param pointerId
    */
   public isDown(pointerId: number) {
+    if (!this._enabled) {
+      return false;
+    }
     return this.currentFramePointerDown.get(pointerId) ?? false;
   }
 
@@ -132,6 +132,9 @@ export class PointerEventReceiver {
    * @param pointerId
    */
   public wasDown(pointerId: number) {
+    if (!this._enabled) {
+      return false;
+    }
     return this.lastFramePointerDown.get(pointerId) ?? false;
   }
 
@@ -139,6 +142,9 @@ export class PointerEventReceiver {
    * Whether the Pointer is currently dragging.
    */
   public isDragging(pointerId: number): boolean {
+    if (!this._enabled) {
+      return false;
+    }
     return this.isDown(pointerId);
   }
 
@@ -146,6 +152,9 @@ export class PointerEventReceiver {
    * Whether the Pointer just started dragging.
    */
   public isDragStart(pointerId: number): boolean {
+    if (!this._enabled) {
+      return false;
+    }
     return this.isDown(pointerId) && !this.wasDown(pointerId);
   }
 
@@ -153,6 +162,9 @@ export class PointerEventReceiver {
    * Whether the Pointer just ended dragging.
    */
   public isDragEnd(pointerId: number): boolean {
+    if (!this._enabled) {
+      return false;
+    }
     return !this.isDown(pointerId) && this.wasDown(pointerId);
   }
 


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #3087 

