### PR TITLE
feat: [#3596] Add Timer events support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 
+- Added new Timer events! 
+  ```typescript
+  const timer = new ex.Timer({...});
+  timer.events.on('complete', () => {...}); // after the last repeat
+  timer.events.on('action', () => {...}); // every fire of the timer
+  timer.events.on('start', () => {...}); // after the timer is started
+  timer.events.on('stop', () => {...}); // after the timer is stopped 
+  timer.events.on('pause', () => {...}); // after every pause
+  timer.events.on('resume', () => {...}); // after every resume
+  timer.events.on('cancel', () => {...}); // after cancel
+
+  // or specify the onComplete in the constructor
+  const timer2 = new ex.Timer({
+      onComplete: () => {...},
+      ...
+  });
+  ```
 - Added a way to configure general debug settings on text
   ```typescript
   class DebugConfig { 

--- a/src/engine/Timer.ts
+++ b/src/engine/Timer.ts
@@ -92,6 +92,8 @@ export class Timer {
     return this._baseInterval + this.random.integer(this.randomRange[0], this.randomRange[1]);
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  private _onComplete: () => void = () => {};
   private _complete = false;
   public get complete() {
     return this._complete;
@@ -106,6 +108,7 @@ export class Timer {
     const numberOfRepeats = options.numberOfRepeats;
     const randomRange = options.randomRange;
     const random = options.random;
+    this._onComplete = options.onComplete ?? this._onComplete;
 
     if (!!numberOfRepeats && numberOfRepeats >= 0) {
       this.maxNumberOfRepeats = numberOfRepeats;
@@ -165,6 +168,7 @@ export class Timer {
         this._complete = true;
         this._running = false;
         this._elapsedTime = 0;
+        this._onComplete();
         this.events.emit('complete');
       }
 
@@ -180,6 +184,7 @@ export class Timer {
           this._complete = true;
           this._running = false;
           this._elapsedTime = 0;
+          this._onComplete();
           this.events.emit('complete');
         }
       }

--- a/src/spec/vitest/TimerSpec.ts
+++ b/src/spec/vitest/TimerSpec.ts
@@ -595,4 +595,185 @@ describe('A Timer', () => {
     expect(timer.interval).toBe(905);
     timer.update(905);
   });
+
+  describe('events', () => {
+    it("fires 'action' event for every timer tick", () => {
+      const actionSpy = vi.fn();
+      const actionEventSpy = vi.fn();
+
+      const sut = new ex.Timer({
+        interval: 42,
+        repeats: true,
+        numberOfRepeats: 2,
+        action: actionSpy
+      });
+      sut.events.on('action', actionEventSpy);
+
+      scene.add(sut);
+
+      expect(actionSpy).not.toHaveBeenCalled();
+      expect(actionEventSpy).not.toHaveBeenCalled();
+      sut.start();
+      expect(actionSpy).not.toHaveBeenCalled();
+      expect(actionEventSpy).not.toHaveBeenCalledOnce();
+
+      scene.update(engine, 43);
+      scene.update(engine, 43);
+      scene.update(engine, 43);
+      scene.update(engine, 43);
+
+      expect(actionSpy).toHaveBeenCalledTimes(2);
+      expect(actionEventSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("fires 'complete' event when the timer has fired its last action", () => {
+      const completeSpy = vi.fn();
+      const completeEventSpy = vi.fn();
+
+      const sut = new ex.Timer({
+        interval: 42,
+        repeats: true,
+        numberOfRepeats: 2,
+        onComplete: completeSpy
+      });
+      sut.events.on('complete', completeEventSpy);
+
+      scene.add(sut);
+
+      expect(completeSpy).not.toHaveBeenCalled();
+      expect(completeEventSpy).not.toHaveBeenCalled();
+      sut.start();
+      expect(completeSpy).not.toHaveBeenCalled();
+      expect(completeEventSpy).not.toHaveBeenCalledOnce();
+
+      scene.update(engine, 43);
+      scene.update(engine, 43);
+      scene.update(engine, 43);
+      scene.update(engine, 43);
+
+      expect(completeSpy).toHaveBeenCalledTimes(1);
+      expect(completeEventSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires 'start' event when started", () => {
+      const startSpy = vi.fn();
+
+      const sut = new ex.Timer({
+        interval: 42
+      });
+      sut.events.on('start', startSpy);
+
+      scene.add(sut);
+
+      expect(startSpy).not.toHaveBeenCalled();
+      sut.start();
+      expect(startSpy).toHaveBeenCalledOnce();
+    });
+
+    it("fires 'pause' event when paused", () => {
+      const pauseSpy = vi.fn();
+
+      const sut = new ex.Timer({
+        interval: 42
+      });
+      sut.events.on('pause', pauseSpy);
+
+      scene.add(sut);
+
+      expect(pauseSpy).not.toHaveBeenCalled();
+      sut.start();
+      expect(pauseSpy).not.toHaveBeenCalled();
+
+      scene.update(engine, 40);
+
+      sut.pause();
+      expect(pauseSpy).toHaveBeenCalledOnce();
+    });
+
+    it("fires 'resume' event when resumed", () => {
+      const resumeSpy = vi.fn();
+
+      const sut = new ex.Timer({
+        interval: 42
+      });
+      sut.events.on('resume', resumeSpy);
+
+      scene.add(sut);
+
+      expect(resumeSpy).not.toHaveBeenCalled();
+      sut.start();
+      expect(resumeSpy).not.toHaveBeenCalled();
+
+      scene.update(engine, 40);
+
+      sut.pause();
+      expect(resumeSpy).not.toHaveBeenCalledOnce();
+
+      scene.update(engine, 40);
+      sut.resume();
+
+      expect(resumeSpy).toHaveBeenCalledOnce();
+    });
+
+    it("fires 'stop' event when stopped", () => {
+      const stopSpy = vi.fn();
+
+      const sut = new ex.Timer({
+        interval: 42
+      });
+      sut.events.on('stop', stopSpy);
+
+      scene.add(sut);
+
+      expect(stopSpy).not.toHaveBeenCalled();
+      sut.start();
+      expect(stopSpy).not.toHaveBeenCalled();
+
+      scene.update(engine, 40);
+
+      sut.pause();
+      expect(stopSpy).not.toHaveBeenCalledOnce();
+
+      scene.update(engine, 40);
+      sut.resume();
+
+      expect(stopSpy).not.toHaveBeenCalledOnce();
+
+      scene.update(engine, 40);
+      sut.stop();
+
+      expect(stopSpy).toHaveBeenCalledOnce();
+    });
+
+    it("fires 'cancel' event when cancelled", () => {
+      const cancelSpy = vi.fn();
+
+      const sut = new ex.Timer({
+        interval: 42
+      });
+      sut.events.on('cancel', cancelSpy);
+
+      scene.add(sut);
+
+      expect(cancelSpy).not.toHaveBeenCalled();
+      sut.start();
+      expect(cancelSpy).not.toHaveBeenCalled();
+
+      scene.update(engine, 40);
+
+      sut.pause();
+      expect(cancelSpy).not.toHaveBeenCalledOnce();
+
+      scene.update(engine, 40);
+      sut.resume();
+
+      expect(cancelSpy).not.toHaveBeenCalledOnce();
+
+      scene.update(engine, 40);
+      sut.stop();
+      sut.cancel();
+
+      expect(cancelSpy).toHaveBeenCalledOnce();
+    });
+  });
 });


### PR DESCRIPTION

<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

closes: #3596

## Changes:

- Added new Timer events! 
  ```typescript
  const timer = new ex.Timer({...});
  timer.events.on('complete', () => {...}); // after the last repeat
  timer.events.on('action', () => {...}); // every fire of the timer
  timer.events.on('start', () => {...}); // after the timer is started
  timer.events.on('stop', () => {...}); // after the timer is stopped 
  timer.events.on('pause', () => {...}); // after every pause
  timer.events.on('resume', () => {...}); // after every resume
  timer.events.on('cancel', () => {...}); // after cancel

  // or specify the onComplete in the constructor
  const timer2 = new ex.Timer({
      onComplete: () => {...},
      ...
  });
  ```

