### PR TITLE
fix: Screen orientation recalcs viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issue where sometimes the when device orientation changed the screen would not recalculate viewport.
 - Fixed issue where the Loader could run twice even if already loaded when included in the scene loader.
 - Fixed issue where pixel ratio was accidentally doubled during load if the loader was included in the scene loader.
 - Fixed issue where Slide trasition did not work properly when DisplayMode was FitScreenAndFill

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -203,9 +203,9 @@ export interface ScreenOptions {
  */
 export interface ScreenResizeEvent {
   /**
-   * Native browser event
+   * Native browser event (if any)
    */
-  event: Event;
+  event?: Event;
   /**
    * Current viewport in css pixels of the screen
    */
@@ -382,7 +382,7 @@ export class Screen {
     } satisfies PixelRatioChangeEvent);
   };
 
-  private _resizeHandler = (evt: Event) => {
+  private _resizeHandler = (event?: Event) => {
     if (this._isDisposed) {
       return;
     }
@@ -393,7 +393,7 @@ export class Screen {
 
     // Emit resize event
     this.events.emit('resize', {
-      event: evt,
+      event,
       resolution: this.resolution,
       viewport: this.viewport
     } satisfies ScreenResizeEvent);

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -299,8 +299,17 @@ export class Screen {
 
     this._listenForPixelRatio();
 
+    this._listenForOrientationChange();
+
     this._canvas.addEventListener('fullscreenchange', this._fullscreenChangeHandler);
     this.applyResolutionAndViewport();
+  }
+
+  private _listenForOrientationChange() {
+    if (window?.screen?.orientation) {
+      window.screen.orientation.addEventListener('change', this._resizeHandler);
+      // window.screen.orientation.addEventListener('change', evt => console.log('orientation change:', evt));
+    }
   }
 
   private _listenForPixelRatio() {
@@ -325,6 +334,11 @@ export class Screen {
       this.events.clear();
       this._browser.window.off('resize', this._resizeHandler);
       this._browser.window.clear();
+
+      if (window?.screen?.orientation) {
+        window.screen.orientation.removeEventListener('change', this._resizeHandler);
+      }
+
       if (this._resizeObserver) {
         this._resizeObserver.disconnect();
       }

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -727,10 +727,11 @@ export class Screen {
         newY = ((newY - screenMarginY) / screenHeight) * viewport.height;
         newX = (newX / window.innerWidth) * viewport.width;
       } else {
-        const screenWidth = window.innerHeight * this.aspectRatio;
-        const screenMarginX = (window.innerWidth - screenWidth) / 2;
+        const screen = window.screen;
+        const screenWidth = screen.height * this.aspectRatio;
+        const screenMarginX = (screen.width - screenWidth) / 2;
         newX = ((newX - screenMarginX) / screenWidth) * viewport.width;
-        newY = (newY / window.innerHeight) * viewport.height;
+        newY = (newY / screen.height) * viewport.height;
       }
     }
 
@@ -770,10 +771,11 @@ export class Screen {
         newY = (newY / viewport.height) * screenHeight + screenMarginY;
         newX = (newX / viewport.width) * window.innerWidth;
       } else {
-        const screenWidth = window.innerHeight * this.aspectRatio;
-        const screenMarginX = (window.innerWidth - screenWidth) / 2;
+        const screen = window.screen;
+        const screenWidth = screen.height * this.aspectRatio;
+        const screenMarginX = (screen.width - screenWidth) / 2;
         newX = (newX / viewport.width) * screenWidth + screenMarginX;
-        newY = (newY / viewport.height) * window.innerHeight;
+        newY = (newY / viewport.height) * screen.height;
       }
     }
 
@@ -961,12 +963,13 @@ export class Screen {
     const aspect = this.aspectRatio;
     let adjustedWidth = 0;
     let adjustedHeight = 0;
-    if (window.innerWidth / aspect < window.innerHeight) {
-      adjustedWidth = window.innerWidth;
-      adjustedHeight = window.innerWidth / aspect;
+    const screen = window.screen;
+    if (screen.width / aspect < screen.height) {
+      adjustedWidth = screen.width;
+      adjustedHeight = screen.width / aspect;
     } else {
-      adjustedWidth = window.innerHeight * aspect;
-      adjustedHeight = window.innerHeight;
+      adjustedWidth = screen.height * aspect;
+      adjustedHeight = screen.height;
     }
 
     this.viewport = {
@@ -984,8 +987,9 @@ export class Screen {
   private _computeFitScreenAndFill() {
     document.body.style.margin = '0px';
     document.body.style.overflow = 'hidden';
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
+    const screen = window.screen;
+    const vw = screen.width;
+    const vh = screen.height;
     this._computeFitAndFill(vw, vh);
     this.events.emit('resize', {
       resolution: this.resolution,
@@ -1060,8 +1064,9 @@ export class Screen {
     document.body.style.overflow = 'hidden';
     this.canvas.style.position = 'absolute';
 
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
+    const screen = window.screen;
+    const vw = screen.width;
+    const vh = screen.height;
 
     this._computeFitAndZoom(vw, vh);
     this.events.emit('resize', {

--- a/src/engine/Screen.ts
+++ b/src/engine/Screen.ts
@@ -203,6 +203,10 @@ export interface ScreenOptions {
  */
 export interface ScreenResizeEvent {
   /**
+   * Native browser event
+   */
+  event: Event;
+  /**
    * Current viewport in css pixels of the screen
    */
   viewport: ViewportDimension;
@@ -308,7 +312,6 @@ export class Screen {
   private _listenForOrientationChange() {
     if (window?.screen?.orientation) {
       window.screen.orientation.addEventListener('change', this._resizeHandler);
-      // window.screen.orientation.addEventListener('change', evt => console.log('orientation change:', evt));
     }
   }
 
@@ -379,7 +382,7 @@ export class Screen {
     } satisfies PixelRatioChangeEvent);
   };
 
-  private _resizeHandler = () => {
+  private _resizeHandler = (evt: Event) => {
     if (this._isDisposed) {
       return;
     }
@@ -390,6 +393,7 @@ export class Screen {
 
     // Emit resize event
     this.events.emit('resize', {
+      event: evt,
       resolution: this.resolution,
       viewport: this.viewport
     } satisfies ScreenResizeEvent);


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================


Closes #

## Changes:

- Adds a hook in the `Screen.ts` to also listen to the browser ScreenOrientation API and treat that as a "resize" event.
