### PR TITLE
fix: Add missing events for transitions + Fix onTransition for initial scene transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added new `transitionstart` and `transitionend` events to `ex.Scenes`
+- Pipe `navigation*` events to `ex.Engine`
 - Added ability to use `ex.Vector` to specify offset and margin in `SpriteSheet.fromImageSource({..})`
 - New PostProcessor.onDraw() hook to handle uploading textures
 - Adds contact solve bias to RealisticSolver, this allows customization on which direction contacts are solved first. By default there is no bias set to 'none'.
 
 ### Fixed
 
+- Fixed `ex.TriggerOptions` type to all optional parameters
 - Fixed issue where the ActorArgs type hint would not error when providing a color causing confusion when it didn't produce a default graphic.
 - Fixed false positive warning when adding timers 
 - Fixed issue where gamepad buttons wouldn't progress the default loader play button

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed `onTransition` on the initial scene transition
 - Fixed `ex.TriggerOptions` type to all optional parameters
 - Fixed issue where the ActorArgs type hint would not error when providing a color causing confusion when it didn't produce a default graphic.
 - Fixed false positive warning when adding timers 

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -85,15 +85,39 @@ var game = new ex.Engine({
     threshold: { fps: 20, numberOfFrames: 100 }
   }
 });
+
+game.on('navigation', (evt) => {
+  console.log('navigation', evt);
+});
+
+game.on('navigationstart', (evt) => {
+  console.log('navigationstart', evt);
+});
+
+game.on('navigationend', (evt) => {
+  console.log('navigationend', evt);
+});
+
 game.screen.events.on('fullscreen', (evt) => {
   console.log('fullscreen', evt);
 });
+
 game.screen.events.on('resize', (evt) => {
   console.log('resize', evt);
 });
+
 game.screen.events.on('pixelratio', (evt) => {
   console.log('pixelratio', evt);
 });
+
+game.currentScene.on('transitionstart', (evt) => {
+  console.log('transitionstart', evt);
+});
+
+game.currentScene.on('transitionend', (evt) => {
+  console.log('transitionend', evt);
+});
+
 game.currentScene.onPreDraw = (ctx: ex.ExcaliburGraphicsContext) => {
   ctx.save();
   ctx.z = 99;
@@ -879,6 +903,15 @@ player.on('pointerwheel', () => {
 });
 
 var newScene = new ex.Scene();
+
+newScene.on('transitionstart', (evt) => {
+  console.log('transitionstart', evt);
+});
+
+newScene.on('transitionend', (evt) => {
+  console.log('transitionend', evt);
+});
+
 newScene.backgroundColor = ex.Color.ExcaliburBlue;
 newScene.add(new ex.Label({ text: 'MAH LABEL!', x: 200, y: 100 }));
 newScene.on('activate', (evt?: ex.ActivateEvent) => {

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -86,6 +86,10 @@ var game = new ex.Engine({
   }
 });
 
+game.currentScene.onTransition = () => {
+  console.log('initial scene transition');
+};
+
 game.on('navigation', (evt) => {
   console.log('navigation', evt);
 });

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -600,22 +600,9 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
     this.offset = offset ?? Vector.Zero;
     this.transform = new TransformComponent();
     this.addComponent(this.transform);
-
     this.pos = pos ?? vec(x ?? 0, y ?? 0);
-    if (this.pos && isNaN(this.pos.x) && isNaN(this.pos.y)) {
-      this.logger.warnOnce(`Actor with name: ${this.name} was constructed with a NaN pos! This can cause a lot of unexpected bugs!`);
-    }
-
     this.rotation = rotation ?? 0;
-    if (isNaN(this.rotation)) {
-      this.logger.warnOnce(`Actor with name: ${this.name} was constructed with a NaN rotation! This can cause a lot of unexpected bugs!`);
-    }
-
     this.scale = scale ?? vec(1, 1);
-    if (this.scale && isNaN(this.scale.x) && isNaN(this.scale.y)) {
-      this.logger.warnOnce(`Actor with name: ${this.name} was constructed with a NaN scale! This can cause a lot of unexpected bugs!`);
-    }
-
     this.z = z ?? 0;
     this.transform.coordPlane = coordPlane ?? CoordPlane.World;
     this._silenceWarnings = silenceWarnings ?? false;

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -253,7 +253,7 @@ export const ActorEvents = {
   ExitViewPort: 'exitviewport',
   ActionStart: 'actionstart',
   ActionComplete: 'actioncomplete'
-};
+} as const;
 
 /**
  * The most important primitive in Excalibur is an `Actor`. Anything that
@@ -600,9 +600,22 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
     this.offset = offset ?? Vector.Zero;
     this.transform = new TransformComponent();
     this.addComponent(this.transform);
+
     this.pos = pos ?? vec(x ?? 0, y ?? 0);
+    if (this.pos && isNaN(this.pos.x) && isNaN(this.pos.y)) {
+      this.logger.warnOnce(`Actor with name: ${this.name} was constructed with a NaN pos! This can cause a lot of unexpected bugs!`);
+    }
+
     this.rotation = rotation ?? 0;
+    if (isNaN(this.rotation)) {
+      this.logger.warnOnce(`Actor with name: ${this.name} was constructed with a NaN rotation! This can cause a lot of unexpected bugs!`);
+    }
+
     this.scale = scale ?? vec(1, 1);
+    if (this.scale && isNaN(this.scale.x) && isNaN(this.scale.y)) {
+      this.logger.warnOnce(`Actor with name: ${this.name} was constructed with a NaN scale! This can cause a lot of unexpected bugs!`);
+    }
+
     this.z = z ?? 0;
     this.transform.coordPlane = coordPlane ?? CoordPlane.World;
     this._silenceWarnings = silenceWarnings ?? false;

--- a/src/engine/Director/Director.ts
+++ b/src/engine/Director/Director.ts
@@ -233,6 +233,7 @@ export class Director<TKnownScenes extends string = any> {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         maybeStartTransition._addToTargetScene(this._engine, startSceneInstance);
         this.swapScene(this.startScene).then(() => {
+          startSceneInstance.onTransition('in');
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           return this.playTransition(maybeStartTransition, startSceneInstance);
         });

--- a/src/engine/Director/Director.ts
+++ b/src/engine/Director/Director.ts
@@ -24,7 +24,7 @@ export const DirectorEvents = {
   NavigationStart: 'navigationstart',
   Navigation: 'navigation',
   NavigationEnd: 'navigationend'
-};
+} as const;
 
 export interface SceneWithOptions {
   /**
@@ -541,8 +541,10 @@ export class Director<TKnownScenes extends string = any> {
       targetScene.input?.toggleEnabled(!transition.blockInput);
       this._engine.input?.toggleEnabled(!transition.blockInput);
 
+      targetScene.events.emit('transitionstart', transition);
       this.currentTransition._addToTargetScene(this._engine, targetScene);
       await this.currentTransition._play();
+      targetScene.events.emit('transitionend', transition);
 
       targetScene.input?.toggleEnabled(sceneInputEnabled);
     }

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -48,7 +48,7 @@ import { ImageFiltering } from './Graphics/Filtering';
 import { GraphicsDiagnostics } from './Graphics/GraphicsDiagnostics';
 import { Toaster } from './Util/Toaster';
 import { InputMapper } from './Input/InputMapper';
-import { GoToOptions, SceneMap, Director, StartOptions, SceneWithOptions, WithRoot } from './Director/Director';
+import { GoToOptions, SceneMap, Director, StartOptions, SceneWithOptions, WithRoot, DirectorEvents } from './Director/Director';
 import { InputHost } from './Input/InputHost';
 import { getDefaultPhysicsConfig, PhysicsConfig } from './Collision/PhysicsConfig';
 import { DeepRequired } from './Util/Required';
@@ -56,7 +56,7 @@ import { Context, createContext, useContext } from './Context';
 import { DefaultGarbageCollectionOptions, GarbageCollectionOptions, GarbageCollector } from './GarbageCollector';
 import { mergeDeep } from './Util/Util';
 
-export type EngineEvents = {
+export type EngineEvents = DirectorEvents & {
   fallbackgraphicscontext: ExcaliburGraphicsContext2DCanvas;
   initialize: InitializeEvent<Engine>;
   visible: VisibleEvent;
@@ -83,7 +83,8 @@ export const EngineEvents = {
   PreFrame: 'preframe',
   PostFrame: 'postframe',
   PreDraw: 'predraw',
-  PostDraw: 'postdraw'
+  PostDraw: 'postdraw',
+  ...DirectorEvents
 } as const;
 
 /**
@@ -1052,6 +1053,7 @@ O|===|* >________________>\n\
     this.debug = new DebugConfig(this);
 
     this.director = new Director(this, options.scenes);
+    this.director.events.pipe(this.events);
 
     this._initialize(options);
 

--- a/src/engine/Scene.ts
+++ b/src/engine/Scene.ts
@@ -55,6 +55,8 @@ export type SceneEvents = {
   predebugdraw: PreDebugDrawEvent;
   postdebugdraw: PostDebugDrawEvent;
   preload: PreLoadEvent;
+  transitionstart: Transition;
+  transitionend: Transition;
 };
 
 export const SceneEvents = {
@@ -67,8 +69,10 @@ export const SceneEvents = {
   PostDraw: 'postdraw',
   PreDebugDraw: 'predebugdraw',
   PostDebugDraw: 'postdebugdraw',
-  PreLoad: 'preload'
-};
+  PreLoad: 'preload',
+  TransitionStart: 'transitionstart',
+  TransitionEnd: 'transitionend'
+} as const;
 
 export type SceneConstructor = new (...args: any[]) => Scene;
 /**


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

* Fixed `onTransition` on the initial scene transition
* Pipes events navigation events up to engine
* Adds transitionstart/end to scenes
* Adds missing `as const`s

