### PR TITLE
docs: fix typo "n Excalibur" -> "in Excalibur" in tutorial step 03

### DIFF
--- a/site/docs/00-tutorial/03-step-bird-and-ground.mdx
+++ b/site/docs/00-tutorial/03-step-bird-and-ground.mdx
@@ -40,7 +40,7 @@ export class Ground extends ex.Actor {
 
 We can make our `Bird` move by giving it some acceleration in `onInitialize`, it is generally recommended to initialize state in `onInitialize`. It makes testing easier and defers initialization until excalibur primitives are available. `onInitialize` is called once before the first update of the `Actor`.
 
-*BTW n Excalibur the positive y axis points down!*
+*BTW in Excalibur the positive y axis points down!*
 
 ```typescript
 // bird.ts


### PR DESCRIPTION
I found this small typo in the docs while reading it, thanks for the good work on the engine, the docs are very good compared to other engines :)