### PR TITLE
docs: add share tooltip indicator for visual feedback

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -47,7 +47,10 @@
             </label>
             <button id="build" title="Build & Run (CTRL+S)">Build & Run</button>
             <button id="debug" title="Debug (CTRL+D)">Toggle Debug</button>
-            <button id="share">Share</button>
+            <button id="share">
+              Share
+              <span class="tooltip">Link copied to clipboard!</span>
+            </button>
           </div>
           <div class="templates">
             <h2>Templates</h2>

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -178,6 +178,9 @@ const shareCode = async (writeToClipboard?: boolean) => {
   const url = `${window.location}?${encoded}`;
   if (writeToClipboard) {
     await navigator.clipboard.writeText(url);
+    shareButtonEl.classList.remove("copied");
+    void shareButtonEl.offsetWidth; // trigger reflow
+    shareButtonEl.classList.add("copied");
   }
   window.history.pushState({}, '', '?' + encoded);
 };

--- a/playground/src/styles.css
+++ b/playground/src/styles.css
@@ -48,6 +48,7 @@ label {
   padding: 10px;
   border: solid var(--button-color) 2px;
   border-radius: 5px;
+  position: relative;
 }
 
 button:hover {
@@ -209,5 +210,48 @@ body.embedded #preview {
 
   #preview {
     min-width: auto;
+  }
+}
+
+.tooltip {
+  background-color: black;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 12px;
+  left: 50%;
+  padding: 4px 8px;
+  position: absolute;
+  text-align: center;
+  top: 0;
+  opacity: 0;
+  transform: translate(-50%, -10px) scaleX(20%);
+  white-space: pre;
+  width: min-content;
+  z-index: 1;
+}
+
+#share.copied .tooltip {
+  animation: bumpUpAndWait 3500ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+@keyframes bumpUpAndWait {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -10px) scaleX(20%);
+  }
+  
+  10% {
+    opacity: 1;
+    transform: translate(-50%, -30px) scaleX(100%);
+  }
+  
+  90% {
+    opacity: 1;
+    transform: translate(-50%, -30px) scaleX(100%);
+  }
+  
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -10px) scaleX(20%);
   }
 }

--- a/playground/src/templates/audio.ts
+++ b/playground/src/templates/audio.ts
@@ -3,7 +3,7 @@ import * as ex from 'excalibur';
 console.log('hello, world');
 
 const resources = {
-    sound: new ex.Sound('./rpg-audio/audio/handleCoins.ogg'),
+    sound: new ex.Sound('./playground/rpg-audio/audio/handleCoins.ogg'),
 } as const;
 
 const loader = new ex.Loader(Object.values(resources));

--- a/playground/src/templates/spritesheet.ts
+++ b/playground/src/templates/spritesheet.ts
@@ -3,7 +3,7 @@ import * as ex from 'excalibur';
 console.log('hello, world');
   
 const resources = {
-    spritesheet: new ex.ImageSource('./player-run.png'),
+    spritesheet: new ex.ImageSource('./playground/player-run.png'),
 } as const;
 
 const loader = new ex.DefaultLoader();

--- a/playground/src/templates/tileset.ts
+++ b/playground/src/templates/tileset.ts
@@ -3,7 +3,7 @@ import * as ex from 'excalibur';
 console.log('hello, world');
 
 const resources = {
-    tilemap: new ex.ImageSource('./tiny-town/tilemap/tilemap.png'),
+    tilemap: new ex.ImageSource('./playground/tiny-town/tilemap/tilemap.png'),
 } as const;
 
 const loader = new ex.DefaultLoader();


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

Discussed in Discord. This adds a tooltip indicator when the user clicks the share button.
See video (in the video it looks like on hover, but its actually on click):

https://github.com/user-attachments/assets/736d988c-6084-4f9d-b055-58ab6b72c87c

Also fixed up pathing for the playground templates, again. Its like I've never heard of relative links before..