### PR TITLE
docs: adds type checking to all samples

### DIFF
--- a/site/docs/02-fundamentals/03-actors.mdx
+++ b/site/docs/02-fundamentals/03-actors.mdx
@@ -36,7 +36,7 @@ and manipulate it directly.
 Actors (and other entities) must be added to a [Scene](/docs/scenes) to be drawn
 and updated on-screen.
 
-<GameCodeBlock live 
+<PlaygroundEmbed
   title="Basic actors"
   code={BasicActorExample} 
 />
@@ -462,9 +462,7 @@ By default Actors do not participate in collisions. If you wish to make
 an actor participate, you need to switch from the default [[CollisionType.PreventCollision|prevent collision]]
 to an [[CollisionType.Active|active]], [[CollisionType.Fixed|fixed]], or [[CollisionType.Passive|passive]] collision type.
 
-<GameCodeBlock live snippet="collision">
-{ActorCollisionExample}
-</GameCodeBlock>
+<PlaygroundEmbed code={ActorCollisionExample} />
 
 :::note
 

--- a/site/docs/02-fundamentals/05-transitions.mdx
+++ b/site/docs/02-fundamentals/05-transitions.mdx
@@ -70,7 +70,7 @@ game.add('scene1', {
 
 Click canvas to transition!
 
-<GameCodeBlock live 
+<PlaygroundEmbed 
   title="Transition"
   code={TransitionExample} 
 />
@@ -159,7 +159,7 @@ You can specific a duration in milliseconds and it will fade in the specified `d
 
 Click canvas to transition!
 
-<GameCodeBlock live 
+<PlaygroundEmbed 
   title="CrossFade Transition"
   code={CrossFadeTransitionExample} 
 />

--- a/site/docs/02-fundamentals/examples/basic-actors.ts
+++ b/site/docs/02-fundamentals/examples/basic-actors.ts
@@ -1,3 +1,10 @@
+import * as ex from 'excalibur';
+
+const game = new ex.Engine({
+  canvasElementId: 'preview-canvas',
+  displayMode: ex.DisplayMode.FillContainer,
+});
+
 const basicPlayer = new ex.Actor({
   name: 'player', // optionally assign a name
   width: 50,

--- a/site/docs/02-fundamentals/examples/collision.ts
+++ b/site/docs/02-fundamentals/examples/collision.ts
@@ -1,5 +1,13 @@
-ex.Physics.useRealisticPhysics();
-ex.Physics.acc = ex.vec(0, 300);
+import * as ex from 'excalibur';
+
+const game = new ex.Engine({
+  canvasElementId: 'preview-canvas',
+  displayMode: ex.DisplayMode.FillContainer,
+  physics: {
+    solver: ex.SolverStrategy.Realistic,
+    gravity: ex.vec(0, 300),
+  }
+});
 
 const box = new ex.Actor({
     pos: ex.vec(game.halfDrawWidth, -100),

--- a/site/docs/02-fundamentals/examples/scene-crossfade.ts
+++ b/site/docs/02-fundamentals/examples/scene-crossfade.ts
@@ -1,4 +1,9 @@
+import * as ex from 'excalibur';
 
+const game = new ex.Engine({
+  canvasElementId: 'preview-canvas',
+  displayMode: ex.DisplayMode.FillContainer,
+});
 
 class MyScene extends ex.Scene {
   public onInitialize(): void {

--- a/site/docs/02-fundamentals/examples/scene-transitions.ts
+++ b/site/docs/02-fundamentals/examples/scene-transitions.ts
@@ -1,4 +1,9 @@
+import * as ex from 'excalibur';
 
+const game = new ex.Engine({
+  canvasElementId: 'preview-canvas',
+  displayMode: ex.DisplayMode.FillContainer,
+});
 
 class MyScene extends ex.Scene {
   public onInitialize(): void {
@@ -42,7 +47,7 @@ game.add('scene2', {
 });
 
 game.input.pointers.primary.on('down', () => {
-  game.currentSceneName === 'scene2' ? game.goto('scene1') : game.goto('scene2');
+  game.currentSceneName === 'scene2' ? game.goToScene('scene1') : game.goToScene('scene2');
 });
 
 game.start('scene2');

--- a/site/docs/04-graphics/04.2-animation.mdx
+++ b/site/docs/04-graphics/04.2-animation.mdx
@@ -94,19 +94,11 @@ Animation frames can be created by hand in the following example by specifying t
 
 ![Character running sprite sheet](player-run.png)
 
-<GameCodeBlock 
-  live 
-  code={AnimationExample} 
-  assets={{'player-run.png': playerRun}} 
-/>
+<PlaygroundEmbed code={AnimationExample} />
 
 Additionally you can specify the (x, y) positions of sprites in the SpriteSheet of each frame, for example (0, 0) is the the top left sprite, (0, 1) is the sprite directly below that, and so on.
 
-<GameCodeBlock 
-  live 
-  code={AnimationExample2} 
-  assets={{'player-run.png': playerRun}} 
-/>
+<PlaygroundEmbed code={AnimationExample2} />
 
 ## Events
 

--- a/site/docs/04-graphics/04.2-material.mdx
+++ b/site/docs/04-graphics/04.2-material.mdx
@@ -152,7 +152,7 @@ game.input.pointers.primary.on('move', evt => {
 
 ```
 
-<GameCodeBlock live 
+<PlaygroundEmbed 
   title="Simple Material"
   code={SimpleMaterial}
 />
@@ -257,7 +257,7 @@ void main() {
 
 Here is the code in action!
 
-<GameCodeBlock live 
+<PlaygroundEmbed 
   title="Outline Material"
   code={OutlineMaterial}
 />
@@ -377,7 +377,7 @@ void main() {
 }
 ```
 
-<GameCodeBlock live 
+<PlaygroundEmbed 
   title="Reflection Material"
   code={ScreenMaterial}
 />

--- a/site/docs/04-graphics/examples/animation-coords.ts
+++ b/site/docs/04-graphics/examples/animation-coords.ts
@@ -1,9 +1,19 @@
-import playerRun from './player-run.png';
+import * as ex from 'excalibur';
 
-const runImage = new ex.ImageSource(playerRun);
+const game = new ex.Engine({
+  canvasElementId: 'preview-canvas',
+  displayMode: ex.DisplayMode.FillContainer,
+});
+
+const resources = {
+    spritesheet: new ex.ImageSource('./player-run.png'),
+} as const;
+
+const loader = new ex.DefaultLoader();
+loader.addResource(resources.spritesheet);
 
 const runSheet = ex.SpriteSheet.fromImageSource({
-    image: runImage,
+    image: resources.spritesheet,
     grid: {
         rows: 1,
         columns: 21,
@@ -29,7 +39,7 @@ const actor = new ex.Actor({
 });
 actor.graphics.use(runAnim);
 
-const loader = new ex.Loader([runImage]);
 game.start(loader).then(() => {
-    game.currentScene.add(actor);
+  game.currentScene.add(actor);
 });
+

--- a/site/docs/04-graphics/examples/animation.ts
+++ b/site/docs/04-graphics/examples/animation.ts
@@ -1,9 +1,19 @@
-import playerRun from './player-run.png';
+import * as ex from 'excalibur';
 
-const runImage = new ex.ImageSource(playerRun);
+const game = new ex.Engine({
+  canvasElementId: 'preview-canvas',
+  displayMode: ex.DisplayMode.FillContainer,
+});
+
+const resources = {
+    spritesheet: new ex.ImageSource('./player-run.png'),
+} as const;
+
+const loader = new ex.DefaultLoader();
+loader.addResource(resources.spritesheet);
 
 const runSheet = ex.SpriteSheet.fromImageSource({
-    image: runImage,
+    image: resources.spritesheet,
     grid: {
         rows: 1,
         columns: 21,
@@ -19,7 +29,6 @@ const actor = new ex.Actor({
 });
 actor.graphics.use(runAnim);
 
-const loader = new ex.Loader([runImage]);
 game.start(loader).then(() => {
     game.currentScene.add(actor);
 });

--- a/site/docs/04-graphics/examples/outline-material.ts
+++ b/site/docs/04-graphics/examples/outline-material.ts
@@ -1,5 +1,13 @@
+import * as ex from 'excalibur';
+
+const game = new ex.Engine({
+  canvasElementId: 'preview-canvas',
+  displayMode: ex.DisplayMode.FillContainer,
+});
+
 const sword = new ex.ImageSource('https://cdn.rawgit.com/excaliburjs/Excalibur/7dd48128/assets/sword.png', false, ex.ImageFiltering.Pixel);
-const loader = new ex.Loader([sword]);
+const loader = new ex.DefaultLoader();
+loader.addResource(sword);
 
 const outline = `#version 300 es
 precision mediump float;

--- a/site/docs/04-graphics/examples/screen-material.ts
+++ b/site/docs/04-graphics/examples/screen-material.ts
@@ -1,5 +1,8 @@
+import * as ex from 'excalibur';
+
 const sword = new ex.ImageSource('https://cdn.rawgit.com/excaliburjs/Excalibur/7dd48128/assets/sword.png', false, ex.ImageFiltering.Pixel);
-const loader = new ex.Loader([sword]);
+const loader = new ex.DefaultLoader();
+loader.addResource(sword);
 
 const waterFrag = `#version 300 es
 precision mediump float;
@@ -105,6 +108,11 @@ void main() {
   
   fragColor.rgb = mix(screen_color.rgb, mixColor, u_color.a)*fragColor.a + (wave_crest_color.rgb * wave_crest);
 }`;
+
+const game = new ex.Engine({
+  canvasElementId: 'preview-canvas',
+  displayMode: ex.DisplayMode.FillContainer,
+});
 
 const waterMaterial =  game.graphicsContext.createMaterial({
   name: 'water',

--- a/site/docs/04-graphics/examples/simple-material.ts
+++ b/site/docs/04-graphics/examples/simple-material.ts
@@ -1,3 +1,10 @@
+import * as ex from 'excalibur';
+
+const game = new ex.Engine({
+  canvasElementId: 'preview-canvas',
+  displayMode: ex.DisplayMode.FillContainer,
+});
+
 const actor = new ex.Actor({
   pos: ex.vec(200, 200),
   width: 100,

--- a/site/docs/10-physics/08-a-physics.mdx
+++ b/site/docs/10-physics/08-a-physics.mdx
@@ -45,12 +45,10 @@ const game = new Engine({
 
 ### Example
 
-<GameCodeBlock live 
+<PlaygroundEmbed 
   title="Physics"
   code={PhysicsExample} 
 />
-
-<IFrameEmbed src="https://excaliburjs.com/excalibur-snippets/collision/" />
 
 ## Other Physics Settings
 

--- a/site/docs/10-physics/examples/physics.ts
+++ b/site/docs/10-physics/examples/physics.ts
@@ -1,3 +1,10 @@
+import * as ex from 'excalibur';
+
+const game = new ex.Engine({
+  canvasElementId: 'preview-canvas',
+  displayMode: ex.DisplayMode.FillContainer,
+});
+
 const box = new ex.Actor({
     pos: ex.vec(game.halfDrawWidth, -100),
     width: 50,

--- a/site/docs/12-other/13-particles.mdx
+++ b/site/docs/12-other/13-particles.mdx
@@ -4,6 +4,9 @@ slug: /particles
 section: Other
 ---
 
+import sample1 from '!!raw-loader!./examples/13-particles-1.ts';
+import sample2 from '!!raw-loader!./examples/13-particles-2.ts';
+
 Particles can be used to generate dust, smoke, or fire effects in your games.
 
 ## Particles
@@ -42,7 +45,7 @@ const emitter = new ex.ParticleEmitter({
 });
 ```
 
-<IFrameEmbed variant="playground" src="https://excaliburjs.com/excalibur-playground/?embed=true&code=FASwtgDg9gTgLgAgFQIIYGcEFMAeCBmMUYCA5LgMaoA2IARgK4ykDcwwFUAduogOaowWBAF4EXLAHdsOAHQBRLnxASAFAG9gCbQipcAbhnnUsQrnACSAEwBcZCDCz6QUgLR7D6UgBotOqyDoENSoAJ4AslBWWHa4sgAigcFhkdGyAGIg1NQAwtxwqCpYML46CJIgVnAAFnYAbAAMDaU61VggfNVwdgAsTS3adKgUANZ8RAxcVnnUsLFyM7CyAEIho74AvgCUbBzcvNhgIHBwxaLiUjKyAAqo8CAUJvJHJ8Uafjh2AkKy1TT48RgqEkAHVKjUWqEvoIsL9-oDgQAJdqdOAtUzHU4wAAqoQgMSuz0xxVx+NkORAMEeWBaQICDHQdgAjM0-IEiScVHw7HAYAwaX4MXAAEqoU52ADM-T8EDucAeJjsmjKRy4AGV8VhbAgAEzSlWoHAarBayX6nSqgCCSkVCHCYuqNwsAHomQAOBrIBCsg04a18W32mpO10er0ATh9Olo+AJLPN2lVapAAC8494ypms9ntH5E4bk2nmc0c6Ws3mELw5YW4yWy2WK1gpjXmRn6+2K8MKPNZPosBRVCWWVsBgg6FhlFxFjAe9PZMKtaOm9MoLMZ1c56t+S0NsBtrtvrDUFYrKohVidsBD7Iq-BVDsgA" />
+<PlaygroundEmbed code={sample1} />
 
 ### Rectangle emitter
 
@@ -76,7 +79,7 @@ const emitter = new ex.ParticleEmitter({
 });
 ```
 
-<IFrameEmbed variant="playground" src="https://excaliburjs.com/excalibur-playground/?embed=true&code=FASwtgDg9gTgLgAgFQIIYGcEFMAeCBmMUYCA5LgMaoA2IARgK4ykDcwwFUAduogOaowWBAF4EXLAHdsOAHQBRLnxASAFAG9gCbQipcAbhnnUsQrnACSAEwBcZCDCz6QUgLR7D6UgBotOqyDoENSoAJ4AslBWWHa4sgAigcFhkdGyAGIg1NQAwtxwqCpYML46CJIgVnAAFnYAbAAMDaU61VggfNVwdgAsTS3adKgUANZ8RAxcVnnUsLFyM7CyAEIho74AvgCUbBzcvNhgIHBwxaLiUjKyAAqo8CAUJvJHJ8Uafjh2AkKy1TT48RgqEkAHVKjUWqEvoIsL9-oDgQAJdqdOAtUzHU4wAAqoQgMSuz0xxVx+NkACUsBQCkoTN4EH4KlVaggAKzNMqcrnc7l+NodLp2ACMzT8gSJJxUfDscBgDCw9J5SrKfgxcHJqFOdgAzP1lfqVdoIHc4A8THZNGUjlwAIK0gnhTXVG4WAD0QoAHA1kAgeqzFTy-NowKgcHa+OaEI6ai73V6fQBODlKoMIKDGijHKEIIUBg361P4VDRGVyhX5-Op2j4AkivUVgtWlQAZRAAC9a3mG7yraHWx3hcnuz2dLwTf3a0PhzpU1gphPhV3pzOysMKHYJNI4gA1KlwWCqDmuOtbJcrnR0LDKLiLGDzWS3ilYKwDbBTW-3x8ATSw2SgkhaDZgG2XZvlhYsrFUNUsR2YAwNkMd4FUHYgA" />
+<PlaygroundEmbed code={sample2} />
 
 ## Adding an emitter
 
@@ -94,4 +97,3 @@ actor.add(emitter);
 ```typescript
 engine.add(emitter);
 ```
-

--- a/site/docs/12-other/examples/13-particles-1.ts
+++ b/site/docs/12-other/examples/13-particles-1.ts
@@ -1,0 +1,35 @@
+import * as ex from 'excalibur';
+
+const game = new ex.Engine({
+    canvasElementId: 'preview-canvas',
+    displayMode: ex.DisplayMode.FillContainer,
+    width: 600,
+    height: 400,
+    backgroundColor: ex.Color.Black,
+});
+
+const emitter = new ex.ParticleEmitter({
+  x: game.halfDrawWidth,
+  y: game.halfDrawHeight,
+  emitterType: ex.EmitterType.Circle,
+  radius: 10,
+  isEmitting: true,
+  emitRate: 300,
+  particle: {
+    minSpeed: 200,
+    maxSpeed: 300,
+    minAngle: Math.PI/180 * 0,
+    maxAngle: Math.PI/180 * 90,
+    life: 1000,
+    minSize: 1,                        
+    maxSize: 10,                       
+    startSize: 10,                     
+    endSize: 1,                        
+    acc: ex.vec(0, 10),
+    beginColor: ex.Color.Red,
+    endColor: ex.Color.Blue,
+  }
+});
+
+game.add(emitter);
+game.start();

--- a/site/docs/12-other/examples/13-particles-2.ts
+++ b/site/docs/12-other/examples/13-particles-2.ts
@@ -1,0 +1,36 @@
+import * as ex from 'excalibur';
+
+const game = new ex.Engine({
+    canvasElementId: 'preview-canvas',
+    displayMode: ex.DisplayMode.FillContainer,
+    width: 600,
+    height: 400,
+    backgroundColor: ex.Color.Black,
+});
+
+const emitter = new ex.ParticleEmitter({
+  x: game.halfDrawWidth,
+  y: game.halfDrawHeight,
+  emitterType: ex.EmitterType.Rectangle, 
+  width: 50,                             
+  height: 10,
+  isEmitting: true,                      
+  emitRate: 300,                         
+  particle: {
+    minAngle: Math.PI/180 * 45,          
+    maxAngle: Math.PI/180 * 90,          
+    opacity: 1,                          
+    fade: true,                          
+    life: 1000,                          
+    minSize: 1,                          
+    maxSize: 10,                         
+    startSize: 10,                       
+    endSize: 1,                          
+    acc: new ex.Vector(0, -100),         
+    beginColor: ex.Color.Red,
+    endColor: ex.Color.Yellow,
+  }
+});
+
+game.add(emitter);
+game.start();

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -18,8 +18,10 @@
         "clsx": "^2.1.1",
         "docusaurus-plugin-typedoc-api": "4.4.0",
         "docusaurus-preset-shiki-twoslash": "^1.1.41",
+        "lz-string": "^1.5.0",
         "mermaid": "11.12.1",
         "prism-react-renderer": "^2.4.0",
+        "raw-loader": "^4.0.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-live": "4.1.8",
@@ -38,7 +40,7 @@
         "micromark-extension-mdxjs": "^3.0.0",
         "patch-package": "^8.0.0",
         "ts-loader": "9.5.4",
-        "typescript": "~5.2.2",
+        "typescript": "5.6.3",
         "url-loader": "4.1.1"
       },
       "engines": {
@@ -4189,6 +4191,20 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.15.0.tgz",
+      "integrity": "sha512-L5IHdZIDa4bG4yJaOzfasOH/o22MCesY0mx+n6VATbaiCtMeR59pdRqYk4bEiQkIHfxsHPNgdi7VJlZb2FhdMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.15.0",
+        "@shikijs/langs": "^3.15.0",
+        "@shikijs/themes": "^3.15.0",
+        "@shikijs/types": "^3.15.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -4506,6 +4522,55 @@
       "version": "1.0.0-next.23",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
       "integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg=="
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.15.0.tgz",
+      "integrity": "sha512-HnqFsV11skAHvOArMZdLBZZApRSYS4LSztk2K3016Y9VCyZISnlYUYsL2hzlS7tPqKHvNqmI5JSUJZprXloMvA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/types": "3.15.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.15.0.tgz",
+      "integrity": "sha512-WpRvEFvkVvO65uKYW4Rzxs+IG0gToyM8SARQMtGGsH4GDMNZrr60qdggXrFOsdfOVssG/QQGEl3FnJ3EZ+8w8A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/types": "3.15.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.15.0.tgz",
+      "integrity": "sha512-8ow2zWb1IDvCKjYb0KiLNrK4offFdkfNVPXb1OZykpLCzRU6j+efkY+Y7VQjNlNFXonSw+4AOdGYtmqykDbRiQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/types": "3.15.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.15.0.tgz",
+      "integrity": "sha512-BnP+y/EQnhihgHy4oIAN+6FFtmfTekwOLsQbRw9hOKwqgNy8Bdsjq8B05oAt/ZgvIWWFrshV71ytOrlPfYjIJw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
@@ -4923,9 +4988,10 @@
       "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg=="
     },
     "node_modules/@types/hast": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.2.tgz",
-      "integrity": "sha512-B5hZHgHsXvfCoO3xgNJvBnX7N8p86TqQeGKXcokW4XXi+qY4vxxPSFYofytvVmpFxzPv7oxDQzjg5Un5m2/xiw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
       }
@@ -5601,9 +5667,10 @@
       }
     },
     "node_modules/ansi-sequence-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.3.tgz",
+      "integrity": "sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw==",
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -7752,6 +7819,15 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/docusaurus-plugin-typedoc-api/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/docusaurus-plugin-typedoc-api/node_modules/marked": {
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
@@ -7761,6 +7837,54 @@
       },
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/docusaurus-plugin-typedoc-api/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/docusaurus-plugin-typedoc-api/node_modules/typedoc": {
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
+      "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
+      }
+    },
+    "node_modules/docusaurus-plugin-typedoc-api/node_modules/typedoc/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/docusaurus-preset-shiki-twoslash": {
@@ -10296,6 +10420,16 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -10448,12 +10582,14 @@
     "node_modules/lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "license": "MIT"
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10469,6 +10605,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
@@ -10482,6 +10636,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -11024,6 +11179,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -14592,6 +14754,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pupa": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
@@ -14709,6 +14881,44 @@
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-loader": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
+      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/raw-loader/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/rc": {
@@ -16046,6 +16256,7 @@
       "version": "0.14.7",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
       "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+      "license": "MIT",
       "dependencies": {
         "ansi-sequence-parser": "^1.1.0",
         "jsonc-parser": "^3.2.0",
@@ -16875,37 +17086,45 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.7.tgz",
-      "integrity": "sha512-m6A6JjQRg39p2ZVRIN3NKXgrN8vzlHhOS+r9ymUYtcUP/TIQPvWSq7YgE5ZjASfv5Vd5BW5xrir6Gm2XNNcOow==",
+      "version": "0.28.14",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.14.tgz",
+      "integrity": "sha512-ftJYPvpVfQvFzpkoSfHLkJybdA/geDJ8BGQt/ZnkkhnBYoYW6lBgPQXu6vqLxO4X75dA55hX8Af847H5KXlEFA==",
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
+        "@gerrit0/mini-shiki": "^3.12.0",
         "lunr": "^2.3.9",
-        "marked": "^4.3.0",
-        "minimatch": "^9.0.3",
-        "shiki": "^0.14.7"
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.8.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 18",
+        "pnpm": ">= 10"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -16916,10 +17135,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/typedoc/node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16927,6 +17160,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ufo": {
       "version": "1.6.1",
@@ -17528,7 +17768,8 @@
     "node_modules/vscode-textmate": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.0.8",
@@ -21002,6 +21243,19 @@
         "tslib": "^2.6.0"
       }
     },
+    "@gerrit0/mini-shiki": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.15.0.tgz",
+      "integrity": "sha512-L5IHdZIDa4bG4yJaOzfasOH/o22MCesY0mx+n6VATbaiCtMeR59pdRqYk4bEiQkIHfxsHPNgdi7VJlZb2FhdMQ==",
+      "peer": true,
+      "requires": {
+        "@shikijs/engine-oniguruma": "^3.15.0",
+        "@shikijs/langs": "^3.15.0",
+        "@shikijs/themes": "^3.15.0",
+        "@shikijs/types": "^3.15.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -21255,6 +21509,50 @@
       "version": "1.0.0-next.23",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
       "integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg=="
+    },
+    "@shikijs/engine-oniguruma": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.15.0.tgz",
+      "integrity": "sha512-HnqFsV11skAHvOArMZdLBZZApRSYS4LSztk2K3016Y9VCyZISnlYUYsL2hzlS7tPqKHvNqmI5JSUJZprXloMvA==",
+      "peer": true,
+      "requires": {
+        "@shikijs/types": "3.15.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "@shikijs/langs": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.15.0.tgz",
+      "integrity": "sha512-WpRvEFvkVvO65uKYW4Rzxs+IG0gToyM8SARQMtGGsH4GDMNZrr60qdggXrFOsdfOVssG/QQGEl3FnJ3EZ+8w8A==",
+      "peer": true,
+      "requires": {
+        "@shikijs/types": "3.15.0"
+      }
+    },
+    "@shikijs/themes": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.15.0.tgz",
+      "integrity": "sha512-8ow2zWb1IDvCKjYb0KiLNrK4offFdkfNVPXb1OZykpLCzRU6j+efkY+Y7VQjNlNFXonSw+4AOdGYtmqykDbRiQ==",
+      "peer": true,
+      "requires": {
+        "@shikijs/types": "3.15.0"
+      }
+    },
+    "@shikijs/types": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.15.0.tgz",
+      "integrity": "sha512-BnP+y/EQnhihgHy4oIAN+6FFtmfTekwOLsQbRw9hOKwqgNy8Bdsjq8B05oAt/ZgvIWWFrshV71ytOrlPfYjIJw==",
+      "peer": true,
+      "requires": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "peer": true
     },
     "@sideway/address": {
       "version": "4.1.4",
@@ -21642,9 +21940,9 @@
       "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg=="
     },
     "@types/hast": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.2.tgz",
-      "integrity": "sha512-B5hZHgHsXvfCoO3xgNJvBnX7N8p86TqQeGKXcokW4XXi+qY4vxxPSFYofytvVmpFxzPv7oxDQzjg5Un5m2/xiw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
       "requires": {
         "@types/unist": "*"
       }
@@ -22268,9 +22566,9 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-sequence-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.3.tgz",
+      "integrity": "sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -23760,10 +24058,44 @@
             "webpack-merge": "^5.9.0"
           }
         },
+        "brace-expansion": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "marked": {
           "version": "9.1.6",
           "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
           "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q=="
+        },
+        "minimatch": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "typedoc": {
+          "version": "0.25.13",
+          "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
+          "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
+          "requires": {
+            "lunr": "^2.3.9",
+            "marked": "^4.3.0",
+            "minimatch": "^9.0.3",
+            "shiki": "^0.14.7"
+          },
+          "dependencies": {
+            "marked": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+              "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
+            }
+          }
         }
       }
     },
@@ -25594,6 +25926,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "peer": true,
+      "requires": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -25726,6 +26067,20 @@
       "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
       "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="
     },
+    "markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "peer": true,
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      }
+    },
     "markdown-table": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
@@ -25734,7 +26089,8 @@
     "marked": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "peer": true
     },
     "marked-smartypants": {
       "version": "1.1.5",
@@ -26186,6 +26542,12 @@
           }
         }
       }
+    },
+    "mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "peer": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -28347,6 +28709,12 @@
         }
       }
     },
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "peer": true
+    },
     "pupa": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
@@ -28414,6 +28782,27 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
           "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+        }
+      }
+    },
+    "raw-loader": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
+      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
         }
       }
     },
@@ -30072,38 +30461,54 @@
       }
     },
     "typedoc": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.7.tgz",
-      "integrity": "sha512-m6A6JjQRg39p2ZVRIN3NKXgrN8vzlHhOS+r9ymUYtcUP/TIQPvWSq7YgE5ZjASfv5Vd5BW5xrir6Gm2XNNcOow==",
+      "version": "0.28.14",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.14.tgz",
+      "integrity": "sha512-ftJYPvpVfQvFzpkoSfHLkJybdA/geDJ8BGQt/ZnkkhnBYoYW6lBgPQXu6vqLxO4X75dA55hX8Af847H5KXlEFA==",
+      "peer": true,
       "requires": {
+        "@gerrit0/mini-shiki": "^3.12.0",
         "lunr": "^2.3.9",
-        "marked": "^4.3.0",
-        "minimatch": "^9.0.3",
-        "shiki": "^0.14.7"
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.8.1"
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+          "peer": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
         },
         "minimatch": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+          "peer": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
+        },
+        "yaml": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+          "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+          "peer": true
         }
       }
     },
     "typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="
+    },
+    "uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "peer": true
     },
     "ufo": {
       "version": "1.6.1",

--- a/site/package.json
+++ b/site/package.json
@@ -13,6 +13,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
+    "typecheck:samples": "tsc --project ./tsconfig.samples.json",
     "postinstall": "patch-package"
   },
   "dependencies": {
@@ -25,8 +26,10 @@
     "clsx": "^2.1.1",
     "docusaurus-plugin-typedoc-api": "4.4.0",
     "docusaurus-preset-shiki-twoslash": "^1.1.41",
+    "lz-string": "^1.5.0",
     "mermaid": "11.12.1",
     "prism-react-renderer": "^2.4.0",
+    "raw-loader": "^4.0.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-live": "4.1.8",
@@ -40,13 +43,13 @@
     "@docusaurus/module-type-aliases": "3.4.0",
     "@docusaurus/tsconfig": "^3.4.0",
     "@types/react": "^18.3.3",
+    "babel-loader": "10.0.0",
     "css-loader": "6.11.0",
     "micromark-extension-mdxjs": "^3.0.0",
     "patch-package": "^8.0.0",
     "ts-loader": "9.5.4",
-    "typescript": "~5.2.2",
-    "url-loader": "4.1.1",
-		"babel-loader": "10.0.0"
+    "typescript": "5.6.3",
+    "url-loader": "4.1.1"
   },
   "browserslist": {
     "production": [

--- a/site/src/components/docs/IFrameEmbed.tsx
+++ b/site/src/components/docs/IFrameEmbed.tsx
@@ -1,30 +1,20 @@
 import React, { IframeHTMLAttributes } from 'react'
 
-const DEFAULT_FRAME_STYLES = {
-  regular: {
-    width: '100%',
-    height: '420px',
-    border: 0,
-    overflow: 'hidden',
-  },
-  playground: {
-    width: '100%',
-    maxWidth: '640px',
-    borderRadius: '12px',
-    outline: '1px solid var(--ifm-color-emphasis-300)',
-    outlineOffset: '4px',
-    margin: '60px auto',
-    display: 'block',
-    height: '900px',
-    border: 0,
-    overflow: 'hidden',
-  },
+const style = {
+  width: '100%',
+  maxWidth: '640px',
+  borderRadius: '12px',
+  outline: '1px solid var(--ifm-color-emphasis-300)',
+  outlineOffset: '4px',
+  margin: '60px auto',
+  display: 'block',
+  height: '900px',
+  border: 0,
+  overflow: 'hidden',
 } as const
 
-type Props = IframeHTMLAttributes<HTMLIFrameElement> & {
-  variant: 'regular' | 'playground'
-}
+type Props = IframeHTMLAttributes<HTMLIFrameElement>
 
-export default ({ src, variant, ...props }: Props) => (
-  <iframe src={src} style={DEFAULT_FRAME_STYLES[variant]} {...props}></iframe>
+export default ({ src, ...props }: Props) => (
+  <iframe src={src} style={style} {...props}></iframe>
 )

--- a/site/src/components/docs/PlaygroundEmbed.tsx
+++ b/site/src/components/docs/PlaygroundEmbed.tsx
@@ -1,0 +1,37 @@
+import * as lz from "lz-string";
+
+type Props =  {
+  autoplay?: boolean;
+  code: string;
+  title?: string;
+}
+
+const style = {
+  width: '100%',
+  maxWidth: '640px',
+  borderRadius: '12px',
+  outline: '1px solid var(--ifm-color-emphasis-300)',
+  outlineOffset: '4px',
+  margin: '60px auto',
+  display: 'block',
+  height: '900px',
+  border: 0,
+  overflow: 'hidden',
+}
+
+const PLAYGROUND_URL = 'https://excaliburjs.com/excalibur-playground';
+
+export default ({ autoplay = true, code, title }: Props) => {
+  const params = new URLSearchParams({
+    embed: 'true',
+    code: lz.compressToEncodedURIComponent(code)
+  });
+  
+  if (autoplay) {
+    params.set('autoplay', 'true');
+  }
+  
+  const src = `${PLAYGROUND_URL}/?${params.toString()}`;
+
+  return <iframe src={src} style={style} title={title} />
+}

--- a/site/src/components/docs/index.tsx
+++ b/site/src/components/docs/index.tsx
@@ -2,3 +2,4 @@ export { default as Example } from "./Example";
 export { default as CodeSandboxEmbed } from './CodeSandboxEmbed';
 export { default as IFrameEmbed } from "./IFrameEmbed";
 export { default as GameCodeBlock } from './GameCodeBlock';
+export { default as PlaygroundEmbed } from './PlaygroundEmbed';

--- a/site/tsconfig.samples.json
+++ b/site/tsconfig.samples.json
@@ -1,0 +1,15 @@
+{
+  "extends": ["../src/engine/tsconfig.json"],
+  "include": [
+    "./docs/**/*.ts", 
+    "../src/engine/env.d.ts", 
+    "../src/engine/globals.d.ts", 
+    "../src/engine/files.d.ts"
+  ],
+  "compilerOptions": {
+    "paths": {
+      "@site/*": ["./*"],
+      "excalibur": ["../src/engine"]
+    }
+  }
+}


### PR DESCRIPTION
## Changes:

- upgrade docs typescript to match engine typescript version - resolves `NoInfer` failing in docs
- fix physics sample to use `solver` instead of now removed `ex.Physics.useRealisticPhysics`
- fix scene transition sample to use `goToScene` instead of now removed `goto`
- removed embedded particle samples, replacing them with local samples that can be type checked
- embed all samples as playgrounds that autoplay
- types can be checked from within the docs site directory with `npm run typecheck:samples`
  - can be validated locally by changing any sample and seeing the above command fail

<table>
<tr>
<td>
<img width="1972" height="2290" alt="image" src="https://github.com/user-attachments/assets/6f60c854-0d6a-4d66-9a14-0b7661004c97" />
</td>
<td>
<img width="1862" height="2418" alt="CleanShot 2025-11-26 at 00 20 23@2x" src="https://github.com/user-attachments/assets/076df3ad-094f-4371-a500-ce9e0cfc10ef" />
</td>
</tr>
<tr>
<td>Physics sample</td>
<td>Animation sample</td>
</tr>
</table>

## Missing:

Its late, and I'm probably blind, but I couldn't trace the deployment step in the `.github` workflows?

I need to add `npm run typecheck:samples` prior to the docs build. 




