### PR TITLE
Site samples styles

### DIFF
--- a/site/docs/13-plugins/15-tiled-plugin.mdx
+++ b/site/docs/13-plugins/15-tiled-plugin.mdx
@@ -78,9 +78,9 @@ Currently the plugin supports rendering both the Orthogonal and Isometric orient
 
 ![Tiled orientations](./tiled/orientation.png)
 
-### Background Color 
+### Background Color
 
-The plugin supports pulling the `Background Color` from the Tiled map. Configure the `useMapBackgroundColor` in your constructor 
+The plugin supports pulling the `Background Color` from the Tiled map. Configure the `useMapBackgroundColor` in your constructor
 
 ```typescript
 const tiledMap = new TiledResource('./isometric.tmx', {
@@ -104,7 +104,7 @@ The way that the plugin represents multiple tile layers in Tiled is by creating 
 
 You can mark a layer solid by setting the special custom boolean property `solid = true` on the tile layer. This will indicate to the plugin that any space with a non-zero Tile gid should be treated as a solid rectangle.
 
-However sometimes you need more than just solid rectangles, so the plugin also supports custom colliders setup on tiles in tilesets (read more about tilesets below). 
+However sometimes you need more than just solid rectangles, so the plugin also supports custom colliders setup on tiles in tilesets (read more about tilesets below).
 
 :::note
 
@@ -150,7 +150,7 @@ Tiled allows Infinite Tile Maps, these allow you to build tile maps without widt
 
 The plugin supports every type of tilesets in Tiled, embedded, external, collection of images, etc.
 
-Given a Tiled gid (global tile id), you can retrieve the tileset 
+Given a Tiled gid (global tile id), you can retrieve the tileset
 
 ```typescript
 const tiledMap = new TiledResource(...);
@@ -183,7 +183,7 @@ const colliders = tileset.getCollidersForGid(123);
 
 ### Custom Colliders
 
-All shapes and sizes are supported for custom colliders apart from non-circle ellipses. In fact you can have multiple geometries specified per Tile! 
+All shapes and sizes are supported for custom colliders apart from non-circle ellipses. In fact you can have multiple geometries specified per Tile!
 
 Custom colliders can be used in Tile layers, Inserted Tile objects and Templates!
 
@@ -210,7 +210,7 @@ const objectLayers = tiledMap.getObjectLayers();
 
 ### Querying for Objects
 
-All objects in the plugin can be queried based on various aspects about them, either their name, class, or potentially a property name/value! You can retrieve the Tiled object and/or the Actor produced by the plugin! 
+All objects in the plugin can be queried based on various aspects about them, either their name, class, or potentially a property name/value! You can retrieve the Tiled object and/or the Actor produced by the plugin!
 
 ```typescript
 
@@ -382,7 +382,11 @@ const tiledMap = new TiledResource('./example-city.tmx', {
 })
 ```
 
-A note on bundlers, because of an unfortunate naming collision `.tsx` also is used for TypeScript React components. Because of this you may need to work around bundler notions of what the file is to treat it as raw xml instead of a React component. For example, In the vite sample to work around `.tsx`
+A note on bundlers, because of an unfortunate naming collision `.tsx` also is used for TypeScript React components. Because of this you may need to work around bundler notions of what the file is to treat it as raw xml instead of a React component.
+
+### Vite configuration
+
+For example, in the Vite sample, we work around the `.tsx` issue using this configuration:
 
 ```typescript
 // vite.config.js
@@ -409,3 +413,38 @@ export default defineConfig({
     }
 });
 ```
+
+
+### Webpack configuration
+
+In the Webpack sample, we work around the `.tsx` issue using this configuration:
+
+```typescript
+module: {
+    rules: [
+        {
+            test: /\.ts?$/,
+            use: 'ts-loader',
+            exclude: /node_modules/
+        },
+        {
+            test: /\.(png|jpg|bmp|wav|mp3|tmx|tsx)$/,
+            loader: 'file-loader',
+            options: {
+                name: '[path][name].[ext]',
+                context: path.resolve(__dirname)
+            }
+        }
+    ]
+}
+```
+
+:::warning
+
+By default Bundlers will often add a hash to imported, static assets. For example: `styles.c1c53abc.css`
+
+Under normal circumstances this is fantastic for breaking cach when assets change. However Tiled assumes its dependent files are located in the same relative directory, using the same name that was used locally.
+
+If you receive 404 errors when the tilesets or assets are retrieved, double check the filename has not been altered by your bundler.
+
+:::

--- a/site/src/pages/samples/_data.ts
+++ b/site/src/pages/samples/_data.ts
@@ -19,6 +19,7 @@ export default [
     description: 'A Tetris clone built with Excalibur. Demonstrates using a JavaScript library (React) as UI.',
     url: 'https://excaliburjs.com/sample-excalitris',
     source: 'https://github.com/excaliburjs/sample-excalitris',
+    backgroundColor: '#a5105c',
   },
   {
     title: 'Jelly Jumper',
@@ -26,6 +27,7 @@ export default [
     description: 'High fidelity sample of a platforming game with jump physics inspired by Super Mario World!',
     url: 'https://excaliburjs.com/sample-jelly-jumper',
     source: 'https://github.com/excaliburjs/sample-jelly-jumper',
+    backgroundColor: '#1e7050',
   },
   {
     title: 'Pathfinding',
@@ -54,6 +56,7 @@ export default [
     description: 'Example of building grid based movement.',
     url: 'https://codesandbox.io/s/github/excaliburjs/sample-grid',
     source: 'https://github.com/excaliburjs/sample-grid',
+    backgroundColor: '#643a32',
   },
   {
     title: 'Tiled w/ Parcel',
@@ -82,6 +85,7 @@ export default [
     description: 'This is a small platforming example.',
     url: 'https://codesandbox.io/s/github/excaliburjs/sample-platformer',
     source: 'https://github.com/excaliburjs/sample-platformer',
+    backgroundColor: '#5fcde4',
   },
   {
     title: 'Matter.js',
@@ -104,6 +108,7 @@ export default [
       'This is a sample clone of the popular mobile game flappy bird.',
     url: 'https://codesandbox.io/s/github/excaliburjs/excalibird',
     source: 'https://github.com/excaliburjs/excalibird',
+    backgroundColor: '#007fff',
   },
   {
     title: "Shoot 'Em Up",
@@ -111,6 +116,7 @@ export default [
     description: "This is an example of how to create a Shoot 'Em Up game",
     url: 'https://codesandbox.io/s/github/excaliburjs/sample-shootemup',
     source: 'https://github.com/excaliburjs/sample-shootemup',
+    backgroundColor: '#000000',
   },
   {
     title: 'Breakout',
@@ -118,5 +124,6 @@ export default [
     description: 'This is a sample brick breaking game.',
     url: 'https://codesandbox.io/s/github/excaliburjs/sample-breakout',
     source: 'https://github.com/excaliburjs/sample-breakout',
+    backgroundColor: '#020064',
   },
 ]

--- a/site/src/pages/samples/index.js
+++ b/site/src/pages/samples/index.js
@@ -7,9 +7,9 @@ import styles from './styles.module.css';
 
 const CardList = ({ items }) => (
   <div className={styles.cards}>
-    {items.map(({ image, title, description, url, source }) => (
+    {items.map(({ image, title, description, url, source, backgroundColor = 'var(--ifm-color-primary)' }) => (
       <div className={styles.card} key={title}>
-        <div className={styles.image}>
+        <div className={styles.image} style={{ backgroundColor }}>
           <img src={image} alt={title} title={title} />
         </div>
         <div className={styles.content}>

--- a/site/src/pages/samples/styles.module.css
+++ b/site/src/pages/samples/styles.module.css
@@ -27,9 +27,11 @@
 }
 
 .card>.image {
-  background: rgba(0, 0, 0, .05);
-  display: block;
+  align-items: center;
+  aspect-ratio: 290 / 265;
+  display: flex;
   flex: 0 0 auto;
+  justify-content: center;
   padding: 0;
   position: relative;
 }


### PR DESCRIPTION
=== :clipboard: PR Checklist :clipboard: ===

- [x] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

Closes #3519 

## Changes:

- Adds an aspect ratio to the sample images, based off the tallest image so far, so we get consistent heights
- Adds the option to overwrite the color on a sample by sample basis, but defaults to the Excalibur blue
- Adds some additional webpack configuration to reflect the recent changes [here](https://github.com/excaliburjs/sample-tiled-webpack/pull/5)


<img width="2614" height="1584" alt="image" src="https://github.com/user-attachments/assets/54e3c721-45c6-4a21-be9e-4b18a5b329e1" />

