### PR TITLE
[#3236] Fix missing word typo in 06.1-actions.mdx

### DIFF
--- a/site/docs/02-fundamentals/02-conventions.mdx
+++ b/site/docs/02-fundamentals/02-conventions.mdx
@@ -9,7 +9,7 @@ There are a few things that Excalibur does that are good to know before you star
 
 1. Excalibur uses a theater metaphor, for example: [[Scene|Scenes]], [[Actor|Actors]], and [Actions](/docs/actions).
 
-2. Excalibur uses [Resources](docs/category/resources) to load external files like [images](/docs/ImageSource) and [sounds](/docs/Sound). They can also be used to load other things like data or config.
+2. Excalibur uses [Resources](/docs/category/resources) to load external files like [images](/docs/ImageSource) and [sounds](/docs/Sound). They can also be used to load other things like data or config.
 
 2. The negative y direction is up, and the positive y direction is down.
 

--- a/site/docs/07-actions/06.1-actions.mdx
+++ b/site/docs/07-actions/06.1-actions.mdx
@@ -54,7 +54,7 @@ public Ship extends ex.Actor {
       new ex.Vector(75, 80)
     ];
     // spawn at start point
-    this.repeatForever(ctx => {
+    this.actions.repeatForever(ctx => {
       this.x = path[0].x;
       this.y = path[0].y;
       // create action queue


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #3236

## Changes:

- The line `this.repeatForever(ctx => {` is now `this.actions.repeatForever(ctx => {`.