### PR TITLE
BUG: fixed actor cloning of null collider, added test 

### DIFF
--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -679,7 +679,9 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
     clone.addComponent((clone.motion = this.motion.clone() as MotionComponent), true);
     clone.addComponent((clone.actions = this.actions.clone() as ActionsComponent), true);
     clone.addComponent((clone.body = this.body.clone() as BodyComponent), true);
-    clone.addComponent((clone.collider = this.collider.clone() as ColliderComponent), true);
+    if (this.collider.get()) {
+      clone.addComponent((clone.collider = this.collider.clone() as ColliderComponent), true);
+    }
 
     const builtInComponents: Component[] = [
       this.transform,

--- a/src/spec/ActorSpec.ts
+++ b/src/spec/ActorSpec.ts
@@ -143,6 +143,42 @@ describe('A game actor', () => {
     expect(sut.color).toEqual(original.color);
   });
 
+  it('can be cloned with null collider', () => {
+    const original = new ex.Actor({
+      width: 10,
+      height: 100,
+      anchor: ex.vec(0, 1),
+      color: ex.Color.Azure
+    });
+    original.pos = ex.vec(10, 20);
+    original.vel = ex.vec(30, 30);
+
+    original.collider.clear();
+    const sut = original.clone();
+
+    expect(sut.get(ex.TransformComponent)).not.toBe(original.get(ex.TransformComponent));
+    expect(sut.get(ex.MotionComponent)).not.toBe(original.get(ex.MotionComponent));
+    expect(sut.get(ex.ActionsComponent)).not.toBe(original.get(ex.ActionsComponent));
+    expect(sut.get(ex.PointerComponent)).not.toBe(original.get(ex.PointerComponent));
+    expect(sut.get(ex.BodyComponent)).not.toBe(original.get(ex.BodyComponent));
+    expect(sut.get(ex.ColliderComponent)).not.toBe(original.get(ex.ColliderComponent));
+    expect(sut.get(ex.GraphicsComponent)).not.toBe(original.get(ex.GraphicsComponent));
+
+    // New refs
+    expect(sut).not.toBe(original);
+    expect(sut.id).not.toBe(original.id);
+    expect(sut.color).not.toBe(original.color);
+    expect(sut.anchor).not.toBe(original.anchor);
+
+    // Same values
+    expect(sut.pos).toBeVector(original.pos);
+    expect(sut.vel).toBeVector(original.vel);
+    expect(sut.width).toBe(original.width);
+    expect(sut.height).toBe(original.height);
+    expect(sut.anchor).toEqual(original.anchor);
+    expect(sut.color).toEqual(original.color);
+  });
+
   it('should have default properties set', () => {
     const actor = new ex.Actor();
 


### PR DESCRIPTION
Actor.ts: updated .clone() method to test for non-null collider prior to attempting to clone.
Added test 'can be cloned with null collider; to ActorSpec.ts

This fixes issue reported in discord on 1/23/25:
https://discord.com/channels/1195771303215513671/1195779955611672598/1332073907213308055

Issue: 
![image](https://github.com/user-attachments/assets/ba3a2698-9a20-4dd0-a4f9-6f927bd01569)
