### PR TITLE
docs: fix typo "wether" → "whether" in actor.ts JSDoc

### DIFF
--- a/src/engine/actor.ts
+++ b/src/engine/actor.ts
@@ -864,7 +864,7 @@ export class Actor extends Entity implements Eventable, PointerEvents, CanInitia
   }
 
   /**
-   * Indicates wether the actor has been killed.
+   * Indicates whether the actor has been killed.
    */
   public isKilled(): boolean {
     return !this.isActive;


### PR DESCRIPTION
JSDoc-only typo fix on the `isKilled()` method in `src/engine/actor.ts:867`. No behavior change.