### PR TITLE
fix: Apply z index to particles [#3503]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ const query = new Query({})
 
 ### Fixed
 
+- Fixed issue where `ParticleEmitter` `Particle` did not receive z index value from emitter when in World space
 - Fixed issue where an animation that was `anim.reset()` inside of an animation event handler like `anim.once('end', () => anim.reset())` would not work correctly
 - Fixed issue where `GpuParticleEmitter` did not rotate with their parents
 - Fixed issue where Cpu `ParticleEmitter` did not respect `ParticleTransform.Local`

--- a/src/engine/Particles/ParticleEmitter.ts
+++ b/src/engine/Particles/ParticleEmitter.ts
@@ -156,6 +156,7 @@ export class ParticleEmitter extends Actor {
       beginColor: this.particle.beginColor,
       endColor: this.particle.endColor,
       pos: vec(ranX, ranY),
+      z: this.particle.transform === ParticleTransform.Global ? this.z : undefined,
       vel: vec(dx, dy),
       acc: this.particle.acc,
       angularVelocity: this.particle.angularVelocity,

--- a/src/engine/Particles/Particles.ts
+++ b/src/engine/Particles/Particles.ts
@@ -94,6 +94,7 @@ export class Particle extends Entity {
     this.transform.pos = options.pos ?? this.transform.pos;
     this.transform.rotation = options.rotation ?? 0;
     this.transform.scale = vec(1, 1);
+    this.transform.z = options.z ?? 0;
 
     this.motion.vel = options.vel ?? this.motion.vel;
     this.motion.angularVelocity = options.angularVelocity ?? 0;
@@ -198,6 +199,10 @@ export interface ParticleConfig {
    * Starting rotation of the particle
    */
   rotation?: number;
+  /**
+   * Optionally set the z index of the particle, default is 0
+   */
+  z?: number;
   /**
    * Size of the particle in pixels
    */

--- a/src/spec/vitest/ParticleSpec.ts
+++ b/src/spec/vitest/ParticleSpec.ts
@@ -279,6 +279,7 @@ describe('A particle', () => {
         randomRotation: false
       },
       pos: new ex.Vector(0, 0),
+      z: 5,
       width: 20,
       height: 30,
       isEmitting: true,
@@ -294,5 +295,10 @@ describe('A particle', () => {
     expect(emitter.children.length).toBe(0);
     expect(engine.currentScene.actors.length).toBe(1);
     expect(engine.currentScene.world.entityManager.entities.length).toBe(21);
+    expect(
+      engine.currentScene.world.entityManager.entities
+        .filter((entity) => entity instanceof ex.Particle)
+        .every((entity) => entity.transform.z === 5)
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
=== :clipboard: PR Checklist :clipboard: ===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================


Closes #3503

Bug raised in Discord:
https://discord.com/channels/1195771303215513671/1408751467808034936

## Changes

 - The ParticleEmitter passes its z value down to particles when configured for Global space
