### PR TITLE
feat: Support meta data for Animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ const query = new Query({})
 
 ### Fixed
 
+- Fixed issue where an animation that was `anim.reset()` inside of an animation event handler like `anim.once('end', () => anim.reset())` would not work correctly
 - Fixed issue where `GpuParticleEmitter` did not rotate with their parents
 - Fixed issue where Cpu `ParticleEmitter` did not respect `ParticleTransform.Local`
 - Fixed issue where same origin iframes did not work properly with keyboard & pointer events

--- a/src/spec/vitest/AnimationSpec.ts
+++ b/src/spec/vitest/AnimationSpec.ts
@@ -690,4 +690,72 @@ describe('A Graphics Animation', () => {
     anim.speed = 100;
     expect(anim.speed).toBe(100);
   });
+
+  it('can be reset during the end event (end)', () => {
+    const rect = new ex.Rectangle({
+      width: 100,
+      height: 100,
+      color: ex.Color.Blue
+    });
+    const frames: ex.Frame[] = [
+      {
+        graphic: rect,
+        duration: 100
+      },
+      {
+        graphic: rect,
+        duration: 100
+      }
+    ];
+    const anim = new ex.Animation({
+      frames: frames,
+      strategy: ex.AnimationStrategy.End
+    });
+    const endSpy = vi.fn(() => {
+      anim.reset();
+      expect(anim.currentFrameIndex).toBe(0);
+    });
+    anim.events.once('end', endSpy);
+    anim.play();
+    expect(anim.currentFrameIndex).toBe(0);
+    anim.tick(100, 1);
+    expect(anim.currentFrameIndex).toBe(1);
+    anim.tick(100, 2);
+    expect(endSpy).toHaveBeenCalledOnce();
+    expect(anim.currentFrameIndex).toBe(0);
+  });
+
+  it('can be reset during the end event (freeze)', () => {
+    const rect = new ex.Rectangle({
+      width: 100,
+      height: 100,
+      color: ex.Color.Blue
+    });
+    const frames: ex.Frame[] = [
+      {
+        graphic: rect,
+        duration: 100
+      },
+      {
+        graphic: rect,
+        duration: 100
+      }
+    ];
+    const anim = new ex.Animation({
+      frames: frames,
+      strategy: ex.AnimationStrategy.Freeze
+    });
+    const endSpy = vi.fn(() => {
+      anim.reset();
+      expect(anim.currentFrameIndex).toBe(0);
+    });
+    anim.events.once('end', endSpy);
+    anim.play();
+    expect(anim.currentFrameIndex).toBe(0);
+    anim.tick(100, 1);
+    expect(anim.currentFrameIndex).toBe(1);
+    anim.tick(100, 2);
+    expect(endSpy).toHaveBeenCalledOnce();
+    expect(anim.currentFrameIndex).toBe(0);
+  });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Feature requested on the discord: https://discord.com/channels/1195771303215513671/1400805035503390721

# Changes

arbitrary meta data can now be added for an `Animation`

```ts
const rect = new ex.Rectangle({
  width: 100,
  height: 100,
  color: ex.Color.Blue
});
const anim = new ex.Animation({
  frames: [
    {
      graphic: rect,
      duration: 100
    }
  ],
  data: { someKey: 'someValue' }
});

console.log(anim.data.get('someKey')) // someValue

anim.data.set('otherKey', 'otherValue')
console.log(anim.data.get('otherKey')) // otherValue
```

`fromSpriteSheet(...)` now also accepts data as an optional argument.

```ts
const anim = ex.Animation.fromSpriteSheet(someSpriteSheet, [0, 1, 2, 3], 100, ex.AnimationStrategy.Freeze, {
  someKey: 'someValue'
});
```

as well as `fromSpriteSheetCoordinates({...})`

```ts
const anim = ex.Animation.fromSpriteSheetCoordinates({
  spriteSheet: someSpriteSheet,
  frameCoordinates: [{ x: 0, y: 0, duration: 100 }],
  data: {
    someKey: 'someValue'
  }
});
```