### PR TITLE
fix(tests): compatibility with VS Code Vitest extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
     "src/spec/*.map": true
   },
   "typescript.tsdk": "./node_modules/typescript/lib",
+  "vitest.cliArguments": "--project=unit --browser.headless",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,7 +28,7 @@ export default defineConfig(
         reporter: [['html'], ['lcov', { projectRoot: __dirname }], ['text-summary']],
         reportsDirectory: path.join(__dirname, 'coverage')
       },
-      projects: ['./src/spec/vitest.config.unit.ts', './src/spec/vitest.config.visual.ts']
+      projects: [path.resolve(__dirname, './src/spec/vitest.config.unit.ts'), path.resolve(__dirname, './src/spec/vitest.config.visual.ts')]
     }
   } satisfies ViteUserConfig)
 );


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

## Changes:

- Fixes an issue with errors being thrown by Vitest VS Code extension for multiple projects and file paths
- Runs `headless` mode for `unit` test project within VS Code Test Explorer

<img width="440" height="340" alt="image" src="https://github.com/user-attachments/assets/d92bf15d-18c1-4427-9523-0628fc745dbf" />


## Errors

```
error: Found multiple projects that run browser tests in headed mode: "unit (chromium)", "visual (chromium)". 
Vitest cannot run multiple headed browsers at the same time. 
Please, filter projects with --browser=name or --project=name flag or run tests with "headless: true" option.
```