### PR TITLE
fix: Enhance pointer event handling by adding coordPlane check for graphics tracking, also added world to screen space conversion on pointer event check

### DIFF
--- a/src/engine/collision/bounding-box.ts
+++ b/src/engine/collision/bounding-box.ts
@@ -5,6 +5,7 @@ import { Side } from './side';
 import type { ExcaliburGraphicsContext, RectGraphicsOptions } from '../graphics/context/excalibur-graphics-context';
 import type { AffineMatrix } from '../math/affine-matrix';
 import { getMinIndex } from '../util/util';
+import type { CoordPlane } from '../math';
 
 export interface BoundingBoxOptions {
   left: number;
@@ -16,7 +17,7 @@ export interface BoundingBoxOptions {
 /**
  * Axis Aligned collision primitive for Excalibur.
  */
-export class BoundingBox {
+export class BoundingBox<TCoordinates = CoordPlane.World> {
   public top: number;
   public right: number;
   public bottom: number;
@@ -48,7 +49,7 @@ export class BoundingBox {
   /**
    * Returns a new instance of {@apilink BoundingBox} that is a copy of the current instance
    */
-  public clone(dest?: BoundingBox): BoundingBox {
+  public clone(dest?: BoundingBox<TCoordinates>): BoundingBox<TCoordinates> {
     const result = dest || new BoundingBox(0, 0, 0, 0);
     result.left = this.left;
     result.right = this.right;
@@ -91,7 +92,7 @@ export class BoundingBox {
     return Side.None;
   }
 
-  public static fromPoints(points: Vector[]): BoundingBox {
+  public static fromPoints<TCoordinates = CoordPlane.World>(points: Vector[]): BoundingBox<TCoordinates> {
     let minX = Infinity;
     let minY = Infinity;
     let maxX = -Infinity;
@@ -120,7 +121,12 @@ export class BoundingBox {
    * @param anchor Default Vector.Half
    * @param pos Default Vector.Zero
    */
-  public static fromDimension(width: number, height: number, anchor: Vector = Vector.Half, pos: Vector = Vector.Zero) {
+  public static fromDimension<TCoordinates = CoordPlane.World>(
+    width: number,
+    height: number,
+    anchor: Vector = Vector.Half,
+    pos: Vector = Vector.Zero
+  ): BoundingBox<TCoordinates> {
     return new BoundingBox(
       -width * anchor.x + pos.x,
       -height * anchor.y + pos.y,
@@ -173,7 +179,7 @@ export class BoundingBox {
     return new Vector(this.left, this.bottom);
   }
 
-  public translate(pos: Vector): BoundingBox {
+  public translate(pos: Vector): BoundingBox<TCoordinates> {
     return new BoundingBox(this.left + pos.x, this.top + pos.y, this.right + pos.x, this.bottom + pos.y);
   }
 
@@ -181,9 +187,9 @@ export class BoundingBox {
    * Rotates a bounding box by and angle and around a point, if no point is specified (0, 0) is used by default. The resulting bounding
    * box is also axis-align. This is useful when a new axis-aligned bounding box is needed for rotated geometry.
    */
-  public rotate(angle: number, point: Vector = Vector.Zero): BoundingBox {
+  public rotate(angle: number, point: Vector = Vector.Zero): BoundingBox<TCoordinates> {
     const points = this.getPoints().map((p) => p.rotate(angle, point));
-    return BoundingBox.fromPoints(points);
+    return BoundingBox.fromPoints<TCoordinates>(points);
   }
 
   /**
@@ -191,16 +197,16 @@ export class BoundingBox {
    * @param scale
    * @param point
    */
-  public scale(scale: Vector, point: Vector = Vector.Zero): BoundingBox {
+  public scale(scale: Vector, point: Vector = Vector.Zero): BoundingBox<TCoordinates> {
     const shifted = this.translate(point);
-    return new BoundingBox(shifted.left * scale.x, shifted.top * scale.y, shifted.right * scale.x, shifted.bottom * scale.y);
+    return new BoundingBox<TCoordinates>(shifted.left * scale.x, shifted.top * scale.y, shifted.right * scale.x, shifted.bottom * scale.y);
   }
 
   /**
    * Transform the axis aligned bounding box by a {@apilink Matrix}, producing a new axis aligned bounding box
    * @param matrix
    */
-  public transform(matrix: AffineMatrix) {
+  public transform(matrix: AffineMatrix, dest?: BoundingBox) {
     // inlined these calculations to not use vectors would speed it up slightly
     // const matFirstColumn = vec(matrix.data[0], matrix.data[1]);
     // const xa = matFirstColumn.scale(this.left);
@@ -228,7 +234,15 @@ export class BoundingBox {
     const right = Math.max(xa1, xb1) + Math.max(ya1, yb1) + matrixPos.x;
     const bottom = Math.max(xa2, xb2) + Math.max(ya2, yb2) + matrixPos.y;
 
-    return new BoundingBox({
+    if (dest) {
+      dest.left = left;
+      dest.top = top;
+      dest.right = right;
+      dest.bottom = bottom;
+      return dest;
+    }
+
+    return new BoundingBox<TCoordinates>({
       left, //: topLeft.x,
       top, //: topLeft.y,
       right, //: bottomRight.x,
@@ -346,7 +360,7 @@ export class BoundingBox {
    * Combines this bounding box and another together returning a new bounding box
    * @param other  The bounding box to combine
    */
-  public combine(other: BoundingBox, dest?: BoundingBox): BoundingBox {
+  public combine(other: BoundingBox<TCoordinates>, dest?: BoundingBox<TCoordinates>): BoundingBox<TCoordinates> {
     const compositeBB = dest || new BoundingBox(0, 0, 0, 0);
     const left = Math.min(this.left, other.left);
     const top = Math.min(this.top, other.top);
@@ -430,7 +444,7 @@ export class BoundingBox {
    * Test whether the bounding box has intersected with another bounding box, returns the side of the current bb that intersected.
    * @param bb The other actor to test
    */
-  public intersectWithSide(bb: BoundingBox): Side {
+  public intersectWithSide(bb: BoundingBox<TCoordinates>): Side {
     const intersect = this.intersect(bb);
     return BoundingBox.getSideFromIntersection(intersect);
   }

--- a/src/engine/collision/bounding-box.ts
+++ b/src/engine/collision/bounding-box.ts
@@ -5,7 +5,6 @@ import { Side } from './side';
 import type { ExcaliburGraphicsContext, RectGraphicsOptions } from '../graphics/context/excalibur-graphics-context';
 import type { AffineMatrix } from '../math/affine-matrix';
 import { getMinIndex } from '../util/util';
-import type { CoordPlane } from '../math';
 
 export interface BoundingBoxOptions {
   left: number;
@@ -17,7 +16,7 @@ export interface BoundingBoxOptions {
 /**
  * Axis Aligned collision primitive for Excalibur.
  */
-export class BoundingBox<TCoordinates = CoordPlane.World> {
+export class BoundingBox {
   public top: number;
   public right: number;
   public bottom: number;
@@ -49,7 +48,7 @@ export class BoundingBox<TCoordinates = CoordPlane.World> {
   /**
    * Returns a new instance of {@apilink BoundingBox} that is a copy of the current instance
    */
-  public clone(dest?: BoundingBox<TCoordinates>): BoundingBox<TCoordinates> {
+  public clone(dest?: BoundingBox): BoundingBox {
     const result = dest || new BoundingBox(0, 0, 0, 0);
     result.left = this.left;
     result.right = this.right;
@@ -92,7 +91,7 @@ export class BoundingBox<TCoordinates = CoordPlane.World> {
     return Side.None;
   }
 
-  public static fromPoints<TCoordinates = CoordPlane.World>(points: Vector[]): BoundingBox<TCoordinates> {
+  public static fromPoints(points: Vector[]): BoundingBox {
     let minX = Infinity;
     let minY = Infinity;
     let maxX = -Infinity;
@@ -121,12 +120,7 @@ export class BoundingBox<TCoordinates = CoordPlane.World> {
    * @param anchor Default Vector.Half
    * @param pos Default Vector.Zero
    */
-  public static fromDimension<TCoordinates = CoordPlane.World>(
-    width: number,
-    height: number,
-    anchor: Vector = Vector.Half,
-    pos: Vector = Vector.Zero
-  ): BoundingBox<TCoordinates> {
+  public static fromDimension(width: number, height: number, anchor: Vector = Vector.Half, pos: Vector = Vector.Zero): BoundingBox {
     return new BoundingBox(
       -width * anchor.x + pos.x,
       -height * anchor.y + pos.y,
@@ -179,7 +173,7 @@ export class BoundingBox<TCoordinates = CoordPlane.World> {
     return new Vector(this.left, this.bottom);
   }
 
-  public translate(pos: Vector): BoundingBox<TCoordinates> {
+  public translate(pos: Vector): BoundingBox {
     return new BoundingBox(this.left + pos.x, this.top + pos.y, this.right + pos.x, this.bottom + pos.y);
   }
 
@@ -187,9 +181,9 @@ export class BoundingBox<TCoordinates = CoordPlane.World> {
    * Rotates a bounding box by and angle and around a point, if no point is specified (0, 0) is used by default. The resulting bounding
    * box is also axis-align. This is useful when a new axis-aligned bounding box is needed for rotated geometry.
    */
-  public rotate(angle: number, point: Vector = Vector.Zero): BoundingBox<TCoordinates> {
+  public rotate(angle: number, point: Vector = Vector.Zero): BoundingBox {
     const points = this.getPoints().map((p) => p.rotate(angle, point));
-    return BoundingBox.fromPoints<TCoordinates>(points);
+    return BoundingBox.fromPoints(points);
   }
 
   /**
@@ -197,9 +191,9 @@ export class BoundingBox<TCoordinates = CoordPlane.World> {
    * @param scale
    * @param point
    */
-  public scale(scale: Vector, point: Vector = Vector.Zero): BoundingBox<TCoordinates> {
+  public scale(scale: Vector, point: Vector = Vector.Zero): BoundingBox {
     const shifted = this.translate(point);
-    return new BoundingBox<TCoordinates>(shifted.left * scale.x, shifted.top * scale.y, shifted.right * scale.x, shifted.bottom * scale.y);
+    return new BoundingBox(shifted.left * scale.x, shifted.top * scale.y, shifted.right * scale.x, shifted.bottom * scale.y);
   }
 
   /**
@@ -242,7 +236,7 @@ export class BoundingBox<TCoordinates = CoordPlane.World> {
       return dest;
     }
 
-    return new BoundingBox<TCoordinates>({
+    return new BoundingBox({
       left, //: topLeft.x,
       top, //: topLeft.y,
       right, //: bottomRight.x,
@@ -360,7 +354,7 @@ export class BoundingBox<TCoordinates = CoordPlane.World> {
    * Combines this bounding box and another together returning a new bounding box
    * @param other  The bounding box to combine
    */
-  public combine(other: BoundingBox<TCoordinates>, dest?: BoundingBox<TCoordinates>): BoundingBox<TCoordinates> {
+  public combine(other: BoundingBox, dest?: BoundingBox): BoundingBox {
     const compositeBB = dest || new BoundingBox(0, 0, 0, 0);
     const left = Math.min(this.left, other.left);
     const top = Math.min(this.top, other.top);
@@ -444,7 +438,7 @@ export class BoundingBox<TCoordinates = CoordPlane.World> {
    * Test whether the bounding box has intersected with another bounding box, returns the side of the current bb that intersected.
    * @param bb The other actor to test
    */
-  public intersectWithSide(bb: BoundingBox<TCoordinates>): Side {
+  public intersectWithSide(bb: BoundingBox): Side {
     const intersect = this.intersect(bb);
     return BoundingBox.getSideFromIntersection(intersect);
   }

--- a/src/engine/collision/detection/sparse-hash-grid.ts
+++ b/src/engine/collision/detection/sparse-hash-grid.ts
@@ -252,7 +252,7 @@ export class SparseHashGrid<TObject extends { bounds: BoundingBox }, TProxy exte
     // the bounds stay 0
     // this.bounds.reset();
     for (let i = 0; i < targets.length; i++) {
-      const target = targets[0];
+      const target = targets[i];
       const proxy = this.objectToProxy.get(target);
       if (!proxy) {
         continue;

--- a/src/engine/collision/detection/sparse-hash-grid.ts
+++ b/src/engine/collision/detection/sparse-hash-grid.ts
@@ -225,6 +225,9 @@ export class SparseHashGrid<TObject extends { bounds: BoundingBox }, TProxy exte
     }
   }
 
+  /**
+   * **WARNING** TObjects must use the same coordPlan on their .bounds to work properly
+   */
   track(target: TObject): void {
     const proxy = this._buildProxy(target);
     this.objectToProxy.set(target, proxy);

--- a/src/engine/collision/detection/sparse-hash-grid.ts
+++ b/src/engine/collision/detection/sparse-hash-grid.ts
@@ -248,7 +248,8 @@ export class SparseHashGrid<TObject extends { bounds: BoundingBox }, TProxy exte
     // FIXME resetting bounds is wrong, if nothing has updated then
     // the bounds stay 0
     // this.bounds.reset();
-    for (const target of targets) {
+    for (let i = 0; i < targets.length; i++) {
+      const target = targets[0];
       const proxy = this.objectToProxy.get(target);
       if (!proxy) {
         continue;

--- a/src/engine/graphics/graphics-component.ts
+++ b/src/engine/graphics/graphics-component.ts
@@ -451,6 +451,7 @@ export class GraphicsComponent extends Component {
     if (this.owner) {
       const tx = this.owner.get(TransformComponent);
       if (tx) {
+        // either world or screen space bounds
         bounds.transform(tx.get().matrix, bounds);
       }
 
@@ -459,12 +460,6 @@ export class GraphicsComponent extends Component {
         const camera = this.owner.scene?.camera;
         const screen = this.owner.scene?.engine?.screen;
         if (camera && screen) {
-          // const points = [...bounds.getPoints()];
-          // for (let i = 0; i < points.length; i++) {
-          //   points[i] = screen.screenToWorldCoordinates(points[i]);
-          // }
-          // bounds = BoundingBox.fromPoints(points);
-
           // For speed
           // dubious transform by tampering with the camera inverse then putting it back
           const topLeft = screen.contentArea.topLeft;

--- a/src/engine/graphics/graphics-component.ts
+++ b/src/engine/graphics/graphics-component.ts
@@ -12,6 +12,7 @@ import { GraphicsGroup } from '../graphics/graphics-group';
 import { Color } from '../color';
 import { Raster } from './raster';
 import { Text } from './text';
+import { CoordPlane } from '../math';
 
 /**
  * Type guard for checking if a Graphic HasTick (used for graphics that change over time like animations)
@@ -441,15 +442,41 @@ export class GraphicsComponent extends Component {
     return this._localBounds as BoundingBox; // recalc guarantees type
   }
 
+  private _scratchWorldBounds = new BoundingBox();
   /**
    * Get world bounds of graphics component
    */
   public get bounds(): BoundingBox {
-    let bounds = this.localBounds;
+    const bounds = this.localBounds.clone(this._scratchWorldBounds);
     if (this.owner) {
       const tx = this.owner.get(TransformComponent);
       if (tx) {
-        bounds = bounds.transform(tx.get().matrix);
+        bounds.transform(tx.get().matrix, bounds);
+      }
+
+      const isScreenSpace = tx.coordPlane === CoordPlane.Screen;
+      if (isScreenSpace) {
+        const camera = this.owner.scene?.camera;
+        const screen = this.owner.scene?.engine?.screen;
+        if (camera && screen) {
+          // const points = [...bounds.getPoints()];
+          // for (let i = 0; i < points.length; i++) {
+          //   points[i] = screen.screenToWorldCoordinates(points[i]);
+          // }
+          // bounds = BoundingBox.fromPoints(points);
+
+          // For speed
+          // dubious transform by tampering with the camera inverse then putting it back
+          const topLeft = screen.contentArea.topLeft;
+          const oldX = camera.inverse.data[4];
+          const oldY = camera.inverse.data[5];
+          camera.inverse.data[4] += topLeft.x;
+          camera.inverse.data[5] += topLeft.y;
+          bounds.transform(camera.inverse, bounds);
+          camera.inverse.data[4] = oldX;
+          camera.inverse.data[5] = oldY;
+        }
+        return bounds;
       }
     }
     return bounds;

--- a/src/engine/input/pointer-system.ts
+++ b/src/engine/input/pointer-system.ts
@@ -54,7 +54,7 @@ export class PointerSystem extends System {
       const maybeGfx = e.get(GraphicsComponent);
       if (maybeGfx) {
         this._graphics.push(maybeGfx);
-        this._graphicsHashGrid.track(maybeGfx); // disambiguate screen and world space
+        this._graphicsHashGrid.track(maybeGfx);
       }
       this._sortedTransforms.push(tx);
       this._sortedEntities.push(tx.owner);

--- a/src/engine/input/pointer-system.ts
+++ b/src/engine/input/pointer-system.ts
@@ -37,7 +37,6 @@ export class PointerSystem extends System {
 
     this.query.entityAdded$.subscribe((e) => {
       const tx = e.get(TransformComponent);
-      const coordPlane = tx.coordPlane;
       const pointer = e.get(PointerComponent);
       this._pointerEventDispatcher.addObject(
         e,
@@ -53,10 +52,9 @@ export class PointerSystem extends System {
       );
       this._entityToPointer.set(e, pointer);
       const maybeGfx = e.get(GraphicsComponent);
-      const isInScreenSpace = coordPlane === CoordPlane.Screen;
-      if (maybeGfx && isInScreenSpace) {
+      if (maybeGfx) {
         this._graphics.push(maybeGfx);
-        this._graphicsHashGrid.track(maybeGfx);
+        this._graphicsHashGrid.track(maybeGfx); // disambiguate screen and world space
       }
       this._sortedTransforms.push(tx);
       this._sortedEntities.push(tx.owner);
@@ -144,7 +142,7 @@ export class PointerSystem extends System {
         }
       }
 
-      const graphics = this._graphicsHashGrid.query(this._engine.worldToScreenCoordinates(pos.worldPos));
+      const graphics = this._graphicsHashGrid.query(pos.worldPos);
       for (let i = 0; i < graphics.length; i++) {
         const graphic = graphics[i];
         const maybePointer = this._entityToPointer.get(graphic.owner);

--- a/src/engine/input/pointer-system.ts
+++ b/src/engine/input/pointer-system.ts
@@ -37,6 +37,7 @@ export class PointerSystem extends System {
 
     this.query.entityAdded$.subscribe((e) => {
       const tx = e.get(TransformComponent);
+      const coordPlane = tx.coordPlane;
       const pointer = e.get(PointerComponent);
       this._pointerEventDispatcher.addObject(
         e,
@@ -52,7 +53,8 @@ export class PointerSystem extends System {
       );
       this._entityToPointer.set(e, pointer);
       const maybeGfx = e.get(GraphicsComponent);
-      if (maybeGfx) {
+      const isInScreenSpace = coordPlane === CoordPlane.Screen;
+      if (maybeGfx && isInScreenSpace) {
         this._graphics.push(maybeGfx);
         this._graphicsHashGrid.track(maybeGfx);
       }
@@ -142,7 +144,7 @@ export class PointerSystem extends System {
         }
       }
 
-      const graphics = this._graphicsHashGrid.query(pos.worldPos);
+      const graphics = this._graphicsHashGrid.query(this._engine.worldToScreenCoordinates(pos.worldPos));
       for (let i = 0; i < graphics.length; i++) {
         const graphic = graphics[i];
         const maybePointer = this._entityToPointer.get(graphic.owner);

--- a/src/engine/screen.ts
+++ b/src/engine/screen.ts
@@ -782,6 +782,7 @@ export class Screen {
     if (this._camera) {
       return this._camera.inverse.multiply(point);
     }
+    // fallback to center screen camera
     return point.sub(vec(this.resolution.width / 2, this.resolution.height / 2));
   }
 
@@ -795,6 +796,8 @@ export class Screen {
     if (this._camera) {
       return this._camera.transform.multiply(point);
     }
+
+    // fallback to center screen camera
     return point.add(vec(this.resolution.width / 2, this.resolution.height / 2));
   }
 


### PR DESCRIPTION
Fixed pointer event handling for screen-space graphics by ensuring only screen-space graphics are tracked in the pointer system and converting world coordinates to screen coordinates before querying the graphics hash grid.

What changed:
- Captured coordPlane from the entity transform during pointer registration.
- Added a guard so only graphics with CoordPlane.Screen are tracked by _graphicsHashGrid.
- Converted pointer event world position to screen space with _engine.worldToScreenCoordinates(...) before querying _graphicsHashGrid.

Files changed
pointer-system.ts