### PR TITLE
[Bug] Collider.ts, touching(), returning always true

### DIFF
--- a/src/engine/Collision/Colliders/Collider.ts
+++ b/src/engine/Collision/Colliders/Collider.ts
@@ -38,7 +38,8 @@ export abstract class Collider implements Clonable<Collider> {
   public touching(other: Collider): boolean {
     const contact = this.collide(other);
 
-    if (contact) {
+    // if there is a contact then we are touching
+    if (contact && contact.length > 0) {
       return true;
     }
 


### PR DESCRIPTION
Modified Collider.ts
in touching()

```
if(contact){
   ...
}
```

contact receives a [ ] empty array is no collisions, but that evaluates as truthy, so returns true for touching.

changed to `if(contact && contact.length > 0){...`