### PR TITLE
[feat] Add methods to retrieve parsed sprite and image

### DIFF
--- a/site/docs/04-graphics/04.1-spritesheets.mdx
+++ b/site/docs/04-graphics/04.1-spritesheets.mdx
@@ -60,16 +60,19 @@ const ss = ex.SpriteSheet.fromImageSourceWithSourceViews({
 
 ## Parsing Out Discrete Images
 
-If you pass a large sheet image into a SpriteSheet then use a Sprite via `getSprite()`, Excalibur draws a window into that larger sheet.  But what if you want a completely isolated Sprite parsed out of the host image?  What if you wanted to use that Sprite in an HTML image for UI?  We got convenience methods to help with that.  They work exactly like `getSprite()` but they return NEW and unique Sprites and ImageElements.
+If you pass a large sheet image into a SpriteSheet then use a Sprite via `getSprite()`, Excalibur draws a window into that larger sheet.
+But what if you want a completely isolated Sprite parsed out of the host image?
+What if you wanted to use that Sprite in an HTML image for UI? 
+We got convenience methods to help with that.  They work exactly like `getSprite()` but they return NEW and unique Sprites and ImageElements.
 
 ```ts
-const myNewSprite = getParsedSprite(x,y); // new Sprite
+const myNewSprite = ss.getSpriteAsStandalone(x,y); // new Sprite
 ```
 
-or 
+or
 
 ```ts
-const myNewImage = getParsedImage(x,y); //New HTMLImageElement
+const myNewImage = getSpriteAsImage(x,y); // new HTMLImageElement
 ```
 
 

--- a/src/engine/Graphics/SpriteSheet.ts
+++ b/src/engine/Graphics/SpriteSheet.ts
@@ -178,7 +178,13 @@ export class SpriteSheet {
     throw Error(`Invalid sprite coordinates (${x}, ${y})`);
   }
 
-  public async getParsedSprite(x: number, y: number): Promise<Sprite> {
+  /**
+   * Returns a sprite that has a new backing image the exact size of the sprite that tha is a copy of the original sprite slice.
+   *
+   * Useful if you need to apply effects, manipulate, or mutate the image and you don't want to disturb the original sprite sheet.
+   *
+   */
+  public async getSpriteAsStandalone(x: number, y: number): Promise<Sprite> {
     if (x >= this.columns || x < 0) {
       throw Error(`No sprite exists in the SpriteSheet at (${x}, ${y}), x: ${x} should be between 0 and ${this.columns - 1} columns`);
     }
@@ -229,7 +235,12 @@ export class SpriteSheet {
     });
   }
 
-  public async getParsedImage(x: number, y: number): Promise<HTMLImageElement> {
+  /**
+   * Returns a new image exact size and copy of the original sprite slice.
+   *
+   * Useful if you need to apply effects, manipulate, or mutate the image and you don't want to disturb the original sprite sheet.
+   */
+  public async getSpriteAsImage(x: number, y: number): Promise<HTMLImageElement> {
     if (x >= this.columns || x < 0) {
       throw Error(`No sprite exists in the SpriteSheet at (${x}, ${y}), x: ${x} should be between 0 and ${this.columns - 1} columns`);
     }
@@ -265,7 +276,7 @@ export class SpriteSheet {
     const imgSrc = new Image(sprite.width, sprite.height);
     imgSrc.src = cnv.toDataURL();
 
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       imgSrc.onload = () => {
         resolve(imgSrc);
       };

--- a/src/spec/vitest/SpriteSheetSpec.ts
+++ b/src/spec/vitest/SpriteSheetSpec.ts
@@ -248,7 +248,7 @@ describe('A SpriteSheet for Graphics', () => {
       }
     });
 
-    const newImage = await ss.getParsedImage(0, 0);
+    const newImage = await ss.getSpriteAsImage(0, 0);
     expect(newImage.width).toBe(42);
     expect(newImage.height).toBe(60);
     expect(newImage).toBeInstanceOf(Image);
@@ -272,7 +272,7 @@ describe('A SpriteSheet for Graphics', () => {
       }
     });
 
-    const newSprite = await ss.getParsedSprite(0, 0);
+    const newSprite = await ss.getSpriteAsStandalone(0, 0);
     expect(newSprite.width).toBe(42);
     expect(newSprite.height).toBe(60);
     expect(newSprite).toBeInstanceOf(ex.Sprite);


### PR DESCRIPTION
Introduce two new methods for obtaining parsed sprites and images from the sprite sheet, enhancing the functionality for rendering and image manipulation.

