### PR TITLE
fix: Animation behavior when reset() from animation event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ const query = new Query({})
 
 ### Fixed
 
+- Fixed issue where an animation that was `anim.reset()` inside of an animation event handler like `anim.once('end', () => anim.reset())` would not work correctly
 - Fixed issue where `GpuParticleEmitter` did not rotate with their parents
 - Fixed issue where Cpu `ParticleEmitter` did not respect `ParticleTransform.Local`
 - Fixed issue where same origin iframes did not work properly with keyboard & pointer events

--- a/src/engine/Graphics/Animation.ts
+++ b/src/engine/Graphics/Animation.ts
@@ -166,7 +166,7 @@ export class Animation extends Graphic implements HasTick {
   private _done = false;
   private _playing = true;
   private _speed = 1;
-  private _wasReset: boolean;
+  private _wasResetDuringFrameCalc: boolean;
 
   constructor(options: GraphicOptions & AnimationOptions) {
     super(options);
@@ -380,7 +380,6 @@ export class Animation extends Graphic implements HasTick {
    */
   public play(): void {
     this._playing = true;
-    this._wasReset = false;
   }
 
   /**
@@ -388,7 +387,6 @@ export class Animation extends Graphic implements HasTick {
    */
   public pause(): void {
     this._playing = false;
-    this._wasReset = false;
     this._firstTick = true; // firstTick must be set to emit the proper frame event
   }
 
@@ -396,7 +394,7 @@ export class Animation extends Graphic implements HasTick {
    * Reset the animation back to the beginning, including if the animation were done
    */
   public reset(): void {
-    this._wasReset = true;
+    this._wasResetDuringFrameCalc = true;
     this._done = false;
     this._firstTick = true;
     this._currentFrame = 0;
@@ -451,6 +449,7 @@ export class Animation extends Graphic implements HasTick {
   }
 
   private _nextFrame(): number {
+    this._wasResetDuringFrameCalc = false;
     const currentFrame = this._currentFrame;
     if (this._done) {
       return currentFrame;
@@ -497,8 +496,9 @@ export class Animation extends Graphic implements HasTick {
         break;
       }
     }
-    if (this._wasReset) {
-      this._wasReset = false;
+    if (this._wasResetDuringFrameCalc) {
+      // if reset during frame calculation discard the calc'd next and return the current frame.
+      this._wasResetDuringFrameCalc = false;
       return this._currentFrame;
     }
     return next;

--- a/src/engine/Graphics/Animation.ts
+++ b/src/engine/Graphics/Animation.ts
@@ -166,6 +166,7 @@ export class Animation extends Graphic implements HasTick {
   private _done = false;
   private _playing = true;
   private _speed = 1;
+  private _wasReset: boolean;
 
   constructor(options: GraphicOptions & AnimationOptions) {
     super(options);
@@ -379,6 +380,7 @@ export class Animation extends Graphic implements HasTick {
    */
   public play(): void {
     this._playing = true;
+    this._wasReset = false;
   }
 
   /**
@@ -386,6 +388,7 @@ export class Animation extends Graphic implements HasTick {
    */
   public pause(): void {
     this._playing = false;
+    this._wasReset = false;
     this._firstTick = true; // firstTick must be set to emit the proper frame event
   }
 
@@ -393,6 +396,7 @@ export class Animation extends Graphic implements HasTick {
    * Reset the animation back to the beginning, including if the animation were done
    */
   public reset(): void {
+    this._wasReset = true;
     this._done = false;
     this._firstTick = true;
     this._currentFrame = 0;
@@ -492,6 +496,10 @@ export class Animation extends Graphic implements HasTick {
         next = currentFrame + (this._pingPongDirection % this.frames.length);
         break;
       }
+    }
+    if (this._wasReset) {
+      this._wasReset = false;
+      return this._currentFrame;
     }
     return next;
   }

--- a/src/engine/Graphics/Animation.ts
+++ b/src/engine/Graphics/Animation.ts
@@ -166,7 +166,7 @@ export class Animation extends Graphic implements HasTick {
   private _done = false;
   private _playing = true;
   private _speed = 1;
-  private _wasResetDuringFrameCalc: boolean;
+  private _wasResetDuringFrameCalc: boolean = false;
 
   constructor(options: GraphicOptions & AnimationOptions) {
     super(options);

--- a/src/spec/vitest/AnimationSpec.ts
+++ b/src/spec/vitest/AnimationSpec.ts
@@ -690,4 +690,39 @@ describe('A Graphics Animation', () => {
     anim.speed = 100;
     expect(anim.speed).toBe(100);
   });
+
+  it('can be reset during the end event', () => {
+    const rect = new ex.Rectangle({
+      width: 100,
+      height: 100,
+      color: ex.Color.Blue
+    });
+    const frames: ex.Frame[] = [
+      {
+        graphic: rect,
+        duration: 100
+      },
+      {
+        graphic: rect,
+        duration: 100
+      }
+    ];
+    const anim = new ex.Animation({
+      frames: frames,
+      speed: 2,
+      strategy: ex.AnimationStrategy.End
+    });
+    const endSpy = vi.fn(() => {
+      anim.reset();
+      expect(anim.currentFrameIndex).toBe(0);
+    });
+    anim.events.once('end', endSpy);
+    anim.play();
+    expect(anim.currentFrameIndex).toBe(0);
+    anim.tick(100, 1);
+    expect(anim.currentFrameIndex).toBe(1);
+    anim.tick(100, 2);
+    expect(endSpy).toHaveBeenCalledOnce();
+    expect(anim.currentFrameIndex).toBe(0);
+  });
 });


### PR DESCRIPTION

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Bug found on the discord https://discordapp.com/channels/1195771303215513671/1401189791017467967

## Changes:

- Events can change frames during the frame calculation if reset is called, check for such case
