### PR TITLE
fix: [#3748] Circle-based CPU particles respect Z

### DIFF
--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -50,7 +50,7 @@ var game = new ex.Engine({
   displayMode: ex.DisplayMode.FitScreenAndFill,
   snapToPixel: false,
   // fixedUpdateFps: 30,
-  // pixelRatio: 2,
+  pixelRatio: 4,
   fixedUpdateFps: 60,
   maxFps: 60,
   antialiasing: {

--- a/sandbox/src/game.ts
+++ b/sandbox/src/game.ts
@@ -1082,6 +1082,7 @@ var emitter = new ex.ParticleEmitter({
   pos: new ex.Vector(100, 300),
   width: 2,
   height: 2,
+  z: -10,
   particle: {
     minSpeed: 417,
     maxSpeed: 589,
@@ -1090,11 +1091,11 @@ var emitter = new ex.ParticleEmitter({
     opacity: 0.84,
     fade: true,
     life: 2465,
-    maxSize: 20.5,
-    minSize: 10,
+    maxSize: 40.5,
+    minSize: 40,
     beginColor: ex.Color.Red,
     endColor: ex.Color.Yellow,
-    graphic: blockSprite,
+    // graphic: blockSprite,
     angularVelocity: Math.PI / 10,
     acc: new ex.Vector(0, 460),
     randomRotation: true

--- a/src/engine/graphics/context/circle-renderer/circle-renderer.ts
+++ b/src/engine/graphics/context/circle-renderer/circle-renderer.ts
@@ -81,6 +81,12 @@ export class CircleRenderer implements RendererPlugin {
     return false;
   }
 
+  _scratchTopLeft = vec(0, 0);
+  _scratchTopRight = vec(0, 0);
+  _scratchBottomRight = vec(0, 0);
+  _scratchBottomLeft = vec(0, 0);
+  _scratchRadius = vec(0, 0);
+
   draw(pos: Vector, radius: number, color: Color, stroke: Color = Color.Transparent, strokeThickness: number = 0): void {
     if (this._isFull()) {
       this.flush();
@@ -92,10 +98,21 @@ export class CircleRenderer implements RendererPlugin {
     const opacity = this._context.opacity;
     const snapToPixel = this._context.snapToPixel;
 
-    const topLeft = transform.multiply(pos.add(vec(-radius, -radius)));
-    const topRight = transform.multiply(pos.add(vec(radius, -radius)));
-    const bottomRight = transform.multiply(pos.add(vec(radius, radius)));
-    const bottomLeft = transform.multiply(pos.add(vec(-radius, radius)));
+    this._scratchRadius.x = -radius;
+    this._scratchRadius.y = -radius;
+    const topLeft = transform.multiply(pos.add(this._scratchRadius, this._scratchTopLeft), this._scratchTopLeft);
+
+    this._scratchRadius.x = radius;
+    this._scratchRadius.y = -radius;
+    const topRight = transform.multiply(pos.add(this._scratchRadius, this._scratchTopRight), this._scratchTopRight);
+
+    this._scratchRadius.x = radius;
+    this._scratchRadius.y = radius;
+    const bottomRight = transform.multiply(pos.add(this._scratchRadius, this._scratchBottomRight), this._scratchBottomRight);
+
+    this._scratchRadius.x = -radius;
+    this._scratchRadius.y = radius;
+    const bottomLeft = transform.multiply(pos.add(this._scratchRadius, this._scratchBottomLeft), this._scratchBottomLeft);
 
     if (snapToPixel) {
       topLeft.x = ~~(topLeft.x + pixelSnapEpsilon);

--- a/src/engine/particles/particles.ts
+++ b/src/engine/particles/particles.ts
@@ -121,7 +121,8 @@ export class Particle extends Entity {
       this.graphics.localBounds = BoundingBox.fromDimension(this.size, this.size, Vector.Half);
       this.graphics.onPostDraw = (ctx) => {
         ctx.save();
-        ctx.debug.drawPoint(vec(0, 0), { color: this._currentColor, size: this.size });
+        ctx.z = this.transform.z;
+        ctx.drawCircle(vec(0, 0), this.size, this._currentColor, Color.Black, 1);
         ctx.restore();
       };
     }

--- a/src/engine/particles/particles.ts
+++ b/src/engine/particles/particles.ts
@@ -122,7 +122,7 @@ export class Particle extends Entity {
       this.graphics.onPostDraw = (ctx) => {
         ctx.save();
         ctx.z = this.transform.z;
-        ctx.drawCircle(vec(0, 0), this.size, this._currentColor, Color.Black, 1);
+        ctx.drawCircle(vec(0, 0), this.size, this._currentColor);
         ctx.restore();
       };
     }


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

fixes: #3748

## Changes:

- Switches out renderer to correct one, oversight from renderer refactoring
- Removes mem allocations in the hot particle draw loop

## TODOs

- [x] Particle size is different from previous renderer, determine correct actual size. Debug renderer was using screen space sizing, not world space which was incorrect. New renderer is now correctly rendering at world space.
