### PR TITLE
fix: CompositeCollider behavior affecting TileMap w/Realistic Solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue with CompositeCollider where large TileMaps would sometimes causes odd collision behavior in the Realistic Solver when the body & collider components are far apart in a TileMap.
 - Fixed crash on Xiaomi Redmi Phones by lazy loading the GPU particle renderer, GPU particles still do not work on these phones
 - Add warning if World.add() falls through! This is caused by multiple versions of Excalibur usually
 - Fixed CollidePolygonPolygon crash with some defense against invalid separation

--- a/src/engine/Collision/Colliders/CollisionJumpTable.ts
+++ b/src/engine/Collision/Colliders/CollisionJumpTable.ts
@@ -294,7 +294,7 @@ export const CollisionJumpTable = {
     return [];
   },
 
-  FindContactSeparation(contact: CollisionContact, localPoint: Vector) {
+  FindContactSeparation(contact: CollisionContact, localPoint: Vector): number {
     const shapeA = contact.colliderA;
     const txA = contact.bodyA?.transform ?? new TransformComponent();
     const shapeB = contact.colliderB;
@@ -314,10 +314,16 @@ export const CollisionJumpTable = {
         let side: LineSegment;
         let worldPoint: Vector;
         if (contact.info.collider === shapeA) {
-          side = new LineSegment(txA.apply(contact.info.localSide.begin), txA.apply(contact.info.localSide.end));
+          side = new LineSegment(
+            txA.apply(contact.info.localSide.begin).add(shapeA.offset),
+            txA.apply(contact.info.localSide.end).add(shapeA.offset)
+          );
           worldPoint = txB.apply(localPoint);
         } else {
-          side = new LineSegment(txB.apply(contact.info.localSide.begin), txB.apply(contact.info.localSide.end));
+          side = new LineSegment(
+            txB.apply(contact.info.localSide.begin).add(shapeB.offset),
+            txB.apply(contact.info.localSide.end).add(shapeB.offset)
+          );
           worldPoint = txA.apply(localPoint);
         }
 


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================


Fixes issue where the realistic solver gets confused with TileMaps mentioned in the discord https://discord.com/channels/1195771303215513671/1320140196372676692

The issue causes massive overcorrection because it _appears_ to the solver that the collider in a composite is further away from the contact than it actually is.


https://github.com/user-attachments/assets/45bceff6-ab06-40b7-9c91-a4886505c124


In the fix we shift the collider local side by the offset (which is what is used in composites to position relative to the transform). This gives an accurate pos for the contact point


https://github.com/user-attachments/assets/db83f756-8aa0-43a0-99da-72a7bebbb772


