### PR TITLE
fix: respect particle config z when ParticleTransform.Global is set (#3748)

### DIFF
--- a/src/engine/particles/particle-emitter.ts
+++ b/src/engine/particles/particle-emitter.ts
@@ -156,7 +156,7 @@ export class ParticleEmitter extends Actor {
       beginColor: this.particle.beginColor,
       endColor: this.particle.endColor,
       pos: vec(ranX, ranY),
-      z: this.particle.transform === ParticleTransform.Global ? this.z : undefined,
+      z: this.particle.transform === ParticleTransform.Global ? (this.particle.z ?? this.z) : undefined,
       vel: vec(dx, dy),
       acc: this.particle.acc,
       angularVelocity: this.particle.angularVelocity,

--- a/src/spec/vitest/particle-spec.ts
+++ b/src/spec/vitest/particle-spec.ts
@@ -303,4 +303,41 @@ describe('A particle', () => {
         .every((entity) => entity.transform.z === 5)
     ).toBeTruthy();
   });
+
+  it('uses particle config z when specified, overriding emitter z', () => {
+    const emitter = new ex.ParticleEmitter({
+      particle: {
+        transform: ex.ParticleTransform.Global,
+        z: 10
+      },
+      pos: new ex.Vector(0, 0),
+      z: 5,
+      random: new ex.Random(1337)
+    });
+    engine.add(emitter);
+    emitter.emitParticles(10);
+    expect(
+      engine.currentScene.world.entityManager.entities
+        .filter((entity) => entity instanceof ex.Particle)
+        .every((entity) => entity.transform.z === 10)
+    ).toBeTruthy();
+  });
+
+  it('falls back to emitter z when particle config z is not set', () => {
+    const emitter = new ex.ParticleEmitter({
+      particle: {
+        transform: ex.ParticleTransform.Global
+      },
+      pos: new ex.Vector(0, 0),
+      z: 7,
+      random: new ex.Random(1337)
+    });
+    engine.add(emitter);
+    emitter.emitParticles(10);
+    expect(
+      engine.currentScene.world.entityManager.entities
+        .filter((entity) => entity instanceof ex.Particle)
+        .every((entity) => entity.transform.z === 7)
+    ).toBeTruthy();
+  });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #3748

## Changes:

- In `src/engine/particles/particle-emitter.ts`, changed the `z` assignment in `_createParticle` from `this.z` to `(this.particle.z ?? this.z)` so that a `z` value specified in the particle config takes precedence over the emitter-level `z`, while retaining backward compatibility for emitters that only set `z` on themselves
- Added two regression tests to `src/spec/vitest/particle-spec.ts` — one verifying that `particle.z` overrides the emitter's `z` when `ParticleTransform.Global` is active, and one verifying the emitter's `z` is still used as a fallback when no `particle.z` is set