### PR TITLE
fix: pointer wheel memory leak for legacy browsers

### DIFF
--- a/src/engine/input/pointer-event-receiver.ts
+++ b/src/engine/input/pointer-event-receiver.ts
@@ -384,10 +384,10 @@ export class PointerEventReceiver {
       this.target.removeEventListener('wheel', this._boundWheel);
     } else if (document.onmousewheel !== undefined) {
       // Webkit and IE
-      this.target.addEventListener('mousewheel', this._boundWheel);
+      this.target.removeEventListener('mousewheel', this._boundWheel);
     } else {
       // Remaining browser and older Firefox
-      this.target.addEventListener('MozMousePixelScroll', this._boundWheel);
+      this.target.removeEventListener('MozMousePixelScroll', this._boundWheel);
     }
   }
 

--- a/src/spec/vitest/pointer-input-spec.ts
+++ b/src/spec/vitest/pointer-input-spec.ts
@@ -427,4 +427,23 @@ describe('A pointer', () => {
       expect(wheelHandler).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('detach', () => {
+    it('should properly remove wheel event listeners on detach', () => {
+      const receiver = engine.input.pointers as any;
+      const target = receiver.target;
+
+      const removeEventListenerSpy = vi.spyOn(target, 'removeEventListener');
+
+      receiver.detach();
+
+      // Should call removeEventListener, not addEventListener, for wheel events
+      const wheelCalls = removeEventListenerSpy.mock.calls.filter(
+        (call) => call[0] === 'wheel' || call[0] === 'mousewheel' || call[0] === 'MozMousePixelScroll'
+      );
+      expect(wheelCalls.length).toBeGreaterThan(0);
+
+      removeEventListenerSpy.mockRestore();
+    });
+  });
 });


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #

## Changes:

- change 1
- change 2
