### PR TITLE
feat: Add convenience `graphic` and `material` to Actor ctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added a convenience parameter to set the initial graphics or material in an Actor
+  ```typescript
+  const cloudSprite = cloud.toSprite();
+  const swirlMaterial = game.graphicsContext.createMaterial({
+    name: 'swirl',
+    fragmentSource
+  });
+  const actor = new ex.Actor({
+      graphic: cloudSprite,
+      material: swirlMaterial
+  });
+  ```
 - Simpler easing functions of the form `(currentTime: number) => number` instead of the 4 parameter legacy ones
 - Support for disabling integration for all offscreen entities, or on a per entity basis
 

--- a/src/engine/Actor.ts
+++ b/src/engine/Actor.ts
@@ -43,6 +43,7 @@ import { CoordPlane } from './Math/coord-plane';
 import type { EventKey, Handler, Subscription } from './EventEmitter';
 import { EventEmitter } from './EventEmitter';
 import type { Component } from './EntityComponentSystem';
+import type { Graphic, Material } from './Graphics';
 
 /**
  * Type guard for checking if something is an Actor
@@ -105,6 +106,14 @@ export type ActorArgs = ColliderArgs & {
    * If a width/height or a radius was set a default graphic will be added
    */
   color?: Color;
+  /**
+   * Optionally set the default graphic
+   */
+  graphic?: Graphic;
+  /**
+   * Optionally set the default material
+   */
+  material?: Material;
   /**
    * Optionally set the color of an actor, only used if no graphics are present
    * If a width/height or a radius was set a default graphic will be added
@@ -581,7 +590,9 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
       anchor,
       offset,
       collisionType,
-      collisionGroup
+      collisionGroup,
+      graphic,
+      material
     } = {
       ...config
     };
@@ -663,6 +674,12 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
     }
 
     this.graphics.isVisible = visible ?? true;
+    if (graphic) {
+      this.graphics.use(graphic);
+    }
+    if (material) {
+      this.graphics.material = material;
+    }
   }
 
   public clone(): Actor {


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

- Added a convenience parameter to set the initial graphics or material in an Actor
  ```typescript
  const cloudSprite = cloud.toSprite();
  const swirlMaterial = game.graphicsContext.createMaterial({
    name: 'swirl',
    fragmentSource
  });
  const actor = new ex.Actor({
      graphic: cloudSprite,
      material: swirlMaterial
  });
  ```
