### PR TITLE
reat: support any, all and not component/tag filters on Query

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -83,6 +83,13 @@
         "allowTernary": true
       }
     ],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "message": "Do not commit tests with 'fit'",
+        "selector": "CallExpression[callee.name='fit']"
+      }
+    ],
     "jsdoc/require-param": 0,
     "jsdoc/require-param-description": 0,
     "jsdoc/require-param-type": 0,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -87,7 +87,7 @@
       "error",
       {
         "message": "Do not commit tests with 'fit'",
-        "selector": "CallExpression[callee.name='fit']"
+        "selector": "CallExpression[callee.name='fit'] > Identifier"
       }
     ],
     "jsdoc/require-param": 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added ability to use `ex.Vector` to specify offset and margin in `SpriteSheet.fromImageSource({..})`
 - New PostProcessor.onDraw() hook to handle uploading textures
 - Adds contact solve bias to RealisticSolver, this allows customization on which direction contacts are solved first. By default there is no bias set to 'none'.
+- System queries can now exclude entities with specific components
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,33 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added ability to use `ex.Vector` to specify offset and margin in `SpriteSheet.fromImageSource({..})`
 - New PostProcessor.onDraw() hook to handle uploading textures
 - Adds contact solve bias to RealisticSolver, this allows customization on which direction contacts are solved first. By default there is no bias set to 'none'.
-- System queries can now exclude entities with specific components
+- Queries can now take additional options to filter in/out by components or tags.
+
+```ts
+const query = new Query({
+  // all fields are optional
+  components: {
+    all: [ComponentA, ComponentB] as const, // important for type safety!
+    any: [ComponentC, ComponentD] as const, // important for type safety!
+    not: [ComponentE]
+  },
+  tags: {
+    all: ['tagA', 'tagB'],
+    any: ['tagC', 'tagD'],
+    not: ['tagE']
+  }
+})
+
+// previous constructor type still works and is shorthand for components.all
+new Query([ComponentA, ComponentB] as const)
+```
+
+- Queries can now match all entities by specifying no filters
+
+```ts
+const query = new Query({})
+```
+
 
 ### Fixed
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -96,7 +96,7 @@ module.exports = (config) => {
     ],
     client: {
       // Excalibur logs / console logs suppressed when captureConsole = false;
-      captureConsole: false,
+      captureConsole: process.env.CAPTURE_CONSOLE === 'true',
       jasmine: {
         random: true,
         timeoutInterval: 70000 // needs to be bigger than no-activity

--- a/src/engine/EntityComponentSystem/Query.ts
+++ b/src/engine/EntityComponentSystem/Query.ts
@@ -25,7 +25,10 @@ export class Query<TKnownComponentCtors extends ComponentCtor<Component> = never
    */
   public entityRemoved$ = new Observable<Entity<ComponentInstance<TKnownComponentCtors>>>();
 
-  constructor(public readonly requiredComponents: TKnownComponentCtors[]) {
+  constructor(
+    public readonly requiredComponents: TKnownComponentCtors[],
+    public readonly excludedComponents: ComponentCtor<Component>[] = []
+  ) {
     if (requiredComponents.length === 0) {
       throw new Error('Cannot create query without components');
     }
@@ -52,7 +55,11 @@ export class Query<TKnownComponentCtors extends ComponentCtor<Component> = never
    * @param entity
    */
   checkAndAdd(entity: Entity) {
-    if (!this.entities.includes(entity) && entity.hasAll(Array.from(this.components))) {
+    if (
+      !this.entities.includes(entity) &&
+      entity.hasAll(Array.from(this.components)) &&
+      !this.excludedComponents.some((c) => entity.has(c))
+    ) {
       this.entities.push(entity);
       this.entityAdded$.notifyAll(entity);
       return true;

--- a/src/engine/EntityComponentSystem/Query.ts
+++ b/src/engine/EntityComponentSystem/Query.ts
@@ -5,6 +5,42 @@ import { Component, ComponentCtor } from '../EntityComponentSystem/Component';
 export type ComponentInstance<T> = T extends ComponentCtor<infer R> ? R : never;
 
 /**
+ * Turns `Entity<A | B>` into `Entity<A> | Entity<B>`
+ */
+export type DistributeEntity<T> = T extends infer U extends Component ? Entity<U> : never;
+
+export interface QueryEvents<
+  TKnownComponentCtors extends ComponentCtor<Component> = never,
+  TAnyComponentCtors extends ComponentCtor<Component> = never
+> {
+  add: QueryEntity<TKnownComponentCtors, TAnyComponentCtors>;
+  remove: QueryEntity<TKnownComponentCtors, TAnyComponentCtors>;
+}
+
+export interface QueryParams<
+  TKnownComponentCtors extends ComponentCtor<Component> = never,
+  TAnyComponentCtors extends ComponentCtor<Component> = never
+> {
+  components?: {
+    all?: TKnownComponentCtors[];
+    any?: TAnyComponentCtors[];
+    not?: ComponentCtor<Component>[];
+  };
+  tags?: {
+    all?: string[];
+    any?: string[];
+    not?: string[];
+  };
+}
+
+export type QueryEntity<
+  TAllComponentCtors extends ComponentCtor<Component> = never,
+  TAnyComponentCtors extends ComponentCtor<Component> = never
+> = [TAnyComponentCtors] extends [never] // (trick to exclude `never` explicitly)
+  ? Entity<ComponentInstance<TAllComponentCtors>>
+  : Entity<ComponentInstance<TAllComponentCtors>> | DistributeEntity<ComponentInstance<TAnyComponentCtors>>;
+
+/**
  * Represents query for entities that match a list of types that is cached and observable
  *
  * Queries can be strongly typed by supplying a type union in the optional type parameter
@@ -12,42 +48,146 @@ export type ComponentInstance<T> = T extends ComponentCtor<infer R> ? R : never;
  * const queryAB = new ex.Query<ComponentTypeA | ComponentTypeB>(['A', 'B']);
  * ```
  */
-export class Query<TKnownComponentCtors extends ComponentCtor<Component> = never> {
+export class Query<
+  TAllComponentCtors extends ComponentCtor<Component> = never,
+  TAnyComponentCtors extends ComponentCtor<Component> = never
+> {
   public readonly id: string;
-  public components = new Set<TKnownComponentCtors>();
-  public entities: Entity<ComponentInstance<TKnownComponentCtors>>[] = [];
+
+  public entities: Entity<ComponentInstance<TAllComponentCtors>>[] = [];
+
   /**
    * This fires right after the component is added
    */
-  public entityAdded$ = new Observable<Entity<ComponentInstance<TKnownComponentCtors>>>();
+  public entityAdded$ = new Observable<Entity<ComponentInstance<TAllComponentCtors>>>();
   /**
    * This fires right before the component is actually removed from the entity, it will still be available for cleanup purposes
    */
-  public entityRemoved$ = new Observable<Entity<ComponentInstance<TKnownComponentCtors>>>();
+  public entityRemoved$ = new Observable<Entity<ComponentInstance<TAllComponentCtors>>>();
 
-  constructor(
-    public readonly requiredComponents: TKnownComponentCtors[],
-    public readonly excludedComponents: ComponentCtor<Component>[] = []
-  ) {
-    if (requiredComponents.length === 0) {
-      throw new Error('Cannot create query without components');
+  public readonly filter = {
+    components: {
+      all: new Set<TAllComponentCtors>(),
+      any: new Set<TAnyComponentCtors>(),
+      not: new Set<ComponentCtor<Component>>()
+    },
+    tags: {
+      all: new Set<string>(),
+      any: new Set<string>(),
+      not: new Set<string>()
     }
-    for (const type of requiredComponents) {
-      this.components.add(type);
+  };
+
+  constructor(params: TAllComponentCtors[] | QueryParams<TAllComponentCtors, TAnyComponentCtors>) {
+    if (Array.isArray(params)) {
+      params = { components: { all: params } } as QueryParams<TAllComponentCtors, TAnyComponentCtors>;
     }
 
-    this.id = Query.createId(requiredComponents);
+    this.filter.components.all = new Set(params.components?.all ?? []);
+    this.filter.components.any = new Set(params.components?.any ?? []);
+    this.filter.components.not = new Set(params.components?.not ?? []);
+    this.filter.tags.all = new Set(params.tags?.all ?? []);
+    this.filter.tags.any = new Set(params.tags?.any ?? []);
+    this.filter.tags.not = new Set(params.tags?.not ?? []);
+
+    this.id = Query.createId(params);
   }
 
-  static createId(requiredComponents: Function[]) {
+  static createId(params: Function[] | QueryParams<any, any>) {
     // TODO what happens if a user defines the same type name as a built in type
     // ! TODO this could be dangerous depending on the bundler's settings for names
     // Maybe some kind of hash function is better here?
-    return requiredComponents
-      .slice()
-      .map((c) => c.name)
+    if (Array.isArray(params)) {
+      params = { components: { all: params } } as QueryParams<any, any>;
+    }
+
+    const anyComponents = params.components?.any ? `any_${Query.hashComponents(new Set(params.components?.any))}` : '';
+    const allComponents = params.components?.all ? `all_${Query.hashComponents(new Set(params.components?.all))}` : '';
+    const notComponents = params.components?.not ? `not_${Query.hashComponents(new Set(params.components?.not))}` : '';
+
+    const anyTags = params.tags?.any ? `any_${Query.hashTags(new Set(params.tags?.any))}` : '';
+    const allTags = params.tags?.all ? `all_${Query.hashTags(new Set(params.tags?.all))}` : '';
+    const notTags = params.tags?.not ? `not_${Query.hashTags(new Set(params.tags?.not))}` : '';
+
+    return [anyComponents, allComponents, notComponents, anyTags, allTags, notTags].filter(Boolean).join('-');
+  }
+
+  static hashTags(set: Set<string>) {
+    return Array.from(set)
+      .map((t) => `t_${t}`)
       .sort()
       .join('-');
+  }
+
+  static hashComponents(set: Set<ComponentCtor<Component>>) {
+    return Array.from(set)
+      .map((c) => `c_${c.name}`)
+      .sort()
+      .join('-');
+  }
+
+  matches(entity: Entity): boolean {
+    // Components
+    // check if entity has all components
+    for (const component of this.filter.components.all) {
+      if (!entity.has(component)) {
+        return false;
+      }
+    }
+
+    // check if entity has any components
+    if (this.filter.components.any.size > 0) {
+      let found = false;
+      for (const component of this.filter.components.any) {
+        if (entity.has(component)) {
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        return false;
+      }
+    }
+
+    // check if entity has none of the components
+    for (const component of this.filter.components.not) {
+      if (entity.has(component)) {
+        return false;
+      }
+    }
+
+    // Tags
+    // check if entity has all tags
+    for (const tag of this.filter.tags.all) {
+      if (!entity.hasTag(tag)) {
+        return false;
+      }
+    }
+
+    // check if entity has any tags
+    if (this.filter.tags.any.size > 0) {
+      let found = false;
+      for (const tag of this.filter.tags.any) {
+        if (entity.hasTag(tag)) {
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        return false;
+      }
+    }
+
+    // check if entity has none of the tags
+    for (const tag of this.filter.tags.not) {
+      if (entity.hasTag(tag)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**
@@ -55,11 +195,7 @@ export class Query<TKnownComponentCtors extends ComponentCtor<Component> = never
    * @param entity
    */
   checkAndAdd(entity: Entity) {
-    if (
-      !this.entities.includes(entity) &&
-      entity.hasAll(Array.from(this.components)) &&
-      !this.excludedComponents.some((c) => entity.has(c))
-    ) {
+    if (this.matches(entity) && !this.entities.includes(entity)) {
       this.entities.push(entity);
       this.entityAdded$.notifyAll(entity);
       return true;
@@ -79,10 +215,10 @@ export class Query<TKnownComponentCtors extends ComponentCtor<Component> = never
    * Returns a list of entities that match the query
    * @param sort Optional sorting function to sort entities returned from the query
    */
-  public getEntities(sort?: (a: Entity, b: Entity) => number): Entity<ComponentInstance<TKnownComponentCtors>>[] {
+  public getEntities(sort?: (a: Entity, b: Entity) => number): QueryEntity<TAllComponentCtors, TAnyComponentCtors>[] {
     if (sort) {
       this.entities.sort(sort);
     }
-    return this.entities;
+    return this.entities as QueryEntity<TAllComponentCtors, TAnyComponentCtors>[];
   }
 }

--- a/src/engine/EntityComponentSystem/QueryManager.ts
+++ b/src/engine/EntityComponentSystem/QueryManager.ts
@@ -1,5 +1,5 @@
 import { Entity } from './Entity';
-import { Query } from './Query';
+import { Query, QueryParams } from './Query';
 import { Component, ComponentCtor } from './Component';
 import { World } from './World';
 import { TagQuery } from './TagQuery';
@@ -8,10 +8,10 @@ import { TagQuery } from './TagQuery';
  * The query manager is responsible for updating all queries when entities/components change
  */
 export class QueryManager {
-  private _queries = new Map<string, Query<any>>();
+  private _queries = new Map<string, Query<any, any>>();
   private _addComponentHandlers = new Map<Entity, (c: Component) => any>();
   private _removeComponentHandlers = new Map<Entity, (c: Component) => any>();
-  private _componentToQueriesIndex = new Map<ComponentCtor<any>, Query<any>[]>();
+  private _componentToQueriesIndex = new Map<ComponentCtor<any>, Query<any, any>[]>();
 
   private _tagQueries = new Map<string, TagQuery<any>>();
   private _addTagHandlers = new Map<Entity, (tag: string) => any>();
@@ -20,21 +20,24 @@ export class QueryManager {
 
   constructor(private _world: World) {}
 
-  public createQuery<TKnownComponentCtors extends ComponentCtor<Component>>(
-    requiredComponents: TKnownComponentCtors[]
-  ): Query<TKnownComponentCtors> {
-    const id = Query.createId(requiredComponents);
+  public createQuery<
+    TKnownComponentCtors extends ComponentCtor<Component> = never,
+    TAnyComponentCtors extends ComponentCtor<Component> = never
+  >(
+    params: TKnownComponentCtors[] | QueryParams<TKnownComponentCtors, TAnyComponentCtors>
+  ): Query<TKnownComponentCtors, TAnyComponentCtors> {
+    const id = Query.createId(params);
     if (this._queries.has(id)) {
       // short circuit if query is already created
       return this._queries.get(id) as Query<TKnownComponentCtors>;
     }
 
-    const query = new Query(requiredComponents);
+    const query = new Query<TKnownComponentCtors, TAnyComponentCtors>(params);
 
     this._queries.set(query.id, query);
 
     // index maintenance
-    for (const component of requiredComponents) {
+    for (const component of [...query.filter.components.all, ...query.filter.components.any, ...query.filter.components.not]) {
       const queries = this._componentToQueriesIndex.get(component);
       if (!queries) {
         this._componentToQueriesIndex.set(component, [query]);

--- a/src/engine/EntityComponentSystem/World.ts
+++ b/src/engine/EntityComponentSystem/World.ts
@@ -3,7 +3,7 @@ import { Logger } from '../Util/Log';
 import { Component, ComponentCtor } from './Component';
 import { Entity } from './Entity';
 import { EntityManager } from './EntityManager';
-import { Query } from './Query';
+import { Query, QueryParams } from './Query';
 import { QueryManager } from './QueryManager';
 import { System, SystemType } from './System';
 import { SystemCtor, SystemManager, isSystemConstructor } from './SystemManager';
@@ -26,10 +26,11 @@ export class World {
 
   /**
    * Query the ECS world for entities that match your components
-   * @param requiredTypes
    */
-  query<TKnownComponentCtors extends ComponentCtor<Component>>(requiredTypes: TKnownComponentCtors[]): Query<TKnownComponentCtors> {
-    return this.queryManager.createQuery(requiredTypes);
+  query<TKnownComponentCtors extends ComponentCtor<Component> = never, TAnyComponentCtors extends ComponentCtor<Component> = never>(
+    params: TKnownComponentCtors[] | QueryParams<TKnownComponentCtors, TAnyComponentCtors>
+  ): Query<TKnownComponentCtors, TAnyComponentCtors> {
+    return this.queryManager.createQuery(params);
   }
 
   queryTags<TKnownTags extends string>(requiredTags: TKnownTags[]): TagQuery<TKnownTags> {

--- a/src/spec/CollisionShapeSpec.ts
+++ b/src/spec/CollisionShapeSpec.ts
@@ -840,7 +840,6 @@ describe('Collision Shape', () => {
     it('can be drawn with actor', async () => {
       const polygonActor = new ex.Actor({
         pos: new ex.Vector(150, 100),
-        color: ex.Color.Blue,
         collider: ex.Shape.Polygon([new ex.Vector(0, -100), new ex.Vector(-100, 50), new ex.Vector(100, 50)])
       });
 
@@ -1077,7 +1076,6 @@ describe('Collision Shape', () => {
     it('can be drawn with actor', async () => {
       const edgeActor = new ex.Actor({
         pos: new ex.Vector(150, 100),
-        color: ex.Color.Blue,
         collider: ex.Shape.Edge(ex.Vector.Zero, new ex.Vector(300, 300))
       });
 

--- a/src/spec/QuerySpec.ts
+++ b/src/spec/QuerySpec.ts
@@ -14,7 +14,7 @@ describe('A query', () => {
 
   it('has an id', () => {
     const query = new ex.Query([FakeComponentA, FakeComponentB]);
-    expect(query.id).toEqual('FakeComponentA-FakeComponentB');
+    expect(query.id).toEqual('all_c_FakeComponentA-c_FakeComponentB');
   });
 
   it('can match with entities', () => {
@@ -28,8 +28,8 @@ describe('A query', () => {
     const entity2 = new ex.Entity();
     entity2.addComponent(compA);
 
-    expect(entity1.hasAll(queryAB.requiredComponents)).toBe(true, 'entity1 should match has both components A, B');
-    expect(entity2.hasAll(queryAB.requiredComponents)).toBe(false, 'entity2 should not match, only has 1 component A');
+    expect(queryAB.matches(entity1)).toBe(true, 'entity1 should match has both components A, B');
+    expect(queryAB.matches(entity2)).toBe(false, 'entity2 should not match, only has 1 component A');
   });
 
   it('can only add entities that match', () => {
@@ -50,8 +50,57 @@ describe('A query', () => {
     expect(queryAB.getEntities()).toEqual([entity1]);
   });
 
-  it('does not add entity with exclusions', () => {
-    const queryAB = new ex.Query([FakeComponentA], [FakeComponentB]);
+  it('can add entity that match filter.components.any', () => {
+    const queryAB = new ex.Query({
+      components: {
+        any: [FakeComponentA, FakeComponentB]
+      }
+    });
+    const compA = new FakeComponentA();
+    const compB = new FakeComponentB();
+    const entity1 = new ex.Entity();
+    entity1.addComponent(compA);
+
+    const entity2 = new ex.Entity();
+    entity2.addComponent(compB);
+
+    queryAB.checkAndAdd(entity1);
+    expect(queryAB.getEntities()).toEqual([entity1]);
+
+    queryAB.checkAndAdd(entity2);
+    expect(queryAB.getEntities()).toEqual([entity1, entity2]);
+  });
+
+  it('can add entity that match filter.tags.any', () => {
+    const queryAB = new ex.Query({
+      tags: {
+        any: ['tag']
+      }
+    });
+    const compA = new FakeComponentA();
+    const compB = new FakeComponentB();
+    const entity1 = new ex.Entity();
+    entity1.addComponent(compA);
+    entity1.addTag('tag');
+
+    const entity2 = new ex.Entity();
+    entity2.addComponent(compB);
+    entity2.addTag('tag');
+
+    queryAB.checkAndAdd(entity1);
+    expect(queryAB.getEntities()).toEqual([entity1]);
+
+    queryAB.checkAndAdd(entity2);
+    expect(queryAB.getEntities()).toEqual([entity1, entity2]);
+  });
+
+  it('does not add entity with component in filter.components.not', () => {
+    const queryAB = new ex.Query({
+      components: {
+        all: [FakeComponentA],
+        not: [FakeComponentB]
+      }
+    });
     const compA = new FakeComponentA();
     const compB = new FakeComponentB();
     const entity1 = new ex.Entity();
@@ -60,6 +109,30 @@ describe('A query', () => {
     const entity2 = new ex.Entity();
     entity2.addComponent(compA);
     entity2.addComponent(compB);
+
+    queryAB.checkAndAdd(entity1);
+    expect(queryAB.getEntities()).toEqual([entity1]);
+
+    queryAB.checkAndAdd(entity2);
+    expect(queryAB.getEntities()).toEqual([entity1]);
+  });
+
+  it('does not add entity with component in filter.tags.not', () => {
+    const queryAB = new ex.Query({
+      components: {
+        all: [FakeComponentA]
+      },
+      tags: {
+        not: ['tag']
+      }
+    });
+    const compA = new FakeComponentA();
+    const entity1 = new ex.Entity();
+    entity1.addComponent(compA);
+
+    const entity2 = new ex.Entity();
+    entity2.addComponent(compA);
+    entity2.addTag('tag');
 
     queryAB.checkAndAdd(entity1);
     expect(queryAB.getEntities()).toEqual([entity1]);

--- a/src/spec/QuerySpec.ts
+++ b/src/spec/QuerySpec.ts
@@ -50,6 +50,24 @@ describe('A query', () => {
     expect(queryAB.getEntities()).toEqual([entity1]);
   });
 
+  it('does not add entity with exclusions', () => {
+    const queryAB = new ex.Query([FakeComponentA], [FakeComponentB]);
+    const compA = new FakeComponentA();
+    const compB = new FakeComponentB();
+    const entity1 = new ex.Entity();
+    entity1.addComponent(compA);
+
+    const entity2 = new ex.Entity();
+    entity2.addComponent(compA);
+    entity2.addComponent(compB);
+
+    queryAB.checkAndAdd(entity1);
+    expect(queryAB.getEntities()).toEqual([entity1]);
+
+    queryAB.checkAndAdd(entity2);
+    expect(queryAB.getEntities()).toEqual([entity1]);
+  });
+
   it('can remove entities', () => {
     const queryAB = new ex.Query([FakeComponentA, FakeComponentB]);
     const compA = new FakeComponentA();

--- a/src/spec/SystemManagerSpec.ts
+++ b/src/spec/SystemManagerSpec.ts
@@ -165,12 +165,4 @@ describe('A SystemManager', () => {
     expect(system1.update).not.toHaveBeenCalled();
     expect(system2.update).toHaveBeenCalledWith(10);
   });
-
-  it('should throw on invalid system', () => {
-    const world = new ex.World(null);
-    const sm = world.systemManager;
-    expect(() => {
-      sm.addSystem(new FakeSystemPriority1(world, 'ErrorSystem', [], SystemType.Update));
-    }).toThrow(new Error('Cannot create query without components'));
-  });
 });


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

⚠️ Open to any feedback. I went back and forth on a few API designs, ultimately felt this was the simplest & safest without breaking existing behavior.

Improves `ex.Query` to support "any" and "not" filters for components, as well as all/any/not tags filters. The intention is for this to replace `ex.TagQuery`, but that is not (yet) in this PR.

With this change, this would much easily allow systems to exclude entities with tags. For example, GraphicsSystem could now exclude any Entity with an `ex.offscreen` tag instead of manually checking in its update. This could also be used for #3076 by adding a tag to an Entity while paused that excludes it from systems.

I also removed the restriction of throwing on empty component queries, as I think it could make sense to have a system that applies for every Entity. I can change this, though.

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #

## Changes:

- Queries can now take additional options to filter in/out by components or tags.

```ts
const query = new Query({
  // all fields are optional
  components: {
    all: [ComponentA, ComponentB] as const, // important for type safety!
    any: [ComponentC, ComponentD] as const, // important for type safety!
    not: [ComponentE]
  },
  tags: {
    all: ['tagA', 'tagB'],
    any: ['tagC', 'tagD'],
    not: ['tagE']
  }
})

// previous constructor type still works and is shorthand for components.all
new Query([ComponentA, ComponentB] as const)
```

- Queries can now match all entities by specifying no filters

```ts
const query = new Query({})
```
