### PR TITLE
fix(input): clear PointerEventReceiver events independently of PointerSystem (#3356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue where `scaleTo({…})` and `scaleBy({…})` actions used a live reference to the entity's scale vector as the interpolation start point, causing the easing curve to be corrupted if the entity's scale changed during the action
 - Fixed issue where the first action in a sequence would not execute after calling `clearActions()` mid-execution. All action types now properly reset their initialization state when stopped, resolving issue #3468
 - Performance: Font/Text now use smaller texture sizes, improving performance on Safari especially when rendering text
+- Fixed issue #3356 where removing the `PointerSystem` from a scene caused the `PointerEventReceiver`'s per-frame event arrays to grow unbounded (a memory leak), because clearing those arrays was only performed by the `PointerSystem`. The receiver is now always flushed once per frame by the `InputHost`, independent of whether a `PointerSystem` is active.
 
 ### Updates
 

--- a/src/engine/input/input-host.ts
+++ b/src/engine/input/input-host.ts
@@ -52,6 +52,17 @@ export class InputHost {
       this.keyboard.update();
       this.gamepads.update();
     }
+
+    // The PointerSystem normally updates and clears the pointer receiver each frame. If a scene has no
+    // active PointerSystem (e.g. it was removed via `world.remove(world.get(PointerSystem))`), the
+    // receiver's per-frame event arrays would otherwise grow unbounded. Flush here as a fallback so the
+    // receiver is always reset exactly once per frame regardless of the PointerSystem (see issue #3356).
+    if (this.pointers._processedThisFrame) {
+      this.pointers._processedThisFrame = false;
+    } else {
+      this.pointers.update();
+      this.pointers.clear();
+    }
   }
 
   clear() {

--- a/src/engine/input/pointer-event-receiver.ts
+++ b/src/engine/input/pointer-event-receiver.ts
@@ -78,6 +78,17 @@ export class PointerEventReceiver {
 
   private _enabled = true;
 
+  /**
+   * Tracks whether the {@apilink PointerSystem} has already processed (updated and cleared) this
+   * receiver during the current frame.
+   *
+   * This is used by the {@apilink InputHost} to guarantee the receiver's per-frame events are always
+   * flushed, even when no {@apilink PointerSystem} is active in the current scene. Without this, removing
+   * the PointerSystem would cause the `currentFrame*` arrays to grow unbounded on every native pointer event.
+   * @internal
+   */
+  public _processedThisFrame = false;
+
   constructor(
     public readonly target: GlobalEventHandlers & EventTarget,
     public engine: Engine

--- a/src/engine/input/pointer-system.ts
+++ b/src/engine/input/pointer-system.ts
@@ -163,6 +163,12 @@ export class PointerSystem extends System {
     // Clear last frame's events
     this._pointerEventDispatcher.clear();
 
-    this._receivers.forEach((r) => r.clear());
+    // Flag receivers as processed so the InputHost doesn't double-process them this frame.
+    // If the PointerSystem is removed from a scene, the InputHost flush guarantees the receiver
+    // events are still cleared and the currentFrame* arrays don't leak (see issue #3356).
+    this._receivers.forEach((r) => {
+      r.clear();
+      r._processedThisFrame = true;
+    });
   }
 }

--- a/src/spec/vitest/pointer-input-spec.ts
+++ b/src/spec/vitest/pointer-input-spec.ts
@@ -446,4 +446,33 @@ describe('A pointer', () => {
       removeEventListenerSpy.mockRestore();
     });
   });
+
+  describe('without a PointerSystem', () => {
+    it('should still clear per-frame events so the receiver arrays do not leak (#3356)', () => {
+      const receiver = engine.input.pointers as any;
+
+      // Remove the PointerSystem from the scene - previously this meant nothing cleared the
+      // receiver's currentFrame* arrays, leaking memory on every native pointer event.
+      const pointerSystem = engine.currentScene.world.get(ex.PointerSystem);
+      engine.currentScene.world.remove(pointerSystem);
+      expect(engine.currentScene.world.get(ex.PointerSystem)).toBeFalsy();
+
+      const clock = engine.clock as ex.TestClock;
+
+      for (let i = 0; i < 5; i++) {
+        executeMouseEvent('pointerdown', <any>document, ex.NativePointerButton.Left, 10, 10);
+        executeMouseEvent('pointermove', <any>document, null, 15, 15);
+        executeMouseEvent('pointerup', <any>document, ex.NativePointerButton.Left, 10, 10);
+        // advance a full frame
+        clock.step(16);
+      }
+
+      // The arrays must be flushed each frame even though no PointerSystem is present
+      expect(receiver.currentFrameDown.length).toBe(0);
+      expect(receiver.currentFrameMove.length).toBe(0);
+      expect(receiver.currentFrameUp.length).toBe(0);
+      expect(receiver.currentFrameCancel.length).toBe(0);
+      expect(receiver.currentFrameWheel.length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes (#3356)
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #3356

## Changes:

`PointerEventReceiver` accumulates native pointer events in its `currentFrameDown` / `currentFrameUp` / `currentFrameMove` / `currentFrameCancel` / `currentFrameWheel` arrays. Those arrays were only ever consumed (`update()`) and freed (`clear()`) by `PointerSystem.update()` each frame. If a scene removes the `PointerSystem` (e.g. `world.remove(world.get(PointerSystem))`), nothing flushes those arrays, so they grow without bound on every native pointer event — a memory leak (as noted by @eonarheim, pointer flushing should not depend on the system being present).

- `src/engine/input/input-host.ts`: `InputHost.update()` (which runs every frame for both the engine-level and scene-level input hosts) now guarantees the pointer receiver is flushed exactly once per frame, independent of the `PointerSystem`. If the receiver was already processed by the system this frame, it just resets the marker; otherwise it calls `update()` + `clear()` itself.
- `src/engine/input/pointer-system.ts`: after the system updates/clears each receiver it marks `receiver._processedThisFrame = true` so the `InputHost` fallback does not double-process (and therefore never double-emits raw pointer events) when a `PointerSystem` is active.
- `src/engine/input/pointer-event-receiver.ts`: added the internal `_processedThisFrame` flag used to coordinate the two.
- `src/spec/vitest/pointer-input-spec.ts`: added a regression test that removes the `PointerSystem` from the scene, dispatches several pointer events across multiple frames, and asserts the receiver's `currentFrame*` arrays stay empty.
- `CHANGELOG.md`: added a Fixed entry.

> Note: the project's browser-mode (Playwright/Chromium) test runner could not launch a browser in my local sandbox (`browserType.launch: spawn UNKNOWN`), so the suite was validated via `tsc` on the engine sources; the new spec follows the existing patterns in the same file and should run normally in CI.