### PR TITLE
fix(site): patch /api page crash from read-only Function.length

### DIFF
--- a/site/patches/@docusaurus+core+3.5.2.patch
+++ b/site/patches/@docusaurus+core+3.5.2.patch
@@ -1,3 +1,22 @@
+diff --git a/node_modules/@docusaurus/core/lib/client/exports/ComponentCreator.js b/node_modules/@docusaurus/core/lib/client/exports/ComponentCreator.js
+index e3b63d0..d485ff0 100644
+--- a/node_modules/@docusaurus/core/lib/client/exports/ComponentCreator.js
++++ b/node_modules/@docusaurus/core/lib/client/exports/ComponentCreator.js
+@@ -82,8 +82,12 @@ export default function ComponentCreator(path, hash) {
+                     Object.keys(loadedModule)
+                         .filter((k) => k !== 'default')
+                         .forEach((nonDefaultKey) => {
+-                        chunk[nonDefaultKey] =
+-                            loadedModule[nonDefaultKey];
++                        try {
++                            chunk[nonDefaultKey] =
++                                loadedModule[nonDefaultKey];
++                        } catch (e) {
++                            // Skip non-writable properties (e.g. Function.length)
++                        }
+                     });
+                 }
+                 // We now have this chunk prepared. Go down the key path and replace the
 diff --git a/node_modules/@docusaurus/core/lib/commands/build.js b/node_modules/@docusaurus/core/lib/commands/build.js
 index 2865e66..7c69768 100644
 --- a/node_modules/@docusaurus/core/lib/commands/build.js

--- a/site/patches/docusaurus-plugin-typedoc-api+4.4.0.patch
+++ b/site/patches/docusaurus-plugin-typedoc-api+4.4.0.patch
@@ -1,0 +1,11 @@
+diff --git a/node_modules/docusaurus-plugin-typedoc-api/lib/components/ApiPage.js b/node_modules/docusaurus-plugin-typedoc-api/lib/components/ApiPage.js
+index 2204247..58e80d5 100644
+--- a/node_modules/docusaurus-plugin-typedoc-api/lib/components/ApiPage.js
++++ b/node_modules/docusaurus-plugin-typedoc-api/lib/components/ApiPage.js
+@@ -73,5 +73,6 @@ function ApiPage(_ref) {
+     })
+   });
+ }
++Object.defineProperty(ApiPage, 'length', { writable: true, value: ApiPage.length });
+ module.exports = ApiPage;
+ //# sourceMappingURL=ApiPage.js.map


### PR DESCRIPTION
## Summary

Hi there, I just discovered this project and I really like it! Thank you very much for making it!
[I went on the docs and... it wasn't working](https://excaliburjs.com/api/).

<img width="1363" height="659" alt="image" src="https://github.com/user-attachments/assets/510ae25a-9639-4521-bb68-699dc782a328" />

## Fix

- Fix `/api` page crash: "Cannot assign to read only property 'length' of function 'function ApiPage'"
- Root cause: Docusaurus `ComponentCreator` copies webpack CJS interop properties onto function components, hitting read-only `Function.length`
- Two patch-package fixes:
  - `@docusaurus/core`: wrap property assignment in try-catch in `ComponentCreator.js`
  - `docusaurus-plugin-typedoc-api`: make `ApiPage.length` writable before CJS export

Before | After
--- | ---
<img width="1359" height="667" alt="bug-api-page-crashed" src="https://github.com/user-attachments/assets/2e7f855c-4754-4064-81b5-994c53954721" /> | <img width="1366" height="663" alt="fix-api-page-crashed" src="https://github.com/user-attachments/assets/177cea4d-84d3-4452-af62-3183d31da6d4" />



## Test plan
- [x] Run `npm install` in `site/` (patches apply via postinstall)
- [x] Run `npm start` in `site/`
- [x] Navigate to [http://localhost:3000/api](http://localhost:3000/api). Page should load without crashing