### PR TITLE
fix: [#3469] GpuParticle rotation is respected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ const query = new Query({})
 
 ### Fixed
 
+- Fixed issue where `GpuParticleEmitter` did not rotate with their parents
+- Fixed issue where Cpu `ParticleEmitter` did not respect `ParticleTransform.Local`
 - Fixed issue where same origin iframes did not work properly with keyboard & pointer events
 - Fixed issue where the initial scene onPreLoad was not being run
 - Fixed unecessary coupling with `ex.ColliderComponent`/`ex.BodyComponent` that prevented collider tracking on entities that have `ex.TransformComponent`/`ex.ColliderComponent`, this influenced users doing Entity level ECS with pointer events.

--- a/sandbox/tests/gpu-particles/index.ts
+++ b/sandbox/tests/gpu-particles/index.ts
@@ -36,6 +36,7 @@ var cpuParticles = new ex.ParticleEmitter({
   z: 1,
   emitterType: ex.EmitterType.Circle,
   particle: {
+    // transform: ex.ParticleTransform.Local,
     minSpeed: 1,
     maxSpeed: 10,
     minAngle: 3.4,
@@ -59,6 +60,8 @@ particles.isEmitting = true;
 
 var particleParent = new ex.Actor({
   pos: ex.vec(400, 400),
+  rotation: Math.PI / 4,
+  // angularVelocity: .2,
   width: 10,
   height: 10,
   color: ex.Color.Red

--- a/src/engine/Particles/GpuParticleRenderer.ts
+++ b/src/engine/Particles/GpuParticleRenderer.ts
@@ -181,12 +181,17 @@ export class GpuParticleRenderer {
         ranY = radius * Math.sin(angle);
       }
       const tx = this.emitter.transform.apply(vec(ranX, ranY));
+      const rotation = (this.particle.rotation || 0) + angle;
       const data = [
         this.particle.transform === ParticleTransform.Local ? ranX : tx.x,
         this.particle.transform === ParticleTransform.Local ? ranY : tx.y, // pos in world space
         dx,
         dy, // velocity
-        this.particle.randomRotation ? randomInRange(0, TwoPI, this._random) : this.particle.rotation || 0, // rotation
+        this.particle.randomRotation
+          ? randomInRange(0, TwoPI, this._random)
+          : this.particle.transform === ParticleTransform.Local
+            ? this.particle.rotation || 0
+            : rotation, // rotation
         this.particle.angularVelocity || 0, // angular velocity
         this._particleLife // life
       ];

--- a/src/engine/Particles/GpuParticleRenderer.ts
+++ b/src/engine/Particles/GpuParticleRenderer.ts
@@ -165,7 +165,9 @@ export class GpuParticleRenderer {
     const endIndex = particleCount * this._numInputFloats + startIndex;
     let countParticle = 0;
     for (let i = startIndex; i < endIndex; i += this._numInputFloats) {
-      const angle = this._random.floating(this.particle.minAngle || 0, this.particle.maxAngle || TwoPI);
+      let angle = this._random.floating(this.particle.minAngle || 0, this.particle.maxAngle || TwoPI);
+      angle +=
+        this.particle.transform === ParticleTransform.Local ? this.emitter.transform.rotation : this.emitter.transform.globalRotation;
       const speedX = this._random.floating(this.particle.minSpeed || 0, this.particle.maxSpeed || 0);
       const speedY = this._random.floating(this.particle.minSpeed || 0, this.particle.maxSpeed || 0);
       const dx = speedX * Math.cos(angle);
@@ -181,17 +183,12 @@ export class GpuParticleRenderer {
         ranY = radius * Math.sin(angle);
       }
       const tx = this.emitter.transform.apply(vec(ranX, ranY));
-      const rotation = (this.particle.rotation || 0) + angle;
       const data = [
         this.particle.transform === ParticleTransform.Local ? ranX : tx.x,
         this.particle.transform === ParticleTransform.Local ? ranY : tx.y, // pos in world space
         dx,
         dy, // velocity
-        this.particle.randomRotation
-          ? randomInRange(0, TwoPI, this._random)
-          : this.particle.transform === ParticleTransform.Local
-            ? this.particle.rotation || 0
-            : rotation, // rotation
+        this.particle.randomRotation ? randomInRange(0, TwoPI, this._random) : this.particle.rotation || 0, // rotation
         this.particle.angularVelocity || 0, // angular velocity
         this._particleLife // life
       ];
@@ -229,22 +226,22 @@ export class GpuParticleRenderer {
         // upload before the wrap
         // prettier-ignore
         gl.bufferSubData(
-          gl.ARRAY_BUFFER,
-          this._uploadIndex * 4,
-          this._particleData,
-          this._uploadIndex,
-          this._particleData.length - this._uploadIndex
-        );
+					gl.ARRAY_BUFFER,
+					this._uploadIndex * 4,
+					this._particleData,
+					this._uploadIndex,
+					this._particleData.length - this._uploadIndex
+				);
         // upload after the wrap if there are any
         if (this._wrappedParticles) {
           // prettier-ignore
           gl.bufferSubData(
-            gl.ARRAY_BUFFER,
-            0,
-            this._particleData,
-            0,
-            this._wrappedParticles * this._numInputFloats
-          );
+						gl.ARRAY_BUFFER,
+						0,
+						this._particleData,
+						0,
+						this._wrappedParticles * this._numInputFloats
+					);
         }
         this._wrappedLife = this._particleLife;
       }

--- a/src/engine/Particles/ParticleEmitter.ts
+++ b/src/engine/Particles/ParticleEmitter.ts
@@ -148,7 +148,9 @@ export class ParticleEmitter extends Actor {
     }
 
     const p = this._particlePool.rent();
+    p.unparent();
     p.configure({
+      transform: this.particle.transform,
       life: this.particle.life,
       opacity: this.particle.opacity,
       beginColor: this.particle.beginColor,


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #3469

## Changes:
- Fixed issue where `GpuParticleEmitter` did not rotate with their parents
- Fixed issue where Cpu `ParticleEmitter` did not respect `ParticleTransform.Local`

