### PR TITLE
perf: tweak pause to use tags, faster iteration

### DIFF
--- a/site/docs/12-other/12-pausing.mdx
+++ b/site/docs/12-other/12-pausing.mdx
@@ -33,10 +33,10 @@ const player = new ex.Actor({ x: 100, y: 100, canPause: true });
 scene.add(player);
 
 // Pause the scene
-scene.pauseScene();
+scene.pause();
 
 // Resume the scene
-scene.resumeScene();
+scene.resume();
 ```
 
 ## PauseComponent
@@ -52,6 +52,6 @@ The `PauseComponent` tracks whether an entity is currently paused and whether it
 
 ### Scene Events
 
-[Scenes](/docs/scenes) now have `pauseScene()` and `resumeScene()` methods that emit out the pause state of the scene.
+[Scenes](/docs/scenes) now have `pause()` and `resume()` methods that emit out the pause state of the scene.
 
 If you have UI elements, like a Pause Menu for example, that you want to respond to those events, you can listen to the scene's [events](/docs/events) emitter.

--- a/src/engine/actions/actions-system.ts
+++ b/src/engine/actions/actions-system.ts
@@ -1,7 +1,7 @@
 import type { Query, World } from '../entity-component-system';
 import { SystemPriority } from '../entity-component-system';
 import { System, SystemType } from '../entity-component-system//system';
-import { PauseComponent } from '../entity-component-system/components/pause-component';
+import { PauseComponentTag } from '../entity-component-system/components/pause-component';
 import { ActionsComponent } from './actions-component';
 
 export class ActionsSystem extends System {
@@ -9,11 +9,14 @@ export class ActionsSystem extends System {
 
   systemType = SystemType.Update;
   private _actions: ActionsComponent[] = [];
-  query: Query<typeof ActionsComponent | typeof PauseComponent>;
+  query: Query<typeof ActionsComponent>;
 
   constructor(public world: World) {
     super();
-    this.query = this.world.query([ActionsComponent, PauseComponent]);
+    this.query = this.world.query({
+      components: { all: [ActionsComponent] },
+      tags: { not: [PauseComponentTag] }
+    });
 
     this.query.entityAdded$.subscribe((e) => this._actions.push(e.get(ActionsComponent)));
     this.query.entityRemoved$.subscribe((e) => {
@@ -27,9 +30,6 @@ export class ActionsSystem extends System {
   update(elapsed: number): void {
     for (let i = 0; i < this._actions.length; i++) {
       const action = this._actions[i];
-      if (action.owner?.get(PauseComponent).paused) {
-        continue;
-      }
       action.update(elapsed);
     }
   }

--- a/src/engine/actor.ts
+++ b/src/engine/actor.ts
@@ -143,6 +143,8 @@ export type ActorArgs = ColliderArgs & {
   collisionGroup?: CollisionGroup;
   /**
    * Optionally set if the actor can be paused
+   *
+   * (default is true)
    */
   canPause?: boolean;
 };

--- a/src/engine/collision/collision-system.ts
+++ b/src/engine/collision/collision-system.ts
@@ -22,12 +22,12 @@ import { MotionSystem } from './motion-system';
 import { Pair } from './detection/pair';
 import { BodyComponent } from './index';
 import { buildContactIslands } from './island';
-import { PauseComponent } from '../entity-component-system/components/pause-component';
+import { PauseComponentTag } from '../entity-component-system/components/pause-component';
 export class CollisionSystem extends System {
   static priority = SystemPriority.Higher;
 
   public systemType = SystemType.Update;
-  public query: Query<ComponentCtor<TransformComponent> | ComponentCtor<ColliderComponent> | typeof PauseComponent>;
+  public query: Query<ComponentCtor<TransformComponent> | ComponentCtor<ColliderComponent>>;
   public bodyQuery: Query<ComponentCtor<BodyComponent>>;
 
   private _engine: Engine;
@@ -55,7 +55,10 @@ export class CollisionSystem extends System {
     this._physics.$configUpdate.subscribe(() => (this._configDirty = true));
     this._trackCollider = (c: Collider) => this._processor.track(c);
     this._untrackCollider = (c: Collider) => this._processor.untrack(c);
-    this.query = world.query([TransformComponent, ColliderComponent, PauseComponent]);
+    this.query = world.query({
+      components: { all: [TransformComponent, ColliderComponent] },
+      tags: { not: [PauseComponentTag] }
+    });
     this.query.entityAdded$.subscribe((e) => {
       const colliderComponent = e.get(ColliderComponent);
       colliderComponent.$colliderAdded.subscribe(this._trackCollider);
@@ -104,10 +107,6 @@ export class CollisionSystem extends System {
     for (let entityIndex = 0; entityIndex < this.query.entities.length; entityIndex++) {
       const entity = this.query.entities[entityIndex];
       const colliderComp = entity.get(ColliderComponent);
-      const paused = entity.get(PauseComponent);
-      if (paused.paused) {
-        continue;
-      }
       const collider = colliderComp?.get();
       if (colliderComp && colliderComp.owner?.isActive && collider) {
         colliderComp.update();

--- a/src/engine/collision/motion-system.ts
+++ b/src/engine/collision/motion-system.ts
@@ -1,7 +1,7 @@
 import type { Entity, Query, World } from '../entity-component-system';
 import { SystemPriority } from '../entity-component-system';
 import { MotionComponent } from '../entity-component-system/components/motion-component';
-import { PauseComponent } from '../entity-component-system/components/pause-component';
+import { PauseComponentTag } from '../entity-component-system/components/pause-component';
 import { TransformComponent } from '../entity-component-system/components/transform-component';
 import { System, SystemType } from '../entity-component-system/system';
 import { BodyComponent } from './body-component';
@@ -14,15 +14,17 @@ export class MotionSystem extends System {
 
   public systemType = SystemType.Update;
   private _physicsConfigDirty = false;
-  query: Query<typeof TransformComponent | typeof MotionComponent | typeof PauseComponent>;
+  query: Query<typeof TransformComponent | typeof MotionComponent>;
 
   private _createPhysicsQuery(world: World, physics: PhysicsWorld) {
     return world.query({
       components: {
-        all: [TransformComponent, MotionComponent, PauseComponent]
+        all: [TransformComponent, MotionComponent]
       },
       tags: {
-        not: physics.config.integration.onScreenOnly ? ['ex.offscreen', 'ex.is_sleeping'] : ['ex.is_sleeping']
+        not: physics.config.integration.onScreenOnly
+          ? ['ex.offscreen', 'ex.is_sleeping', PauseComponentTag]
+          : ['ex.is_sleeping', PauseComponentTag]
       }
     });
   }
@@ -41,7 +43,6 @@ export class MotionSystem extends System {
   update(elapsed: number): void {
     let transform: TransformComponent;
     let motion: MotionComponent;
-    let paused: PauseComponent;
     const entities = this.query.entities;
     const config = this.physics.config;
     const substep = config.substep;
@@ -49,11 +50,6 @@ export class MotionSystem extends System {
     for (let i = 0; i < entities.length; i++) {
       transform = entities[i].get(TransformComponent);
       motion = entities[i].get(MotionComponent);
-      paused = entities[i].get(PauseComponent);
-
-      if (paused.paused) {
-        continue;
-      }
 
       if (motion.integration.onScreenOnly && entities[i].hasTag('ex.offscreen')) {
         continue;

--- a/src/engine/entity-component-system/components/pause-component.ts
+++ b/src/engine/entity-component-system/components/pause-component.ts
@@ -13,6 +13,6 @@ export class PauseComponent extends Component {
 
   constructor(config: Partial<PauseComponentInterface> = {}) {
     super();
-    this.canPause = config.canPause ?? false;
+    this.canPause = config.canPause ?? this.canPause;
   }
 }

--- a/src/engine/entity-component-system/components/pause-component.ts
+++ b/src/engine/entity-component-system/components/pause-component.ts
@@ -4,6 +4,7 @@ export interface PauseComponentInterface {
   canPause: boolean;
 }
 
+export const PauseComponentTag = 'ex.paused' as const;
 export class PauseComponent extends Component {
   // @ts-ignore
   private static _NAME = 'PauseComponent';

--- a/src/engine/scene.ts
+++ b/src/engine/scene.ts
@@ -764,11 +764,11 @@ export class Scene<TActivationData = unknown> implements CanInitialize, CanActiv
     }
   }
 
-  public pauseScene() {
+  public pause() {
     this.events.emit('pause');
   }
 
-  public resumeScene() {
+  public resume() {
     this.events.emit('resume');
   }
 }

--- a/src/engine/screen-element.ts
+++ b/src/engine/screen-element.ts
@@ -30,6 +30,7 @@ export class ScreenElement extends Actor {
     this.body.collisionType = config?.collisionType ?? CollisionType.PreventCollision;
     this.pointer.useGraphicsBounds = true;
     this.pointer.useColliderShape = false;
+    this.canPause = false;
     if (!config?.collider && config?.width > 0 && config?.height > 0) {
       this.collider.useBoxCollider(config.width, config.height, this.anchor);
     }

--- a/src/engine/tile-map/isometric-entity-system.ts
+++ b/src/engine/tile-map/isometric-entity-system.ts
@@ -3,31 +3,29 @@ import { TransformComponent } from '../entity-component-system/components/transf
 import { IsometricEntityComponent } from './isometric-entity-component';
 import type { Query, World } from '../entity-component-system';
 import { SystemPriority } from '../entity-component-system';
-import { PauseComponent } from '../entity-component-system/components/pause-component';
+import { PauseComponentTag } from '../entity-component-system/components/pause-component';
 
 export class IsometricEntitySystem extends System {
   static priority: number = SystemPriority.Lower;
 
   public readonly systemType = SystemType.Update;
-  query: Query<typeof TransformComponent | typeof IsometricEntityComponent | typeof PauseComponent>;
+  query: Query<typeof TransformComponent | typeof IsometricEntityComponent>;
   constructor(public world: World) {
     super();
-    this.query = this.world.query([TransformComponent, IsometricEntityComponent, PauseComponent]);
+    this.query = this.world.query({
+      components: { all: [TransformComponent, IsometricEntityComponent] },
+      tags: { not: [PauseComponentTag] }
+    });
   }
 
   update(): void {
     let transform: TransformComponent;
     let iso: IsometricEntityComponent;
-    let paused: PauseComponent;
 
     for (let i = 0; i < this.query.entities.length; i++) {
       const entity = this.query.entities[i];
       transform = entity.get(TransformComponent);
       iso = entity.get(IsometricEntityComponent);
-      paused = entity.get(PauseComponent);
-      if (paused.paused) {
-        continue;
-      }
 
       const maxZindexPerElevation = Math.max(iso.columns * iso.tileWidth, iso.rows * iso.tileHeight);
 

--- a/src/engine/util/pause-system.ts
+++ b/src/engine/util/pause-system.ts
@@ -1,7 +1,7 @@
 import type { EventEmitter, Scene, SceneEvents } from '..';
 import type { Query } from '../entity-component-system';
 import { System, SystemType } from '../entity-component-system';
-import { PauseComponent } from '../entity-component-system/components/pause-component';
+import { PauseComponent, PauseComponentTag } from '../entity-component-system/components/pause-component';
 
 export class PauseSystem extends System {
   systemType: SystemType = SystemType.Update;
@@ -29,6 +29,12 @@ export class PauseSystem extends System {
         pauseComponent.paused = false;
       } else {
         pauseComponent.paused = this.isPaused;
+
+        if (this.isPaused) {
+          pauseEntity.addTag(PauseComponentTag);
+        } else {
+          pauseEntity.removeTag(PauseComponentTag);
+        }
       }
     }
   }

--- a/src/spec/vitest/pause-spec.ts
+++ b/src/spec/vitest/pause-spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { PauseSystem } from '../../engine/util/pause-system';
 import { PauseComponent } from '../../engine/entity-component-system/components/pause-component';
 import type { Scene } from '../../engine/scene';
@@ -25,15 +25,15 @@ describe('PauseSystem', () => {
   });
 
   it('should set isPaused to true when scene emits pause event', () => {
-    scene.pauseScene();
+    scene.pause();
     expect(pauseSystem.isPaused).toBe(true);
   });
 
   it('should set isPaused to false when scene emits resume event', () => {
-    scene.pauseScene();
+    scene.pause();
     expect(pauseSystem.isPaused).toBe(true);
 
-    scene.resumeScene();
+    scene.resume();
     expect(pauseSystem.isPaused).toBe(false);
   });
 
@@ -45,7 +45,7 @@ describe('PauseSystem', () => {
 
     expect(pauseComponent.paused).toBe(false);
 
-    scene.pauseScene();
+    scene.pause();
     pauseSystem.update(16);
 
     expect(pauseComponent.paused).toBe(true);
@@ -59,7 +59,7 @@ describe('PauseSystem', () => {
 
     expect(pauseComponent.paused).toBe(false);
 
-    scene.pauseScene();
+    scene.pause();
     pauseSystem.update(16);
 
     expect(pauseComponent.paused).toBe(false);
@@ -76,7 +76,7 @@ describe('PauseSystem', () => {
     nonPausableEntity.addComponent(nonPausableComponent);
     scene.add(nonPausableEntity);
 
-    scene.pauseScene();
+    scene.pause();
     pauseSystem.update(16);
 
     expect(pausableComponent.paused).toBe(true);
@@ -95,13 +95,13 @@ describe('PauseSystem', () => {
     scene.add(entity2);
 
     // Pause
-    scene.pauseScene();
+    scene.pause();
     pauseSystem.update(16);
     expect(component1.paused).toBe(true);
     expect(component2.paused).toBe(true);
 
     // Resume
-    scene.resumeScene();
+    scene.resume();
     pauseSystem.update(16);
     expect(component1.paused).toBe(false);
     expect(component2.paused).toBe(false);
@@ -114,22 +114,22 @@ describe('PauseSystem', () => {
     scene.add(entity);
 
     // First pause
-    scene.pauseScene();
+    scene.pause();
     pauseSystem.update(16);
     expect(pauseComponent.paused).toBe(true);
 
     // Resume
-    scene.resumeScene();
+    scene.resume();
     pauseSystem.update(16);
     expect(pauseComponent.paused).toBe(false);
 
     // Pause again
-    scene.pauseScene();
+    scene.pause();
     pauseSystem.update(16);
     expect(pauseComponent.paused).toBe(true);
 
     // Resume again
-    scene.resumeScene();
+    scene.resume();
     pauseSystem.update(16);
     expect(pauseComponent.paused).toBe(false);
   });
@@ -139,7 +139,7 @@ describe('PauseSystem', () => {
     scene.add(entityWithoutPause);
 
     expect(() => {
-      scene.pauseScene();
+      scene.pause();
       pauseSystem.update(16);
     }).not.toThrow();
   });
@@ -151,17 +151,17 @@ describe('PauseSystem', () => {
     scene.add(entity);
 
     // Initially pausable
-    scene.pauseScene();
+    scene.pause();
     pauseSystem.update(16);
     expect(pauseComponent.paused).toBe(true);
 
     // Make it non-pausable while paused
     pauseComponent.canPause = false;
-    scene.resumeScene();
+    scene.resume();
     pauseSystem.update(16);
 
     // Try to pause again - should not affect it
-    scene.pauseScene();
+    scene.pause();
     pauseSystem.update(16);
     expect(pauseComponent.paused).toBe(false);
   });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

Small tweak to the pause component, makes it no longer a required component, but an excluded one. This makes it harder to forget to configure pause correctly, and it's faster because there is no last minute pause decision during system eval.