### PR TITLE
BugFix : Issue 3427, ScreenAppender blocks pointerevents

### DIFF
--- a/src/engine/Util/Log.ts
+++ b/src/engine/Util/Log.ts
@@ -274,6 +274,8 @@ export class ScreenAppender implements Appender {
     this._ctx = this.canvas.getContext('2d')!;
     this.canvas.style.position = 'absolute';
     this.canvas.style.zIndex = options.zIndex?.toString() ?? '99';
+    this.canvas.style.pointerEvents = 'none';
+    this.canvas.style.userSelect = 'none';
     document.body.appendChild(this.canvas);
     this._positionScreenAppenderCanvas();
     options.engine.screen.events.on('resize', () => {


### PR DESCRIPTION

in /Util/Log.ts, line 277

added:

```ts
this.canvas.style.pointerEvents = 'none';
this.canvas.style.userSelect = 'none';
```

