### PR TITLE
fixes broken link on screen element page.

### DIFF
--- a/site/docs/05-user-interface/02-screen-elements.mdx
+++ b/site/docs/05-user-interface/02-screen-elements.mdx
@@ -4,7 +4,7 @@ slug: /screen-elements
 section: User Interface
 ---
 
-Please consider [html based first](#html-based-ui) but if the UI makes more sense in-canvas look to [screen elements](#screen-elements).
+Please consider [html based first](/docs/html) but if the UI makes more sense in-canvas look to [screen elements](#screen-elements).
 
 ## Screen Elements
 


### PR DESCRIPTION
Hi

I was browsing the documentation the other day and noticed a link on https://excaliburjs.com/docs/screen-elements that I think is broken. Though I should help by fixing it.

The contribution guide said to open an issue before a PR, but I also found [this discussion post](https://github.com/excaliburjs/Excalibur/discussions/3003) about proposing updates to the documentation. I hope this is fine :)