### PR TITLE
fix: Add GamepadEvents export to enhance gamepad input handling

### DIFF
--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -83,7 +83,7 @@ export type {
   NavigatorGamepadEvent,
   GamepadConfiguration
 } from './input/gamepad';
-export { Gamepads, Gamepad, Buttons, Axes } from './input/gamepad';
+export { Gamepads, Gamepad, Buttons, Axes, GamepadEvents } from './input/gamepad';
 
 export type { KeyboardInitOptions } from './input/keyboard';
 export { Keys, KeyEvent, Keyboard } from './input/keyboard';


### PR DESCRIPTION
Add GamepadEvents to the public exports in the engine's main entry point. This makes the GamepadEvents class available to consumers of the Excalibur library, allowing them to access gamepad-related event types and utilities.