### PR TITLE
Feature: Added lerp method to vector class

### DIFF
--- a/site/docs/09-math/07-vector.mdx
+++ b/site/docs/09-math/07-vector.mdx
@@ -61,3 +61,169 @@ console.log(anotherPoint.toString()) // "(50, 50)"
 ```
 
 Notice how both `point` and `samePoint` share the same vector reference, so using `setTo` mutates the vector. Use `clone` to ensure you are not changing vectors unexpectedly!
+
+### Static Methods Available
+
+#### `Vector.fromAngle(angle: number): Vector`
+Creates a unit vector from an angle in radians.
+
+```typescript
+const rightVector = Vector.fromAngle(0); // (1, 0)
+const upVector = Vector.fromAngle(-Math.PI / 2); // (0, -1)
+```
+
+#### `Vector.distance(vec1: Vector, vec2: Vector): number`
+Calculates the distance between two vectors.
+
+```typescript
+const distance = Vector.distance(vec(0, 0), vec(3, 4)); // 5
+```
+
+#### `Vector.isValid(vec: Vector): boolean`
+Checks if a vector is valid (not null, undefined, or containing NaN/Infinity).
+
+```typescript
+const isValid = Vector.isValid(new Vector(1, 2)); // true
+const isInvalid = Vector.isValid(new Vector(NaN, 1)); // false
+```
+
+#### `Vector.min(vec1: Vector, vec2: Vector): Vector`
+Returns a vector with the minimum x and y components.
+
+#### `Vector.max(vec1: Vector, vec2: Vector): Vector`
+Returns a vector with the maximum x and y components.
+
+### Instance Properties
+
+#### `x: number` and `y: number`
+Get or set the vector components. **Warning**: Setting these properties mutates the vector.
+
+#### `magnitude: number`
+Get or set the vector's magnitude (length). Setting this normalizes the vector and scales it to the new magnitude.
+
+### Core Operations
+
+#### `add(v: Vector, dest?: Vector): Vector`
+Adds another vector to this one.
+
+```typescript
+const result = vec(1, 2).add(vec(3, 4)); // (4, 6)
+```
+
+#### `sub(v: Vector, dest?: Vector): Vector`
+Subtracts another vector from this one.
+
+```typescript
+const result = vec(5, 3).sub(vec(2, 1)); // (3, 2)
+```
+
+#### `scale(size: number | Vector, dest?: Vector): Vector`
+Scales the vector by a scalar or component-wise by another vector.
+
+```typescript
+const scaled = vec(2, 3).scale(2); // (4, 6)
+const componentScaled = vec(2, 3).scale(vec(2, 0.5)); // (4, 1.5)
+```
+
+#### `normalize(): Vector`
+Returns a unit vector in the same direction.
+
+```typescript
+const unit = vec(3, 4).normalize(); // (0.6, 0.8)
+```
+
+### Distance and Magnitude
+
+#### `distance(v?: Vector): number`
+Returns the distance to another vector, or magnitude if no vector provided.
+
+```typescript
+const dist = vec(0, 0).distance(vec(3, 4)); // 5
+const magnitude = vec(3, 4).distance(); // 5
+```
+
+#### `squareDistance(v?: Vector): number`
+Returns the squared distance (faster than distance for comparisons).
+
+### Vector Math
+
+#### `dot(v: Vector): number`
+Calculates the dot product with another vector.
+
+```typescript
+const dotProduct = vec(1, 2).dot(vec(3, 4)); // 11
+```
+
+#### `cross(v: Vector | number): number | Vector`
+Calculates the cross product. With a vector, returns a scalar. With a scalar, returns a vector.
+
+```typescript
+const crossScalar = vec(1, 2).cross(vec(3, 4)); // -2
+const crossVector = vec(1, 2).cross(5); // (10, -5)
+```
+
+#### `perpendicular(): Vector`
+Returns a perpendicular vector (rotated 90 degrees).
+
+```typescript
+const perp = vec(1, 0).perpendicular(); // (0, -1)
+```
+
+#### `normal(): Vector`
+Returns the normalized perpendicular vector.
+
+### Rotation and Angles
+
+#### `toAngle(): number`
+Returns the angle of the vector in radians [0, 2π).
+
+```typescript
+const angle = vec(1, 1).toAngle(); // π/4 (45 degrees)
+```
+
+#### `rotate(angle: number, anchor?: Vector, dest?: Vector): Vector`
+Rotates the vector by an angle around an anchor point.
+
+```typescript
+const rotated = vec(1, 0).rotate(Math.PI / 2); // (0, 1)
+```
+
+#### `angleBetween(angle: number, rotationType: RotationType): number`
+Returns the angle needed to rotate this vector to match the target angle.
+
+### Utility Methods
+
+#### `equals(vector: Vector, tolerance?: number): boolean`
+Tests for equality within a tolerance.
+
+```typescript
+const isEqual = vec(1, 1).equals(vec(1.001, 0.999), 0.01); // true
+```
+
+#### `lerp(target: Vector, t: number): Vector`
+Linear interpolation between this vector and the target.  `t` is clamped between [0,1]
+
+```typescript
+const midpoint = vec(0, 0).lerp(vec(10, 10), 0.5); // (5, 5)
+```
+
+#### `average(vec: Vector): Vector`
+Returns the midpoint between this vector and another.
+
+#### `clone(dest?: Vector): Vector`
+Creates a copy of the vector.
+
+#### `negate(): Vector`
+Returns the negated vector.
+
+#### `clampMagnitude(magnitude: number): Vector`
+Clamps the vector's magnitude to a maximum value (mutates the vector).
+
+### Mutating Operations
+
+**⚠️ Warning**: These methods modify the original vector and should be used carefully.
+
+- `addEqual(v: Vector)`: Adds and mutates
+- `subEqual(v: Vector)`: Subtracts and mutates  
+- `scaleEqual(size: number)`: Scales and mutates
+- `setTo(x: number, y: number)`: Sets components and mutates

--- a/src/engine/Math/vector.ts
+++ b/src/engine/Math/vector.ts
@@ -454,6 +454,24 @@ export class Vector implements Clonable<Vector> {
     }
     return `(${this.x}, ${this.y})`;
   }
+
+  /**
+   * Linearly interpolates between the current vector and the target vector.
+   * At `t = 0`, the result is the current vector, and at `t = 1`, the result is the target vector.
+   * Values of `t` outside the range [0, 1] will be clamped to that range.
+   *
+   * @param target The target vector to interpolate towards.
+   * @param t The interpolation factor, clamped between 0 and 1.
+   * @returns A new vector that is the result of the linear interpolation.
+   */
+
+  public lerp(target: Vector, t: number) {
+    t = clamp(t, 0, 1);
+    let newVector = new Vector(0, 0);
+    newVector.x = this.x + (target.x - this.x) * t;
+    newVector.y = this.y + (target.y - this.y) * t;
+    return newVector;
+  }
 }
 
 /**

--- a/src/spec/LinesSpec.ts
+++ b/src/spec/LinesSpec.ts
@@ -1,0 +1,144 @@
+import * as ex from 'excalibur';
+
+describe('Lines', () => {
+  it('exist', () => {
+    expect(ex.LineSegment).toBeDefined();
+  });
+
+  it('can be constructed', () => {
+    const line = new ex.LineSegment(new ex.Vector(1, -1), new ex.Vector(1, 1));
+    expect(line).toBeTruthy();
+  });
+
+  it('can have a slope Vector', () => {
+    const line = new ex.LineSegment(new ex.Vector(1, -1), new ex.Vector(1, 1));
+    const slope = line.getSlope();
+
+    expect(slope.equals(new ex.Vector(0, 1))).toBeTruthy();
+  });
+
+  it('can have a slope value of infinity', () => {
+    const line = new ex.LineSegment(new ex.Vector(1, 0), new ex.Vector(1, 1));
+    const slope = line.slope;
+
+    expect(line.slope).toBe(Infinity);
+  });
+
+  it('can have a slope value of 0', () => {
+    const line = new ex.LineSegment(new ex.Vector(1, 1), new ex.Vector(2, 1));
+    const slope = line.slope;
+
+    expect(line.slope).toBe(0);
+  });
+
+  it('can have a positive slope value', () => {
+    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(1, 1));
+
+    expect(line.slope).toBe(1);
+  });
+
+  it('can have a negative slope value', () => {
+    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(-1, 1));
+
+    expect(line.slope).toBe(-1);
+  });
+
+  it('can have a y intercept of infinity', () => {
+    const line = new ex.LineSegment(new ex.Vector(1, 0), new ex.Vector(1, 1));
+
+    expect(line.intercept).toBe(-Infinity);
+  });
+
+  it('can have a positive y intercept', () => {
+    const line = new ex.LineSegment(new ex.Vector(1, 2), new ex.Vector(2, 2));
+
+    expect(line.intercept).toBe(2);
+  });
+
+  it('can have a negative y intercept', () => {
+    const line = new ex.LineSegment(new ex.Vector(1, 1), new ex.Vector(2, 2));
+
+    expect(line.intercept).toBe(0);
+  });
+
+  it('can have a normal', () => {
+    const line = new ex.LineSegment(new ex.Vector(1, 1), new ex.Vector(2, 1));
+
+    const normal = line.normal();
+    expect(normal.x).toBe(0);
+    expect(normal.y).toBe(-1);
+  });
+
+  it('can have a length', () => {
+    const line = new ex.LineSegment(new ex.Vector(1, -1), new ex.Vector(1, 1));
+    expect(line.getLength()).toBe(2);
+  });
+
+  it('can find a point by X value', () => {
+    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
+    const t = line.findPoint(1);
+
+    expect(t.y).toBe(1);
+  });
+
+  it('can find a point by Y value', () => {
+    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
+    const t = line.findPoint(null, 1);
+
+    expect(t.x).toBe(1);
+  });
+
+  it('can calculate the perpendicular distance from a point', () => {
+    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(200, 0));
+    const point = new ex.Vector(100, 100);
+    expect(line.distanceToPoint(point)).toBe(100);
+  });
+
+  it('can calculate the perpendicular distance from a point not above the line', () => {
+    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(200, 0));
+    const point = new ex.Vector(-100, 100);
+    expect(line.distanceToPoint(point)).toBe(100);
+  });
+
+  it('can determine if point lies on the line by x and y', () => {
+    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
+    const t = line.hasPoint(1, 1);
+
+    expect(t).toBe(true);
+  });
+
+  it('can determine if point lies on the line by Vector', () => {
+    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
+    const t = line.hasPoint(new ex.Vector(1, 1));
+
+    expect(t).toBe(true);
+  });
+
+  it('can determine if point lies on the line by x and y with absolute precision', () => {
+    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
+    const t = line.hasPoint(1.005, 1);
+
+    expect(t).toBe(false);
+  });
+
+  it('can determine if point lies on the line by Vector with absolute precision', () => {
+    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
+    const t = line.hasPoint(new ex.Vector(1.005, 1));
+
+    expect(t).toBe(false);
+  });
+
+  it('can determine if point lies on the line by x and y at a certain threshold', () => {
+    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
+    const t = line.hasPoint(1.005, 1, 0.1);
+
+    expect(t).toBe(true);
+  });
+
+  it('can determine if point lies on the line by Vector at a certain threshold', () => {
+    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
+    const t = line.hasPoint(new ex.Vector(1.005, 1), 0.1);
+
+    expect(t).toBe(true);
+  });
+});

--- a/src/spec/ProjectionsSpec.ts
+++ b/src/spec/ProjectionsSpec.ts
@@ -1,0 +1,36 @@
+import * as ex from 'excalibur';
+
+describe('Projections', () => {
+  it('exists', () => {
+    expect(ex.Projection).toBeDefined();
+  });
+
+  it('can be constructed', () => {
+    const proj = new ex.Projection(5, 10);
+    expect(proj).toBeTruthy();
+  });
+
+  it('can detect overlap between projections', () => {
+    const proj = new ex.Projection(5, 10);
+    const proj2 = new ex.Projection(7, 12);
+    expect(proj.getOverlap(proj2)).toBe(3);
+  });
+
+  it('can detect overlap between projections across zero', () => {
+    const proj = new ex.Projection(-5, 2);
+    const proj2 = new ex.Projection(-2, 5);
+    expect(proj.getOverlap(proj2)).toBe(4);
+  });
+
+  it('can detect no overlap between projections', () => {
+    const proj = new ex.Projection(5, 10);
+    const proj2 = new ex.Projection(10, 12);
+    expect(proj.getOverlap(proj2)).toBe(0);
+  });
+
+  it('can detect no overlap between projections with separation', () => {
+    const proj = new ex.Projection(5, 10);
+    const proj2 = new ex.Projection(11, 12);
+    expect(proj.getOverlap(proj2)).toBe(0);
+  });
+});

--- a/src/spec/vitest/RaysSpec.ts
+++ b/src/spec/vitest/RaysSpec.ts
@@ -1,0 +1,25 @@
+import * as ex from '@excalibur';
+
+describe('Rays', () => {
+  it('exists', () => {
+    expect(ex.Ray).toBeDefined();
+  });
+
+  it('can be constructed', () => {
+    const ray = new ex.Ray(ex.Vector.Zero.clone(), new ex.Vector(1, 0));
+    expect(ray).toBeTruthy();
+    expect(ray.dir.equals(new ex.Vector(1, 0)));
+  });
+
+  it('can intersect with lines', () => {
+    const ray = new ex.Ray(ex.Vector.Zero.clone(), new ex.Vector(1, 0));
+    const line = new ex.LineSegment(new ex.Vector(1, -1), new ex.Vector(1, 1));
+    const intersection = ray.intersect(line);
+
+    expect(intersection).toBeGreaterThan(0);
+
+    const point = ray.getPoint(intersection);
+
+    expect(point.equals(new ex.Vector(1, 0))).toBeTruthy();
+  });
+});

--- a/src/spec/vitest/VectorSpec.ts
+++ b/src/spec/vitest/VectorSpec.ts
@@ -352,207 +352,39 @@ describe('Vectors', () => {
     expect(before.y).toBeCloseTo(after.y, 4);
     expect(sut.magnitude).toBe(5);
   });
-});
 
-describe('Rays', () => {
-  it('exists', () => {
-    expect(ex.Ray).toBeDefined();
+  it('can lerp between vectors', () => {
+    const startingVector = new ex.Vector(0, 0);
+    const endingVector = new ex.Vector(4, 4);
+
+    const lerpVector = startingVector.lerp(endingVector, 0.5);
+    expect(lerpVector.x).toBeCloseTo(2);
+    expect(lerpVector.y).toBeCloseTo(2);
+
+    const lerpVector2 = startingVector.lerp(endingVector, 0.25);
+    expect(lerpVector2.x).toBeCloseTo(1);
+    expect(lerpVector2.y).toBeCloseTo(1);
+
+    const lerpVector3 = startingVector.lerp(endingVector, 0.75);
+    expect(lerpVector3.x).toBeCloseTo(3);
+    expect(lerpVector3.y).toBeCloseTo(3);
+
+    const lerpVector4 = startingVector.lerp(endingVector, 1);
+    expect(lerpVector4.x).toBeCloseTo(4);
+    expect(lerpVector4.y).toBeCloseTo(4);
   });
 
-  it('can be constructed', () => {
-    const ray = new ex.Ray(ex.Vector.Zero.clone(), new ex.Vector(1, 0));
-    expect(ray).toBeTruthy();
-    expect(ray.dir.equals(new ex.Vector(1, 0)));
-  });
+  it('can accept oob numbers in lerp and clamp them', () => {
+    const startingVector = new ex.Vector(0, 0);
+    const endingVector = new ex.Vector(4, 4);
 
-  it('can intersect with lines', () => {
-    const ray = new ex.Ray(ex.Vector.Zero.clone(), new ex.Vector(1, 0));
-    const line = new ex.LineSegment(new ex.Vector(1, -1), new ex.Vector(1, 1));
-    const intersection = ray.intersect(line);
+    const lerpVector = startingVector.lerp(endingVector, 10);
+    expect(lerpVector.x).toBeCloseTo(4);
+    expect(lerpVector.y).toBeCloseTo(4);
 
-    expect(intersection).toBeGreaterThan(0);
-
-    const point = ray.getPoint(intersection);
-
-    expect(point.equals(new ex.Vector(1, 0))).toBeTruthy();
-  });
-});
-
-describe('Lines', () => {
-  it('exist', () => {
-    expect(ex.LineSegment).toBeDefined();
-  });
-
-  it('can be constructed', () => {
-    const line = new ex.LineSegment(new ex.Vector(1, -1), new ex.Vector(1, 1));
-    expect(line).toBeTruthy();
-  });
-
-  it('can have a slope Vector', () => {
-    const line = new ex.LineSegment(new ex.Vector(1, -1), new ex.Vector(1, 1));
-    const slope = line.getSlope();
-
-    expect(slope.equals(new ex.Vector(0, 1))).toBeTruthy();
-  });
-
-  it('can have a slope value of infinity', () => {
-    const line = new ex.LineSegment(new ex.Vector(1, 0), new ex.Vector(1, 1));
-    const slope = line.slope;
-
-    expect(line.slope).toBe(Infinity);
-  });
-
-  it('can have a slope value of 0', () => {
-    const line = new ex.LineSegment(new ex.Vector(1, 1), new ex.Vector(2, 1));
-    const slope = line.slope;
-
-    expect(line.slope).toBe(0);
-  });
-
-  it('can have a positive slope value', () => {
-    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(1, 1));
-
-    expect(line.slope).toBe(1);
-  });
-
-  it('can have a negative slope value', () => {
-    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(-1, 1));
-
-    expect(line.slope).toBe(-1);
-  });
-
-  it('can have a y intercept of infinity', () => {
-    const line = new ex.LineSegment(new ex.Vector(1, 0), new ex.Vector(1, 1));
-
-    expect(line.intercept).toBe(-Infinity);
-  });
-
-  it('can have a positive y intercept', () => {
-    const line = new ex.LineSegment(new ex.Vector(1, 2), new ex.Vector(2, 2));
-
-    expect(line.intercept).toBe(2);
-  });
-
-  it('can have a negative y intercept', () => {
-    const line = new ex.LineSegment(new ex.Vector(1, 1), new ex.Vector(2, 2));
-
-    expect(line.intercept).toBe(0);
-  });
-
-  it('can have a normal', () => {
-    const line = new ex.LineSegment(new ex.Vector(1, 1), new ex.Vector(2, 1));
-
-    const normal = line.normal();
-    expect(normal.x).toBe(0);
-    expect(normal.y).toBe(-1);
-  });
-
-  it('can have a length', () => {
-    const line = new ex.LineSegment(new ex.Vector(1, -1), new ex.Vector(1, 1));
-    expect(line.getLength()).toBe(2);
-  });
-
-  it('can find a point by X value', () => {
-    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
-    const t = line.findPoint(1);
-
-    expect(t.y).toBe(1);
-  });
-
-  it('can find a point by Y value', () => {
-    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
-    const t = line.findPoint(null, 1);
-
-    expect(t.x).toBe(1);
-  });
-
-  it('can calculate the perpendicular distance from a point', () => {
-    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(200, 0));
-    const point = new ex.Vector(100, 100);
-    expect(line.distanceToPoint(point)).toBe(100);
-  });
-
-  it('can calculate the perpendicular distance from a point not above the line', () => {
-    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(200, 0));
-    const point = new ex.Vector(-100, 100);
-    expect(line.distanceToPoint(point)).toBe(100);
-  });
-
-  it('can determine if point lies on the line by x and y', () => {
-    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
-    const t = line.hasPoint(1, 1);
-
-    expect(t).toBe(true);
-  });
-
-  it('can determine if point lies on the line by Vector', () => {
-    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
-    const t = line.hasPoint(new ex.Vector(1, 1));
-
-    expect(t).toBe(true);
-  });
-
-  it('can determine if point lies on the line by x and y with absolute precision', () => {
-    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
-    const t = line.hasPoint(1.005, 1);
-
-    expect(t).toBe(false);
-  });
-
-  it('can determine if point lies on the line by Vector with absolute precision', () => {
-    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
-    const t = line.hasPoint(new ex.Vector(1.005, 1));
-
-    expect(t).toBe(false);
-  });
-
-  it('can determine if point lies on the line by x and y at a certain threshold', () => {
-    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
-    const t = line.hasPoint(1.005, 1, 0.1);
-
-    expect(t).toBe(true);
-  });
-
-  it('can determine if point lies on the line by Vector at a certain threshold', () => {
-    const line = new ex.LineSegment(new ex.Vector(0, 0), new ex.Vector(2, 2));
-    const t = line.hasPoint(new ex.Vector(1.005, 1), 0.1);
-
-    expect(t).toBe(true);
-  });
-});
-
-describe('Projections', () => {
-  it('exists', () => {
-    expect(ex.Projection).toBeDefined();
-  });
-
-  it('can be constructed', () => {
-    const proj = new ex.Projection(5, 10);
-    expect(proj).toBeTruthy();
-  });
-
-  it('can detect overlap between projections', () => {
-    const proj = new ex.Projection(5, 10);
-    const proj2 = new ex.Projection(7, 12);
-    expect(proj.getOverlap(proj2)).toBe(3);
-  });
-
-  it('can detect overlap between projections across zero', () => {
-    const proj = new ex.Projection(-5, 2);
-    const proj2 = new ex.Projection(-2, 5);
-    expect(proj.getOverlap(proj2)).toBe(4);
-  });
-
-  it('can detect no overlap between projections', () => {
-    const proj = new ex.Projection(5, 10);
-    const proj2 = new ex.Projection(10, 12);
-    expect(proj.getOverlap(proj2)).toBe(0);
-  });
-
-  it('can detect no overlap between projections with separation', () => {
-    const proj = new ex.Projection(5, 10);
-    const proj2 = new ex.Projection(11, 12);
-    expect(proj.getOverlap(proj2)).toBe(0);
+    const lerpVector2 = startingVector.lerp(endingVector, -10);
+    expect(lerpVector2.x).toBeCloseTo(0);
+    expect(lerpVector2.y).toBeCloseTo(0);
   });
 });
 


### PR DESCRIPTION
Added lerp method to Vector class, with clamped t for time [0,1]

Made a comprehensive update to the Vector documentation, spelled out more about what's available with Vectors

added lerptests to Vector spec, 
can lerp ...
can clamp lerp time...

broke AlgebraSpec.ts into VectorSpect.ts, LinesSpect.ts, ProjectionsSpec.ts, and RaysSpec.ts