### PR TITLE
docs: updated code examples for flappy bird tutorial

### DIFF
--- a/site/docs/00-tutorial/04-step-flying-bird.mdx
+++ b/site/docs/00-tutorial/04-step-flying-bird.mdx
@@ -49,3 +49,14 @@ export class Bird extends ex.Actor {
 
 }
 ```
+
+:::info
+**Heads up!**  
+After adding the flap/jump logic, you may notice a strange behavior:  
+if the Bird hits the ground and "dies," pressing the jump key **one more time** will cause the Bird to shoot upward infinitely.
+
+This happens because we haven't added any *game-over* or *collision-lockout* logic yet—so the Bird is still allowed to receive input even after crashing.
+
+Don't worry! This is expected at this stage of the tutorial.  
+We'll fix this behavior later once we introduce proper game-over handling.
+:::

--- a/site/docs/00-tutorial/08-step-periodic-pipes.mdx
+++ b/site/docs/00-tutorial/08-step-periodic-pipes.mdx
@@ -39,6 +39,7 @@ import * as ex from 'excalibur';
 import { Bird } from './bird';
 import { Ground } from './ground';
 import { Pipe } from './pipe';
+import { Config } from './config';
 
 export class PipeFactory {
 

--- a/site/docs/00-tutorial/09-step-scoring-points.mdx
+++ b/site/docs/00-tutorial/09-step-scoring-points.mdx
@@ -73,6 +73,10 @@ When our `Bird` flies between two pipes we want to increment the score. To do th
 
 ```typescript
 // score-trigger.ts
+import * as ex from 'excalibur';
+import { Config } from './config';
+import { Level } from './level';
+
 export class ScoreTrigger extends ex.Actor {
     constructor(pos: ex.Vector, private level: Level) {
         super({


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Relates to https://github.com/excaliburjs/Excalibur/issues/3627

## Changes:

Updated flappy bird tutorial with a note regarding expected behavior of bug when the bird dies.

Updated flappy bird tutorial code snippets to include a few missing imports.

Documentation Updates:

Step 4 of flappy bird tutorial (https://excaliburjs.com/docs/step-4-flying-bird)

Before
<img width="1382" height="748" alt="Screenshot 2025-12-19 at 12 24 33 PM" src="https://github.com/user-attachments/assets/2c2ad3d1-7382-4c84-812a-87c6a03f437a" />

After
<img width="1342" height="659" alt="Screenshot 2025-12-19 at 12 23 30 PM" src="https://github.com/user-attachments/assets/d56682f8-e912-4a3f-bb60-6203ff9eba66" />


Step 8 of flappy bird tutorial (https://excaliburjs.com/docs/step-8-periodic-pipes)

Before
<img width="1413" height="786" alt="Screenshot 2025-12-19 at 12 26 15 PM" src="https://github.com/user-attachments/assets/b7551333-f5e0-4c30-9bf5-f2b08cd89257" />


After
<img width="1054" height="390" alt="Screenshot 2025-12-19 at 12 23 55 PM" src="https://github.com/user-attachments/assets/adb006dc-59aa-447f-85a1-222de52df07e" />


Step 9 of flappy bird tutorial (https://excaliburjs.com/docs/step-9-scoring-points)

Before
<img width="1109" height="725" alt="Screenshot 2025-12-19 at 12 27 33 PM" src="https://github.com/user-attachments/assets/33ff6c43-af87-4883-b062-c44258a35b65" />


After
<img width="1070" height="297" alt="Screenshot 2025-12-19 at 12 24 02 PM" src="https://github.com/user-attachments/assets/9f2d1cdb-1401-428e-b1db-7817820a77e0" />

