### PR TITLE
Added isTouchOrPenEvent to limit what can trigger pointerenter and po…

### DIFF
--- a/src/engine/input/pointer-events-to-object-dispatcher.ts
+++ b/src/engine/input/pointer-events-to-object-dispatcher.ts
@@ -3,6 +3,7 @@ import type { PointerEvent } from './pointer-event';
 import type { GlobalCoordinates } from '../math';
 import type { PointerEventReceiver } from './pointer-event-receiver';
 import { RentalPool } from '../util/rental-pool';
+import { PointerType } from './pointer-type';
 
 /**
  * Signals that an object has nested pointer events on nested objects that are not an Entity with
@@ -257,8 +258,16 @@ export class PointerEventsToObjectDispatcher<TObject extends { events: EventEmit
   ) {
     // up, down, and move are considered for enter and leave
     for (const event of lastUpDownMoveEvents) {
+      let isActive = event.active && object.active();
+      let isTouchOrPenEvent = event.pointerType === PointerType.Pen || event.pointerType === PointerType.Touch;
       // enter
-      if (event.active && object.active() && this._entered(object, event.pointerId)) {
+      if (
+        isActive &&
+        // enter can happen on move
+        (this._entered(object, event.pointerId) ||
+          // or enter can happen on pointer down
+          (isTouchOrPenEvent && event.type === 'down' && this._objectCurrentlyUnderPointer(object, event.pointerId)))
+      ) {
         object.events.emit('pointerenter', event as any);
         if (receiver.isDragging(event.pointerId)) {
           object.events.emit('pointerdragenter', event as any);
@@ -266,12 +275,11 @@ export class PointerEventsToObjectDispatcher<TObject extends { events: EventEmit
         break;
       }
       if (
-        event.active &&
-        object.active() &&
+        isActive &&
         // leave can happen on move
         (this._left(object, event.pointerId) ||
           // or leave can happen on pointer up
-          (this._objectCurrentlyUnderPointer(object, event.pointerId) && event.type === 'up'))
+          (isTouchOrPenEvent && event.type === 'up' && this._objectCurrentlyUnderPointer(object, event.pointerId)))
       ) {
         object.events.emit('pointerleave', event as any);
         if (receiver.isDragging(event.pointerId)) {

--- a/src/engine/input/pointer-events-to-object-dispatcher.ts
+++ b/src/engine/input/pointer-events-to-object-dispatcher.ts
@@ -258,8 +258,8 @@ export class PointerEventsToObjectDispatcher<TObject extends { events: EventEmit
   ) {
     // up, down, and move are considered for enter and leave
     for (const event of lastUpDownMoveEvents) {
-      let isActive = event.active && object.active();
-      let isTouchOrPenEvent = event.pointerType === PointerType.Pen || event.pointerType === PointerType.Touch;
+      const isActive = event.active && object.active();
+      const isTouchOrPenEvent = event.pointerType === PointerType.Pen || event.pointerType === PointerType.Touch;
       // enter
       if (
         isActive &&

--- a/src/spec/vitest/pointer-events-to-object-dispatcher-spec.ts
+++ b/src/spec/vitest/pointer-events-to-object-dispatcher-spec.ts
@@ -1,0 +1,384 @@
+import * as ex from '@excalibur';
+import { PointerEventsToObjectDispatcher } from '../../engine/input/pointer-events-to-object-dispatcher';
+
+/**
+ * Builds a minimal stand-in for PointerEventReceiver.
+ * Only the fields actually read by PointerEventsToObjectDispatcher are populated.
+ */
+function makeReceiver(
+  overrides: {
+    currentFrameDown?: ex.PointerEvent[];
+    currentFrameUp?: ex.PointerEvent[];
+    currentFrameMove?: ex.PointerEvent[];
+    currentFrameCancel?: ex.PointerEvent[];
+    currentFrameWheel?: any[];
+    isDragging?: (id: number) => boolean;
+    isDragStart?: (id: number) => boolean;
+    isDragEnd?: (id: number) => boolean;
+  } = {}
+) {
+  return {
+    currentFrameDown: [],
+    currentFrameUp: [],
+    currentFrameMove: [],
+    currentFrameCancel: [],
+    currentFrameWheel: [],
+    currentFramePointerCoords: new Map<number, ex.GlobalCoordinates>(),
+    isDragging: () => false,
+    isDragStart: () => false,
+    isDragEnd: () => false,
+    ...overrides
+  } as unknown as ex.PointerEventReceiver;
+}
+
+/** Builds a PointerEvent with controllable type and pointerType. */
+function makePointerEvent(type: 'down' | 'up' | 'move' | 'cancel', pointerType: ex.PointerType, pointerId = 0): ex.PointerEvent {
+  const coords = new ex.GlobalCoordinates(ex.vec(0, 0), ex.vec(0, 0), ex.vec(0, 0));
+  return new ex.PointerEvent(type, pointerId, ex.PointerButton.Unknown, pointerType, coords, new Event('pointerevent'));
+}
+
+/** Builds a simple object that satisfies the TObject constraint. */
+function makeTrackedObject() {
+  return { events: new ex.EventEmitter() };
+}
+
+describe('PointerEventsToObjectDispatcher', () => {
+  describe('_processEnterLeaveAndEmit (enter conditions)', () => {
+    it('fires pointerenter on the first frame any pointer appears over an object (mouse move, _entered path)', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      // Object is under the pointer in the current frame, but has no last-frame entry → _entered is true
+      dispatcher.addPointerToObject(obj, 0);
+
+      const moveEvent = makePointerEvent('move', ex.PointerType.Mouse);
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameMove: [moveEvent] }), [obj]);
+
+      expect(emitSpy).toHaveBeenCalledWith('pointerenter', moveEvent);
+    });
+
+    it('fires pointerenter on touch down even when object was tracked in the previous frame (_entered is false)', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      // Put object in last frame
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+      // Object is still under the pointer this frame (touch down at same location)
+      dispatcher.addPointerToObject(obj, 0);
+
+      const downEvent = makePointerEvent('down', ex.PointerType.Touch);
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameDown: [downEvent] }), [obj]);
+
+      // _entered is false (object was in last frame), but isTouchOrPenEvent + down fires enter
+      expect(emitSpy).toHaveBeenCalledWith('pointerenter', downEvent);
+    });
+
+    it('fires pointerenter on pen down even when object was tracked in the previous frame (_entered is false)', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+      dispatcher.addPointerToObject(obj, 0);
+
+      const downEvent = makePointerEvent('down', ex.PointerType.Pen);
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameDown: [downEvent] }), [obj]);
+
+      expect(emitSpy).toHaveBeenCalledWith('pointerenter', downEvent);
+    });
+
+    it('does NOT fire pointerenter on mouse down when _entered is false (object was already tracked last frame)', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      // Put object in last frame so _entered is false
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+      dispatcher.addPointerToObject(obj, 0);
+
+      const downEvent = makePointerEvent('down', ex.PointerType.Mouse);
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameDown: [downEvent] }), [obj]);
+
+      // Mouse down alone should not fire pointerenter; only move/_entered path applies for mouse
+      expect(emitSpy).not.toHaveBeenCalledWith('pointerenter', expect.anything());
+    });
+
+    it('does NOT fire pointerenter when the event is cancelled (active = false)', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      dispatcher.addPointerToObject(obj, 0);
+
+      const downEvent = makePointerEvent('down', ex.PointerType.Touch);
+      downEvent.cancel(); // event.active = false
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameDown: [downEvent] }), [obj]);
+
+      expect(emitSpy).not.toHaveBeenCalledWith('pointerenter', expect.anything());
+    });
+
+    it('does NOT fire pointerenter when the object is inactive', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => false
+      ); // active = false
+      dispatcher.addPointerToObject(obj, 0);
+
+      const downEvent = makePointerEvent('down', ex.PointerType.Touch);
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameDown: [downEvent] }), [obj]);
+
+      expect(emitSpy).not.toHaveBeenCalledWith('pointerenter', expect.anything());
+    });
+
+    it('does NOT fire pointerenter on touch down when the object is not under the pointer', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      // Object NOT added to current frame → not under pointer
+      // Put in last frame only so we get into the dispatch block
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+
+      const downEvent = makePointerEvent('down', ex.PointerType.Touch);
+      // currentFrameDown has an event for pointer 0, but object is not under that pointer
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameDown: [downEvent] }), [obj]);
+
+      expect(emitSpy).not.toHaveBeenCalledWith('pointerenter', expect.anything());
+    });
+  });
+
+  describe('_processEnterLeaveAndEmit (leave conditions)', () => {
+    it('fires pointerleave when a pointer moves off an object (_left path)', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      // Object under pointer last frame…
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+      // …but NOT under pointer this frame (pointer moved away)
+
+      const moveEvent = makePointerEvent('move', ex.PointerType.Mouse);
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameMove: [moveEvent] }), [obj]);
+
+      expect(emitSpy).toHaveBeenCalledWith('pointerleave', moveEvent);
+    });
+
+    it('fires pointerleave on touch up while object is still under the pointer (_left is false)', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      // Object was under pointer last frame…
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+      // …and is still under pointer this frame (finger lifted at same location)
+      dispatcher.addPointerToObject(obj, 0);
+
+      const upEvent = makePointerEvent('up', ex.PointerType.Touch);
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameUp: [upEvent] }), [obj]);
+
+      // _left is false (object IS in current frame), but isTouchOrPenEvent + up fires leave
+      expect(emitSpy).toHaveBeenCalledWith('pointerleave', upEvent);
+    });
+
+    it('fires pointerleave on pen up while object is still under the pointer (_left is false)', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+      dispatcher.addPointerToObject(obj, 0);
+
+      const upEvent = makePointerEvent('up', ex.PointerType.Pen);
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameUp: [upEvent] }), [obj]);
+
+      expect(emitSpy).toHaveBeenCalledWith('pointerleave', upEvent);
+    });
+
+    it('does NOT fire pointerleave on mouse up when _left is false (object still under pointer)', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      // Object in both last and current frames → _left is false
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+      dispatcher.addPointerToObject(obj, 0);
+
+      const upEvent = makePointerEvent('up', ex.PointerType.Mouse);
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameUp: [upEvent] }), [obj]);
+
+      // Mouse up alone should not fire pointerleave when pointer is still over the object
+      expect(emitSpy).not.toHaveBeenCalledWith('pointerleave', expect.anything());
+    });
+
+    it('does NOT fire pointerleave when the event is cancelled (active = false)', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+      dispatcher.addPointerToObject(obj, 0);
+
+      const upEvent = makePointerEvent('up', ex.PointerType.Touch);
+      upEvent.cancel(); // event.active = false
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameUp: [upEvent] }), [obj]);
+
+      expect(emitSpy).not.toHaveBeenCalledWith('pointerleave', expect.anything());
+    });
+
+    it('does NOT fire pointerleave when the object is inactive', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => false
+      ); // active = false
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+      dispatcher.addPointerToObject(obj, 0);
+
+      const upEvent = makePointerEvent('up', ex.PointerType.Touch);
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameUp: [upEvent] }), [obj]);
+
+      expect(emitSpy).not.toHaveBeenCalledWith('pointerleave', expect.anything());
+    });
+
+    it('does NOT fire pointerleave on touch up when the object is not under the pointer', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      // Object in last frame but NOT in current frame (pointer moved away before lifting)
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+      // Do not add to current frame
+
+      // A move event is needed to get into the dispatch block; use pointer 1 so _left for 0 doesn't trigger
+      // Instead just use the up event with a different pointer so neither _left nor the new condition fires
+      const upEvent = makePointerEvent('up', ex.PointerType.Touch, 1); // different pointer id
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameUp: [upEvent] }), [obj]);
+
+      expect(emitSpy).not.toHaveBeenCalledWith('pointerleave', expect.anything());
+    });
+  });
+
+  describe('_processEnterLeaveAndEmit (drag variants)', () => {
+    it('fires pointerdragenter on touch down when dragging', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+      dispatcher.addPointerToObject(obj, 0);
+
+      const downEvent = makePointerEvent('down', ex.PointerType.Touch);
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameDown: [downEvent], isDragging: () => true }), [obj]);
+
+      expect(emitSpy).toHaveBeenCalledWith('pointerdragenter', downEvent);
+    });
+
+    it('fires pointerdragleave on touch up when dragging', () => {
+      const dispatcher = new PointerEventsToObjectDispatcher();
+      const obj = makeTrackedObject();
+      const emitSpy = vi.spyOn(obj.events, 'emit');
+
+      dispatcher.addObject(
+        obj,
+        () => false,
+        () => true
+      );
+      dispatcher.addPointerToObject(obj, 0);
+      dispatcher.clear();
+      dispatcher.addPointerToObject(obj, 0);
+
+      const upEvent = makePointerEvent('up', ex.PointerType.Touch);
+      dispatcher.dispatchEvents(makeReceiver({ currentFrameUp: [upEvent], isDragging: () => true }), [obj]);
+
+      expect(emitSpy).toHaveBeenCalledWith('pointerdragleave', upEvent);
+    });
+  });
+});


### PR DESCRIPTION
…interleave

-Added AI-generated unit tests, since there weren't any before for pointer-events-to-object-dispatcher.ts

<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #3730

## Changes:

- "pointerleave" now only fires when the click that was released was a pen or touch event.
- "pointerenter" now fires when the click was a pen or touch event.

### Notes:
The unit tests are AI generated.  I gave them an initial look and all of them are passing, but I would appreciate it if whomever approves this PR gives them another look.
