### PR TITLE
fix: ex.Random improve unique seeding on constructor w/o provided seed

### DIFF
--- a/site/docs/09-math/07-random.mdx
+++ b/site/docs/09-math/07-random.mdx
@@ -8,15 +8,9 @@ section: Math
 
 You can instantiate the [[Random]] class with an optional seed number. You can
 reuse this seed anytime to get the exact sequence of random numbers back. If no
-seed is provided, it uses `Date.now()` ticks as the seed.
+seed is provided, it uses a static base seed from `Date.now()` ticks and increments each call.
 
-:::warning
-
-Avoid creating multiple instances of `new ex.Random()`, if you create many in the same moment they will share the same `Date.now()` seed and will produce the same sequence of numbers.
-
-It is recommended to create 1 instance of your seeded random and share it across your game.
-
-:::
+If you create mulitple instances of `new ex.Random()`, it will sequentially increment a base seed from an initial `Date.now()` call.  So each instance of the generator will be unique.
 
 ```ts
 const rand = new ex.Random(1234)

--- a/src/engine/Math/Random.ts
+++ b/src/engine/Math/Random.ts
@@ -59,12 +59,7 @@ export class Random {
     this._mt = new Array<number>(this._n);
     // need to mask to support higher bit machines
 
-    const dynamicSeed = () => {
-      seedOffset++;
-      return initialSeed + seedOffset;
-    };
-
-    this._mt[0] = (seed || dynamicSeed()) >>> 0;
+    this._mt[0] = (seed || initialSeed + seedOffset++) >>> 0;
     this._seed = this._mt[0];
 
     for (let i = 1; i < this._n; i++) {

--- a/src/engine/Math/Random.ts
+++ b/src/engine/Math/Random.ts
@@ -11,6 +11,8 @@
  * 32-bit mask
  */
 const BITMASK32: number = 0xffffffff;
+const initialSeed = Date.now();
+let seedOffset = 0;
 
 /**
  * Pseudo-random number generator following the Mersenne_Twister algorithm. Given a seed this generator will produce the same sequence
@@ -48,14 +50,22 @@ export class Random {
   private _mt: number[];
 
   private _index: number;
+  private _seed: number;
 
   /**
    * If no seed is specified, the Date.now() is used
    */
-  constructor(public seed?: number) {
+  constructor(seed?: number) {
     this._mt = new Array<number>(this._n);
     // need to mask to support higher bit machines
-    this._mt[0] = (seed || Date.now()) >>> 0;
+
+    const dynamicSeed = () => {
+      seedOffset++;
+      return initialSeed + seedOffset;
+    };
+
+    this._mt[0] = (seed || dynamicSeed()) >>> 0;
+    this._seed = this._mt[0];
 
     for (let i = 1; i < this._n; i++) {
       const s = this._mt[i - 1] ^ (this._mt[i - 1] >>> (this._w - 2));
@@ -270,5 +280,9 @@ export class Random {
    */
   public d20() {
     return this.integer(1, 20);
+  }
+
+  get seed() {
+    return this._seed;
   }
 }

--- a/src/spec/vitest/RandomSpec.ts
+++ b/src/spec/vitest/RandomSpec.ts
@@ -1,6 +1,6 @@
 import * as ex from '@excalibur';
 
-describe('A random number', () => {
+describe.only('A random number', () => {
   it('exists', () => {
     expect(ex.Random).toBeDefined();
   });
@@ -318,5 +318,22 @@ describe('A random number', () => {
 
     expect(min).toBeGreaterThan(0);
     expect(max).toBeLessThan(21);
+  });
+
+  it('will have a seed even if not passed into constructor', () => {
+    const random1 = new ex.Random();
+    expect(random1.seed).toBeDefined();
+  });
+
+  it('can have sequential random instances with unique seeds', () => {
+    const random1 = new ex.Random();
+    const random2 = new ex.Random();
+    const random3 = new ex.Random();
+    const seed1 = random1.seed;
+    const seed2 = random2.seed;
+    const seed3 = random3.seed;
+    expect(seed1).not.toBe(seed2);
+    expect(seed1).not.toBe(seed3);
+    expect(seed2).not.toBe(seed3);
   });
 });

--- a/src/spec/vitest/RandomSpec.ts
+++ b/src/spec/vitest/RandomSpec.ts
@@ -1,6 +1,6 @@
 import * as ex from '@excalibur';
 
-describe.only('A random number', () => {
+describe('A random number', () => {
   it('exists', () => {
     expect(ex.Random).toBeDefined();
   });


### PR DESCRIPTION
3 files changed

- Random.ts
- 07-random.mdx
- RandomSpec.ts

# Random.ts
added static intialSeed form Date.now() and an incrementing offset.
also, this ensures that the actual seed used is available property
moved public seed  to private _seed
added getter for seed
in constructor(), if no seed provided it pulls from the 'next' seed in the incrementing list

# 07-random.mdx
updated documentation to reflect new functionality

# RandomSpec.ts
-added 2 tests
- will have a seed even if not passed into constructor
- can have sequential random instances with unique seeds

# Checklist for PR
- added tests
- all tests pass locally
- created test project to exercise new logic with favorable results
- updated docs
