### PR TITLE
fix: Clean up memory leaks from Entities in Maps [#3510]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ const query = new Query({})
 - Fixed CollidePolygonPolygon crash with some defense against invalid separation
 - Fixed issue with PostProcessor where it would not run correctly if no actors present
 - Removed warning in development for unadded entities
+- Fixed memory leaks from retained entities in `Map<Entity>`
 
 ### Updates
 

--- a/src/engine/EntityComponentSystem/EntityManager.ts
+++ b/src/engine/EntityComponentSystem/EntityManager.ts
@@ -104,10 +104,12 @@ export class EntityManager {
       const childAddedHandler = this._childAddedHandlerMap.get(entity);
       if (childAddedHandler) {
         entity.childrenAdded$.unsubscribe(childAddedHandler);
+        this._childAddedHandlerMap.delete(entity);
       }
       const childRemovedHandler = this._childRemovedHandlerMap.get(entity);
       if (childRemovedHandler) {
         entity.childrenRemoved$.unsubscribe(childRemovedHandler);
+        this._childRemovedHandlerMap.delete(entity);
       }
 
       // stats

--- a/src/engine/EntityComponentSystem/QueryManager.ts
+++ b/src/engine/EntityComponentSystem/QueryManager.ts
@@ -142,9 +142,11 @@ export class QueryManager {
     }
     if (addComponent) {
       entity.componentAdded$.unsubscribe(addComponent);
+      this._addComponentHandlers.delete(entity);
     }
     if (removeComponent) {
       entity.componentRemoved$.unsubscribe(removeComponent);
+      this._removeComponentHandlers.delete(entity);
     }
 
     // Handle tags
@@ -156,9 +158,11 @@ export class QueryManager {
 
     if (addTag) {
       entity.tagAdded$.unsubscribe(addTag);
+      this._addTagHandlers.delete(entity);
     }
     if (removeTag) {
       entity.tagRemoved$.unsubscribe(removeTag);
+      this._removeTagHandlers.delete(entity);
     }
   }
 

--- a/src/engine/Input/PointerEventsToObjectDispatcher.ts
+++ b/src/engine/Input/PointerEventsToObjectDispatcher.ts
@@ -72,6 +72,7 @@ export class PointerEventsToObjectDispatcher<TObject extends { events: EventEmit
     const proxy = this._objectToProxy.get(object);
     if (proxy) {
       const index = this._proxies.indexOf(proxy);
+      this._objectToProxy.delete(object);
       if (index > -1) {
         this._proxies.splice(index, 1);
       }


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

=== :clipboard: PR Checklist :clipboard: ===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Excalibur makes use of `Map<Entity, TData>` for functionality (event dispatch) and performance, using the entity as a key to event subscriptions or other data. This stores the Entity by reference as a key, making both lookup and storage fairly efficient. Thanks to Excalibur's event system, it's easy for engine developers to maintain these lists in a safe manner (paired entity added and removed event handlers); here we are patching up a few that slipped through.

Fixes open memory leaks I was experiencing in my game (which churns Actors); it now maintains a stable ~80-100mb memory usage, vs climbing to ~2gb before my poor browser gives up. Previously, these maps would grow without bounds as Actors were created and removed.

I did a quick search for more, but wanted to focus on what I could verify.

Tests passed, but I wasn't able to find a place to add new tests to automate verification and left that unchecked for now - if you have a place to start I'd be happy to look!

Thanks for the great engine ⚔️ 

Closes #3510

## Changes:

- removes entities from internal `Map<Entity>` and `Map<object>` lists when on entity removal
