### PR TITLE
feat: new 3D/4D vectors + shader uniform api 

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -7,7 +7,7 @@ In order to do our TypeDoc includes we've forked the
 
 ## Local Dev
 
-Be sure the core types have been generated in the root directory
+Be sure the core excalibur types have been generated in the root directory (requires a build)
 
 ```sh
 > cd .. && npm run build && cd site/

--- a/site/README.md
+++ b/site/README.md
@@ -1,23 +1,34 @@
 # Website
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus 3](https://docusaurus.io/), a modern static website generator.
 
-### Installation
+In order to do our TypeDoc includes we've forked the 
+[docusaurus-plugin-typedoc-plugin](https://github.com/excaliburjs/docusaurus-plugin-typedoc-api) and vendor/ it as a submodule
 
+## Local Dev
+
+Be sure the core types have been generated in the root directory
+
+```sh
+> cd .. && npm run build && cd site/
 ```
-$ yarn
+
+Initialize the submodule for the typedoc plugin
+
+```sh
+> git submodule init
+> git submodule update
 ```
 
-### Local Development
+NPM install and run the dev server
 
+```sh
+> npm install
+> npm run start
 ```
-$ yarn start
-```
-
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
 
-#### Playground integration
+### Playground integration
 
 While working on the docs locally, you may want to also use a local version of the Playground. 
 This is easily achieved with the `PLAYGROUND_URL` environment variable. 
@@ -40,29 +51,3 @@ Run the site as usual:
 npm start
 ```
  
-
-
-
-### Build
-
-```
-$ yarn build
-```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-### Deployment
-
-Using SSH:
-
-```
-$ USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.

--- a/site/docs/09-math/07-vector.mdx
+++ b/site/docs/09-math/07-vector.mdx
@@ -4,43 +4,52 @@ slug: /vector
 section: Math
 ---
 
+Excalibur provides three vector types to handle spatial math:
+* **[[Vector]]**: 2D vectors for positioning, velocities, and physics on a plane.
+* **[[Vector3]]**: 3D vectors commonly used for spatial transforms, lighting, and shader uniforms.
+* **[[Vector4]]**: 4D vectors primary used for homogeneous coordinates, WebGL shaders, and matrix transformations.
+
 Excalibur uses the [[Vector]] structure to represent points. The [[Vector]] class has many different static methods available for doing vector math as well as instance methods to combine vectors together in different ways.
 
-## Creating vectors
+## Creating Vectors
 
-To quickly create a vector, use the [[vec]] global:
+To quickly create vectors, use the global shorthand functions [[vec]], [[vec3]], or [[vec4]]:
 
 ```ts twoslash
-import { vec } from 'excalibur'
+import { vec, vec3, vec4 } from 'excalibur'
 
-const point = vec(0, 10)
+const point2D = vec(0, 10)
+const point3D = vec3(0, 10, 5)
+const point4D = vec4(0, 10, 5, 1)
 ```
 
 Alternatively, you may see examples of using the more verbose `new Vector(x, y)` format:
 
 ```ts twoslash
-import { Vector } from 'excalibur'
+import { Vector, Vector3, Vector4 } from 'excalibur'
 
-const point = new Vector(0, 10)
+const point2D = new Vector(0, 10)
+const point3D = new Vector3(0, 10, 5)
+const point4D = new Vector4(0, 10, 5, 1)
 ```
 
 To set the value of an existing vector, use [[Vector.setTo]]:
 
 ```ts twoslash
-import { vec } from 'excalibur'
+import { vec, vec3, vec4 } from 'excalibur'
 
-const point = vec(0, 10).setTo(10, 10)
+const point2D = vec(0, 10).setTo(10, 10)
+const point3D = vec3(0, 10, 0).setTo(10, 10, 10)
+const point4D = vec4(0, 0, 0, 0).setTo(10, 10, 10, 1)
 ```
 
-There are some built-in vector constants you can use:
+Each vector class provides built-in constants for common directional and utility vectors:
 
-- [[Vector.Zero]]
-- [[Vector.One]]
-- [[Vector.Half]]
-- [[Vector.Left]]
-- [[Vector.Right]]
-- [[Vector.Up]]
-- [[Vector.Down]]
+| Feature | Constants Available |
+| :--- | :--- | 
+| **[[Vector]]** | `Zero, One, Half, Left, Right, Up, Down` |
+| **[[Vector3]]** | `Zero, One, Left, Right, Up, Down, Forward, Back` |
+| **[[Vector4]]** | `Zero, One` |
 
 ## Cloning vectors
 
@@ -73,7 +82,7 @@ This is intentional to avoid confusion about whether you are mutating the vector
 
 ## Linear interpolation (lerp) between vectors
 
-[[Vector.lerp|Lerp]] returns a new vector that represents a point along the line between two vectors. Given a number between 0 and 1 (representing the percentage of progress) and a target vector, it produces the intermediate vector at that fraction of the distance.
+All vector classes support lerp, which returns a new vector representing a point along the path between two vectors. Given a target vector and an interpolation factor t between 0 and 1, it produces the intermediate vector.
 
 The standard formula for linear interpolation is:
 
@@ -90,3 +99,15 @@ When t = 0, the result is a.
 When t = 1, the result is b.
 
 When t = 0.5, the result is exactly halfway between a and b.
+
+```ts twoslash
+import { vec, vec3 } from 'excalibur'
+
+const start2D = vec(0, 0)
+const end2D = vec(100, 200)
+const mid2D = start2D.lerp(end2D, 0.5) // vec(50, 100)
+
+const start3D = vec3(0, 0, 0)
+const end3D = vec3(10, 20, 30)
+const mid3D = start3D.lerp(end3D, 0.5) // vec3(5, 10, 15)
+```

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -2,6 +2,7 @@ import { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import { ThemeConfig as ClassicPresetThemeConfig } from '@docusaurus/preset-classic';
 import path from 'path';
+import ts from 'typescript';
 import webpack from 'webpack';
 import { themes } from 'prism-react-renderer';
 import { remarkApiSymbolLinks } from './plugins/remark-api-symbol-links.mjs';
@@ -22,6 +23,7 @@ const lightCodeTheme = themes.github;
 const darkCodeTheme = themes.dracula;
 
 const typedocProjectRoot = path.join(__dirname, '..', 'src', 'engine');
+const excaliburTypesPath = path.join(__dirname, '..', 'build', 'dist', 'excalibur.d.ts');
 const rehypeRawOptions = {
   passThrough: ['mdxjsEsm', 'mdxJsxTextElement', 'mdxJsxFlowElement', 'mdxFlowExpression']
 };
@@ -104,7 +106,13 @@ const config: Config = {
       'docusaurus-preset-shiki-twoslash',
       {
         themes: ['github-light', 'github-dark'],
-        ignoreCodeblocksWithCodefenceMeta: ['live', 'mermaid']
+        ignoreCodeblocksWithCodefenceMeta: ['live', 'mermaid'],
+        defaultCompilerOptions: {
+          baseUrl: __dirname,
+          paths: { excalibur: [excaliburTypesPath] },
+          moduleResolution: ts.ModuleResolutionKind.Bundler,
+          module: ts.ModuleKind.ESNext
+        }
       }
     ]
   ],
@@ -291,96 +299,3 @@ const config: Config = {
 };
 
 export default config;
-
-// function getTypedocJson() {
-//   try {
-//     return JSON.parse(require('fs').readFileSync(path.join(__dirname, '.docusaurus', 'api-typedoc-default.json'), 'utf8'));
-//   } catch {
-//     return null;
-//   }
-// }
-
-// function buildSymbolLink(symbolPath: string, basePath: string, symbolLinkIndex: Map<string, [string, ReflectionKind][]>) {
-//   let symbolLink = undefined;
-//   const SYMBOL_CONTAINERS = [
-//     ReflectionKind.Project,
-//     ReflectionKind.Class,
-//     ReflectionKind.Interface,
-//     ReflectionKind.Enum,
-//     ReflectionKind.Module,
-//     ReflectionKind.SomeModule,
-//     ReflectionKind.Namespace
-//   ];
-//   const symbolMatches = symbolLinkIndex.get(symbolPath) ?? [];
-//   basePath = ensureTrailingSlash(basePath);
-//
-//   if (symbolMatches && symbolMatches.length) {
-//     const lastContainer = symbolMatches
-//       .concat([])
-//       .reverse()
-//       .find(([, kind]) => SYMBOL_CONTAINERS.includes(kind)) || [undefined, undefined];
-//     const moduleContainer = symbolMatches.find(([, kind]) => kind === ReflectionKind.SomeModule || kind === ReflectionKind.Module || kind === ReflectionKind.Namespace);
-//     let [, containerKind] = lastContainer;
-//
-//     if (moduleContainer) {
-//       containerKind = moduleContainer[1];
-//     }
-//
-//     let containerPath;
-//
-//     switch (containerKind) {
-//       case ReflectionKind.SomeModule:
-//       case ReflectionKind.Module:
-//       case ReflectionKind.Namespace:
-//         containerPath = 'namespace/';
-//         break;
-//       case ReflectionKind.Class:
-//         containerPath = 'class/';
-//         break;
-//       case ReflectionKind.Interface:
-//         containerPath = 'interface/';
-//         break;
-//       case ReflectionKind.Enum:
-//         containerPath = 'enum/';
-//         break;
-//       default:
-//         containerPath = '';
-//     }
-//
-//     // assemble file url
-//     symbolLink = symbolMatches.reduce((path, [matchSymbolName, matchSymbolKind]) => {
-//       switch (matchSymbolKind) {
-//         case ReflectionKind.Project:
-//           break;
-//         case ReflectionKind.SomeModule:
-//         case ReflectionKind.Module:
-//         case ReflectionKind.Namespace:
-//           path = path.replace(/class\//gi, 'namespace/');
-//           path += matchSymbolName.replace(/[^a-z0-9]/gi, '_') + '#';
-//           break;
-//         case ReflectionKind.Class:
-//         case ReflectionKind.Interface:
-//         case ReflectionKind.Enum:
-//           path += matchSymbolName;
-//           break;
-//         case ReflectionKind.Function:
-//           path += 'function/' + matchSymbolName;
-//           break;
-//         default:
-//           path += '#' + matchSymbolName;
-//           break;
-//       }
-//
-//       return path;
-//     }, basePath + containerPath);
-//   }
-//
-//   return symbolLink;
-// }
-
-// function ensureTrailingSlash(path: string) {
-//   if (!path.endsWith('/')) {
-//     return path + '/';
-//   }
-//   return path;
-// }

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -19267,7 +19267,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
       "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
-      "bin": "./bin/svgo",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",
@@ -19277,6 +19276,9 @@
         "csso": "^5.0.5",
         "picocolors": "^1.0.0",
         "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/site/package.json
+++ b/site/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "docusaurus": "docusaurus",
     "start": "npm run build:docusaurus-plugin-typedoc-api && npm run api:generate && docusaurus start",
     "build": "npm run build:docusaurus-plugin-typedoc-api && npm run api:generate && mkdir .docusaurus && cp -r generated/ .docusaurus/generated/ && docusaurus build",
     "build:docusaurus-plugin-typedoc-api": "cd vendor/docusaurus-plugin-typedoc-api && rimraf lib && tsc -p tsconfig.build.json && cp src/components/styles.css lib/components/ && cd ../..",

--- a/src/engine/graphics/context/shader.ts
+++ b/src/engine/graphics/context/shader.ts
@@ -1,4 +1,4 @@
-import type { ExcaliburGraphicsContext, ImageSource, TextureLoader } from '../..';
+import type { ExcaliburGraphicsContext, ImageSource, TextureLoader, Vector3, Vector4 } from '../..';
 import {
   AffineMatrix,
   Color,
@@ -16,7 +16,16 @@ import { getAttributeComponentSize, getAttributePointerType } from './webgl-util
 
 export type UniformDictionary = Record<
   string,
-  number | boolean | Vector | Color | AffineMatrix | Matrix | Float32Array | [uniformData: Float32Array, bindingPoint: number]
+  | number
+  | boolean
+  | Vector
+  | Vector3
+  | Vector4
+  | Color
+  | AffineMatrix
+  | Matrix
+  | Float32Array
+  | [uniformData: Float32Array, bindingPoint: number]
 >;
 /*
  * List of the possible glsl uniform types
@@ -884,6 +893,49 @@ export class Shader {
    */
   trySetUniformFloatVector(name: string, value: Vector): boolean {
     return this.trySetUniform('uniform2f', name, value.x, value.y);
+  }
+
+  /**
+   * Set a {@apilink Vector} uniform for the current shader
+   * **Important** Must call ex.Shader.use() before setting a uniform!
+   * @param name
+   * @param value
+   */
+
+  setUniformFloatVector3(name: string, value: Vector3): void {
+    this.setUniform('uniform3f', name, value.x, value.y, value.z);
+  }
+
+  /**
+   * Set a {@apilink Vector} uniform for the current shader, WILL NOT THROW on error.
+   * **Important** Must call ex.Shader.use() before setting a uniform!
+   * @param name
+   * @param value
+   * @returns
+   */
+  trySetUniformFloatVector3(name: string, value: Vector3): boolean {
+    return this.trySetUniform('uniform3f', name, value.x, value.y, value.z);
+  }
+
+  /**
+   * Set a {@apilink Vector} uniform for the current shader
+   * **Important** Must call ex.Shader.use() before setting a uniform!
+   * @param name
+   * @param value
+   */
+  setUniformFloatVector4(name: string, value: Vector4): void {
+    this.setUniform('uniform4f', name, value.x, value.y, value.z, value.w);
+  }
+
+  /**
+   * Set a {@apilink Vector} uniform for the current shader, WILL NOT THROW on error.
+   * **Important** Must call ex.Shader.use() before setting a uniform!
+   * @param name
+   * @param value
+   * @returns
+   */
+  trySetUniformFloatVector4(name: string, value: Vector4): boolean {
+    return this.trySetUniform('uniform4f', name, value.x, value.y, value.z, value.w);
   }
 
   /**

--- a/src/engine/graphics/context/shader.ts
+++ b/src/engine/graphics/context/shader.ts
@@ -1,4 +1,4 @@
-import type { ExcaliburGraphicsContext, ImageSource, TextureLoader, Vector3, Vector4 } from '../..';
+import type { ExcaliburGraphicsContext, ImageSource, TextureLoader } from '../..';
 import {
   AffineMatrix,
   Color,
@@ -7,7 +7,9 @@ import {
   Logger,
   parseImageFiltering,
   parseImageWrapping,
-  Vector
+  Vector,
+  Vector3,
+  Vector4
 } from '../..';
 import { Matrix } from '../../math/matrix';
 import { watch } from '../../util/watch';
@@ -479,6 +481,20 @@ export class Shader {
           this.trySetUniform('uniform4f', key, value.x, value.y, 0, 0);
         } else {
           this.trySetUniformFloatVector(key, value);
+        }
+      } else if (value instanceof Vector3) {
+        if (uniform?.glType === gl.FLOAT_VEC3) {
+          this.trySetUniform('uniform3f', key, value.x, value.y, value.z);
+        } else if (uniform?.glType === gl.FLOAT_VEC4) {
+          this.trySetUniform('uniform4f', key, value.x, value.y, value.z, 0);
+        } else {
+          this.trySetUniformFloatVector3(key, value);
+        }
+      } else if (value instanceof Vector4) {
+        if (uniform?.glType === gl.FLOAT_VEC4) {
+          this.trySetUniform('uniform4f', key, value.x, value.y, value.z, value.w);
+        } else {
+          this.trySetUniformFloatVector4(key, value);
         }
       } else if (value instanceof Color) {
         this.trySetUniformFloatColor(key, value);

--- a/src/engine/graphics/context/shader.ts
+++ b/src/engine/graphics/context/shader.ts
@@ -923,7 +923,7 @@ export class Shader {
   }
 
   /**
-   * Set a {@apilink Vector} uniform for the current shader, WILL NOT THROW on error.
+   * Set a {@apilink Vector3} uniform for the current shader, WILL NOT THROW on error.
    * **Important** Must call ex.Shader.use() before setting a uniform!
    * @param name
    * @param value
@@ -934,7 +934,7 @@ export class Shader {
   }
 
   /**
-   * Set a {@apilink Vector} uniform for the current shader
+   * Set a {@apilink Vector4} uniform for the current shader
    * **Important** Must call ex.Shader.use() before setting a uniform!
    * @param name
    * @param value
@@ -944,7 +944,7 @@ export class Shader {
   }
 
   /**
-   * Set a {@apilink Vector} uniform for the current shader, WILL NOT THROW on error.
+   * Set a {@apilink Vector4} uniform for the current shader, WILL NOT THROW on error.
    * **Important** Must call ex.Shader.use() before setting a uniform!
    * @param name
    * @param value

--- a/src/engine/graphics/context/shader.ts
+++ b/src/engine/graphics/context/shader.ts
@@ -896,7 +896,7 @@ export class Shader {
   }
 
   /**
-   * Set a {@apilink Vector} uniform for the current shader
+   * Set a {@apilink Vector3} uniform for the current shader
    * **Important** Must call ex.Shader.use() before setting a uniform!
    * @param name
    * @param value

--- a/src/engine/math/affine-matrix.ts
+++ b/src/engine/math/affine-matrix.ts
@@ -1,6 +1,7 @@
 import { Matrix } from './matrix';
 import { canonicalizeAngle, sign } from './util';
 import { vec, Vector } from './vector';
+import { Vector3 } from './vector3';
 
 export class AffineMatrix {
   /**
@@ -204,6 +205,12 @@ export class AffineMatrix {
    * @param vector
    * @param dest
    */
+  multiply(vector: Vector3, dest?: Vector3): Vector3;
+  /**
+   * Multiply the current matrix by a vector producing a new vector
+   * @param vector
+   * @param dest
+   */
   multiply(vector: Vector, dest?: Vector): Vector;
   /**
    * Multiply the current matrix by another matrix producing a new matrix
@@ -211,7 +218,7 @@ export class AffineMatrix {
    * @param dest
    */
   multiply(matrix: AffineMatrix, dest?: AffineMatrix): AffineMatrix;
-  multiply(vectorOrMatrix: Vector | AffineMatrix, dest?: Vector | AffineMatrix): Vector | AffineMatrix {
+  multiply(vectorOrMatrix: Vector | Vector3 | AffineMatrix, dest?: Vector | Vector3 | AffineMatrix): Vector | Vector3 | AffineMatrix {
     if (vectorOrMatrix instanceof Vector) {
       const result = (dest as Vector) || new Vector(0, 0);
       const vector = vectorOrMatrix;
@@ -221,6 +228,19 @@ export class AffineMatrix {
 
       result.x = resultX;
       result.y = resultY;
+      return result;
+    } else if (vectorOrMatrix instanceof Vector3) {
+      const result = (dest as Vector3) || new Vector3(0, 0, 0);
+      const vector = vectorOrMatrix;
+      // these shenanigans are to allow dest and vector to be the same instance
+      const resultX = vector.x * this.data[0] + vector.y * this.data[2] + vector.z * this.data[4];
+      const resultY = vector.x * this.data[1] + vector.y * this.data[3] + vector.z * this.data[5];
+      // last row is always assumed [0, 0, 1]
+      const resultZ = vector.z;
+
+      result.x = resultX;
+      result.y = resultY;
+      result.z = resultZ;
       return result;
     } else {
       const result = (dest as AffineMatrix) || new AffineMatrix();

--- a/src/engine/math/index.ts
+++ b/src/engine/math/index.ts
@@ -15,3 +15,5 @@ export * from './util';
 export * from './rotation-type';
 export * from './graph';
 export * from './easings';
+export * from './vector3';
+export * from './vector4';

--- a/src/engine/math/matrix.ts
+++ b/src/engine/math/matrix.ts
@@ -1,6 +1,8 @@
 import { sign } from './util';
 import { Vector, vec } from './vector';
 import { canonicalizeAngle } from './util';
+import { vec3, Vector3 } from './vector3';
+import { vec4, Vector4 } from './vector4';
 
 export enum MatrixLocations {
   X = 12,
@@ -171,6 +173,32 @@ export class Matrix {
   }
 
   /**
+   * Creates a brand new translation matrix at the specified 3d point
+   * @param vec
+   */
+  public static translation3d(vec: Vector3): Matrix {
+    const mat = Matrix.identity();
+    mat.data[12] = vec.x;
+    mat.data[13] = vec.y;
+    mat.data[14] = vec.z;
+    return mat;
+  }
+
+  /**
+   * Creates a brand new translation matrix at the specified 4d point
+   * @param vec
+   *
+   */
+  public static translation4d(vec: Vector4): Matrix {
+    const mat = Matrix.identity();
+    mat.data[12] = vec.x;
+    mat.data[13] = vec.y;
+    mat.data[14] = vec.z;
+    mat.data[15] = vec.w;
+    return mat;
+  }
+
+  /**
    * Creates a brand new scaling matrix with the specified scaling factor
    * @param sx
    * @param sy
@@ -209,7 +237,22 @@ export class Matrix {
    * @param dest
    */
   multiply(matrix: Matrix, dest?: Matrix): Matrix;
-  multiply(vectorOrMatrix: Vector | Matrix, dest?: Vector | Matrix): Vector | Matrix {
+  /**
+   * Multiply the current matrix by a 4D vector producing a new 4D vector
+   * @param vector
+   * @param dest
+   */
+  multiply(vector: Vector4, dest?: Vector4): Vector4;
+  /**
+   * Multiply the current matrix by a 3D vector producing a new 3D vector
+   * @param vector
+   * @param dest
+   */
+  multiply(vector: Vector3, dest?: Vector3): Vector3;
+  multiply(
+    vectorOrMatrix: Vector | Vector3 | Vector4 | Matrix,
+    dest?: Vector | Vector3 | Vector4 | Matrix
+  ): Vector | Vector3 | Vector4 | Matrix {
     if (vectorOrMatrix instanceof Vector) {
       const result = (dest as Vector) || new Vector(0, 0);
       const vector = vectorOrMatrix;
@@ -220,7 +263,33 @@ export class Matrix {
       result.x = resultX;
       result.y = resultY;
       return result;
+    } else if (vectorOrMatrix instanceof Vector3) {
+      const result = (dest as Vector3) || vec3(0, 0, 0);
+      const vector = vectorOrMatrix;
+      // Treats Vector3 as a 3D point (w = 1.0)
+      const resultX = vector.x * this.data[0] + vector.y * this.data[4] + vector.z * this.data[8] + this.data[12];
+      const resultY = vector.x * this.data[1] + vector.y * this.data[5] + vector.z * this.data[9] + this.data[13];
+      const resultZ = vector.x * this.data[2] + vector.y * this.data[6] + vector.z * this.data[10] + this.data[14];
+
+      result.x = resultX;
+      result.y = resultY;
+      result.z = resultZ;
+      return result;
+    } else if (vectorOrMatrix instanceof Vector4) {
+      const result = (dest as Vector4) || vec4(0, 0, 0, 0);
+      const vector = vectorOrMatrix;
+      const resultX = vector.x * this.data[0] + vector.y * this.data[4] + vector.z * this.data[8] + vector.w * this.data[12];
+      const resultY = vector.x * this.data[1] + vector.y * this.data[5] + vector.z * this.data[9] + vector.w * this.data[13];
+      const resultZ = vector.x * this.data[2] + vector.y * this.data[6] + vector.z * this.data[10] + vector.w * this.data[14];
+      const resultW = vector.x * this.data[3] + vector.y * this.data[7] + vector.z * this.data[11] + vector.w * this.data[15];
+
+      result.x = resultX;
+      result.y = resultY;
+      result.z = resultZ;
+      result.w = resultW;
+      return result;
     } else {
+      // Matrix
       const result = (dest as Matrix) || new Matrix();
       const other = vectorOrMatrix;
       const a11 = this.data[0];

--- a/src/engine/math/vector.ts
+++ b/src/engine/math/vector.ts
@@ -463,6 +463,8 @@ export class Vector implements Clonable<Vector> {
   /**
    * Copies components out into an array or Float32Array
    */
+  public toArray(dest?: number[], offset?: number): number[];
+  public toArray(dest: Float32Array, offset?: number): Float32Array;
   public toArray(dest: number[] | Float32Array = [], offset = 0): number[] | Float32Array {
     dest[offset] = this.x;
     dest[offset + 1] = this.y;

--- a/src/engine/math/vector.ts
+++ b/src/engine/math/vector.ts
@@ -459,6 +459,22 @@ export class Vector implements Clonable<Vector> {
     newVector.y = this.y + (target.y - this.y) * t;
     return newVector;
   }
+
+  /**
+   * Copies components out into an array or Float32Array
+   */
+  public toArray(dest: number[] | Float32Array = [], offset = 0): number[] | Float32Array {
+    dest[offset] = this.x;
+    dest[offset + 1] = this.y;
+    return dest;
+  }
+
+  /**
+   * Converts to a Float32Array suitable for WebGL uniforms
+   */
+  public toFloat32Array(): Float32Array {
+    return new Float32Array([this.x, this.y]);
+  }
 }
 
 /**

--- a/src/engine/math/vector3.ts
+++ b/src/engine/math/vector3.ts
@@ -40,17 +40,17 @@ export class Vector3 implements Clonable<Vector3> {
   }
 
   /**
-   * A unit vector pointing up (0, 1, 0)
+   * A unit vector pointing up (0, -1, 0)
    */
   public static get Up() {
-    return new Vector3(0, 1, 0);
+    return new Vector3(0, -1, 0);
   }
 
   /**
-   * A unit vector pointing down (0, -1, 0)
+   * A unit vector pointing down (0, 1, 0)
    */
   public static get Down() {
-    return new Vector3(0, -1, 0);
+    return new Vector3(0, 1, 0);
   }
 
   /**

--- a/src/engine/math/vector3.ts
+++ b/src/engine/math/vector3.ts
@@ -1,0 +1,375 @@
+// vector3.ts
+import type { Clonable } from '../interfaces/clonable';
+import { clamp } from './util';
+
+/**
+ * A 3D vector.
+ */
+export class Vector3 implements Clonable<Vector3> {
+  /**
+   * Get or set the vector equals epsilon, by default 0.001 meaning vectors within that tolerance on x, y, or z will be considered equal.
+   */
+  public static EQUALS_EPSILON = 0.001;
+
+  /**
+   * A (0, 0, 0) vector
+   */
+  public static get Zero() {
+    return new Vector3(0, 0, 0);
+  }
+
+  /**
+   * A (1, 1, 1) vector
+   */
+  public static get One() {
+    return new Vector3(1, 1, 1);
+  }
+
+  /**
+   * A unit vector pointing right (1, 0, 0)
+   */
+  public static get Right() {
+    return new Vector3(1, 0, 0);
+  }
+
+  /**
+   * A unit vector pointing left (-1, 0, 0)
+   */
+  public static get Left() {
+    return new Vector3(-1, 0, 0);
+  }
+
+  /**
+   * A unit vector pointing up (0, 1, 0)
+   */
+  public static get Up() {
+    return new Vector3(0, 1, 0);
+  }
+
+  /**
+   * A unit vector pointing down (0, -1, 0)
+   */
+  public static get Down() {
+    return new Vector3(0, -1, 0);
+  }
+
+  /**
+   * A unit vector pointing forward/out (0, 0, 1)
+   */
+  public static get Forward() {
+    return new Vector3(0, 0, 1);
+  }
+
+  /**
+   * A unit vector pointing backward/in (0, 0, -1)
+   */
+  public static get Back() {
+    return new Vector3(0, 0, -1);
+  }
+
+  /**
+   * Checks if vector is not null, undefined, or if any of its components are NaN or Infinity.
+   */
+  public static isValid(vec: Vector3) {
+    if (vec === null || vec === undefined) {
+      return false;
+    }
+    if (isNaN(vec.x) || isNaN(vec.y) || isNaN(vec.z)) {
+      return false;
+    }
+
+    if (
+      vec.x === Infinity ||
+      vec.y === Infinity ||
+      vec.z === Infinity ||
+      vec.x === -Infinity ||
+      vec.y === -Infinity ||
+      vec.z === -Infinity
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Calculates distance between two Vectors
+   */
+  public static distance(vec1: Vector3, vec2: Vector3) {
+    return Math.sqrt(Math.pow(vec1.x - vec2.x, 2) + Math.pow(vec1.y - vec2.y, 2) + Math.pow(vec1.z - vec2.z, 2));
+  }
+
+  public static min(vec1: Vector3, vec2: Vector3) {
+    return new Vector3(Math.min(vec1.x, vec2.x), Math.min(vec1.y, vec2.y), Math.min(vec1.z, vec2.z));
+  }
+
+  public static max(vec1: Vector3, vec2: Vector3) {
+    return new Vector3(Math.max(vec1.x, vec2.x), Math.max(vec1.y, vec2.y), Math.max(vec1.z, vec2.z));
+  }
+
+  /**
+   * Creates a Vector3 from an array [x, y, z]
+   */
+  public static fromArray(array: number[] | Float32Array, offset = 0): Vector3 {
+    return new Vector3(array[offset], array[offset + 1], array[offset + 2]);
+  }
+
+  /**
+   * @param x X component of the Vector
+   * @param y Y component of the Vector
+   * @param z Z component of the Vector
+   */
+  constructor(x: number, y: number, z: number) {
+    this._x = x;
+    this._y = y;
+    this._z = z;
+  }
+
+  protected _x = 0;
+  public get x(): number {
+    return this._x;
+  }
+  public set x(val: number) {
+    this._x = val;
+  }
+
+  protected _y = 0;
+  public get y(): number {
+    return this._y;
+  }
+  public set y(val: number) {
+    this._y = val;
+  }
+
+  protected _z = 0;
+  public get z(): number {
+    return this._z;
+  }
+  public set z(val: number) {
+    this._z = val;
+  }
+
+  /**
+   * Sets the x, y, and z components at once, THIS MUTATES the current vector.
+   */
+  public setTo(x: number, y: number, z: number): void {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  /**
+   * Compares this vector against another and tests for equality
+   */
+  public equals(vector: Vector3, tolerance: number = Vector3.EQUALS_EPSILON): boolean {
+    return Math.abs(this.x - vector.x) <= tolerance && Math.abs(this.y - vector.y) <= tolerance && Math.abs(this.z - vector.z) <= tolerance;
+  }
+
+  /**
+   * The distance to another vector. If no other Vector is specified, this will return magnitude.
+   */
+  public distance(v?: Vector3): number {
+    if (!v) {
+      return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
+    }
+    const deltaX = this.x - v.x;
+    const deltaY = this.y - v.y;
+    const deltaZ = this.z - v.z;
+    return Math.sqrt(deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ);
+  }
+
+  public squareDistance(v?: Vector3): number {
+    if (!v) {
+      v = Vector3.Zero;
+    }
+    const deltaX = this.x - v.x;
+    const deltaY = this.y - v.y;
+    const deltaZ = this.z - v.z;
+    return deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ;
+  }
+
+  /**
+   * Clamps the current vector's magnitude mutating it
+   */
+  public clampMagnitude(magnitude: number): Vector3 {
+    const size = this.magnitude;
+    const newSize = clamp(size, 0, magnitude);
+    this.magnitude = newSize;
+    return this;
+  }
+
+  /**
+   * The magnitude (length) of the Vector
+   */
+  public get magnitude(): number {
+    return this.distance();
+  }
+
+  public set magnitude(newMagnitude: number) {
+    this.normalize().scale(newMagnitude, this);
+  }
+
+  /**
+   * Normalizes a non-zero vector to have a magnitude of 1. Zero vectors return a new zero vector.
+   */
+  public normalize(): Vector3 {
+    const distance = this.distance();
+    if (distance === 0) {
+      return Vector3.Zero;
+    }
+    return new Vector3(this.x / distance, this.y / distance, this.z / distance);
+  }
+
+  /**
+   * Returns the average (midpoint) between the current point and the specified point
+   */
+  public average(vec: Vector3): Vector3 {
+    return this.add(vec).scale(0.5);
+  }
+
+  /**
+   * Scales a vector by a factor or component-wise vector
+   */
+  public scale(scale: Vector3, dest?: Vector3): Vector3;
+  public scale(size: number, dest?: Vector3): Vector3;
+  public scale(sizeOrScale: number | Vector3, dest?: Vector3): Vector3 {
+    const result = dest || new Vector3(0, 0, 0);
+    if (sizeOrScale instanceof Vector3) {
+      result.x = this.x * sizeOrScale.x;
+      result.y = this.y * sizeOrScale.y;
+      result.z = this.z * sizeOrScale.z;
+    } else {
+      result.x = this.x * sizeOrScale;
+      result.y = this.y * sizeOrScale;
+      result.z = this.z * sizeOrScale;
+    }
+    return result;
+  }
+
+  /**
+   * Adds one vector to another
+   */
+  public add(v: Vector3, dest?: Vector3): Vector3 {
+    const result = dest || new Vector3(0, 0, 0);
+    result.x = this.x + v.x;
+    result.y = this.y + v.y;
+    result.z = this.z + v.z;
+    return result;
+  }
+
+  /**
+   * Subtracts a vector from another
+   */
+  public sub(v: Vector3, dest?: Vector3): Vector3 {
+    const result = dest || new Vector3(0, 0, 0);
+    result.x = this.x - v.x;
+    result.y = this.y - v.y;
+    result.z = this.z - v.z;
+    return result;
+  }
+
+  /**
+   * Adds one vector to this one modifying the original
+   */
+  public addEqual(v: Vector3): Vector3 {
+    this.setTo(this.x + v.x, this.y + v.y, this.z + v.z);
+    return this;
+  }
+
+  /**
+   * Subtracts a vector from this one modifying the original
+   */
+  public subEqual(v: Vector3): Vector3 {
+    this.setTo(this.x - v.x, this.y - v.y, this.z - v.z);
+    return this;
+  }
+
+  /**
+   * Scales this vector by a factor and modifies the original
+   */
+  public scaleEqual(size: number): Vector3 {
+    this.setTo(this.x * size, this.y * size, this.z * size);
+    return this;
+  }
+
+  /**
+   * Performs a dot product with another vector
+   */
+  public dot(v: Vector3): number {
+    return this.x * v.x + this.y * v.y + this.z * v.z;
+  }
+
+  /**
+   * Performs a 3D cross product with another vector
+   */
+  public cross(v: Vector3, dest?: Vector3): Vector3 {
+    const result = dest || new Vector3(0, 0, 0);
+    const x = this.y * v.z - this.z * v.y;
+    const y = this.z * v.x - this.x * v.z;
+    const z = this.x * v.y - this.y * v.x;
+    result.x = x;
+    result.y = y;
+    result.z = z;
+    return result;
+  }
+
+  /**
+   * Negate the current vector
+   */
+  public negate(): Vector3 {
+    return this.scale(-1);
+  }
+
+  /**
+   * Creates new vector that has the same values as the previous.
+   */
+  public clone(dest?: Vector3): Vector3 {
+    const v = dest ?? new Vector3(0, 0, 0);
+    v.x = this.x;
+    v.y = this.y;
+    v.z = this.z;
+    return v;
+  }
+
+  /**
+   * Returns a string representation of the vector.
+   */
+  public toString(fixed?: number): string {
+    if (fixed !== undefined) {
+      return `(${this.x.toFixed(fixed)}, ${this.y.toFixed(fixed)}, ${this.z.toFixed(fixed)})`;
+    }
+    return `(${this.x}, ${this.y}, ${this.z})`;
+  }
+
+  /**
+   * Linearly interpolates between current vector and target vector.
+   */
+  public lerp(target: Vector3, t: number): Vector3 {
+    t = clamp(t, 0, 1);
+    return new Vector3(this.x + (target.x - this.x) * t, this.y + (target.y - this.y) * t, this.z + (target.z - this.z) * t);
+  }
+
+  /**
+   * Copies components out into an array or Float32Array
+   */
+  public toArray(dest: number[] | Float32Array = [], offset = 0): number[] | Float32Array {
+    dest[offset] = this.x;
+    dest[offset + 1] = this.y;
+    dest[offset + 2] = this.z;
+    return dest;
+  }
+
+  /**
+   * Converts to a Float32Array suitable for WebGL uniforms
+   */
+  public toFloat32Array(): Float32Array {
+    return new Float32Array([this.x, this.y, this.z]);
+  }
+}
+
+/**
+ * Shorthand for creating new 3D Vectors
+ */
+export function vec3(x: number, y: number, z: number): Vector3 {
+  return new Vector3(x, y, z);
+}

--- a/src/engine/math/vector3.ts
+++ b/src/engine/math/vector3.ts
@@ -352,6 +352,8 @@ export class Vector3 implements Clonable<Vector3> {
   /**
    * Copies components out into an array or Float32Array
    */
+  public toArray(dest?: number[], offset?: number): number[];
+  public toArray(dest: Float32Array, offset?: number): Float32Array;
   public toArray(dest: number[] | Float32Array = [], offset = 0): number[] | Float32Array {
     dest[offset] = this.x;
     dest[offset + 1] = this.y;

--- a/src/engine/math/vector4.ts
+++ b/src/engine/math/vector4.ts
@@ -1,0 +1,395 @@
+// vector4.ts
+import type { Clonable } from '../interfaces/clonable';
+import type { Matrix } from './matrix';
+import { Vector3 } from './vector3';
+import { clamp } from './util';
+
+/**
+ * A 4D vector, often used for homogeneous coordinates in WebGL shaders and transforms.
+ */
+export class Vector4 implements Clonable<Vector4> {
+  /**
+   * Get or set the vector equals epsilon, by default 0.001 meaning vectors within that tolerance will be considered equal.
+   */
+  public static EQUALS_EPSILON = 0.001;
+
+  /**
+   * A (0, 0, 0, 0) vector
+   */
+  public static get Zero() {
+    return new Vector4(0, 0, 0, 0);
+  }
+
+  /**
+   * A (1, 1, 1, 1) vector
+   */
+  public static get One() {
+    return new Vector4(1, 1, 1, 1);
+  }
+
+  /**
+   * Creates a homogeneous point vector (w = 1) from a Vector3
+   */
+  public static fromPoint(v: Vector3): Vector4 {
+    return new Vector4(v.x, v.y, v.z, 1);
+  }
+
+  /**
+   * Creates a homogeneous direction vector (w = 0) from a Vector3
+   */
+  public static fromDirection(v: Vector3): Vector4 {
+    return new Vector4(v.x, v.y, v.z, 0);
+  }
+
+  /**
+   * Checks if vector is not null, undefined, or if any of its components are NaN or Infinity.
+   */
+  public static isValid(vec: Vector4) {
+    if (vec === null || vec === undefined) {
+      return false;
+    }
+    if (isNaN(vec.x) || isNaN(vec.y) || isNaN(vec.z) || isNaN(vec.w)) {
+      return false;
+    }
+
+    if (
+      vec.x === Infinity ||
+      vec.y === Infinity ||
+      vec.z === Infinity ||
+      vec.w === Infinity ||
+      vec.x === -Infinity ||
+      vec.y === -Infinity ||
+      vec.z === -Infinity ||
+      vec.w === -Infinity
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Calculates distance between two Vectors
+   */
+  public static distance(vec1: Vector4, vec2: Vector4) {
+    return Math.sqrt(
+      Math.pow(vec1.x - vec2.x, 2) + Math.pow(vec1.y - vec2.y, 2) + Math.pow(vec1.z - vec2.z, 2) + Math.pow(vec1.w - vec2.w, 2)
+    );
+  }
+
+  public static min(vec1: Vector4, vec2: Vector4) {
+    return new Vector4(Math.min(vec1.x, vec2.x), Math.min(vec1.y, vec2.y), Math.min(vec1.z, vec2.z), Math.min(vec1.w, vec2.w));
+  }
+
+  public static max(vec1: Vector4, vec2: Vector4) {
+    return new Vector4(Math.max(vec1.x, vec2.x), Math.max(vec1.y, vec2.y), Math.max(vec1.z, vec2.z), Math.max(vec1.w, vec2.w));
+  }
+
+  /**
+   * Creates a Vector4 from an array [x, y, z, w]
+   */
+  public static fromArray(array: number[] | Float32Array, offset = 0): Vector4 {
+    return new Vector4(array[offset], array[offset + 1], array[offset + 2], array[offset + 3]);
+  }
+
+  /**
+   * @param x X component
+   * @param y Y component
+   * @param z Z component
+   * @param w W component
+   */
+  constructor(x: number, y: number, z: number, w: number) {
+    this._x = x;
+    this._y = y;
+    this._z = z;
+    this._w = w;
+  }
+
+  protected _x = 0;
+  public get x(): number {
+    return this._x;
+  }
+  public set x(val: number) {
+    this._x = val;
+  }
+
+  protected _y = 0;
+  public get y(): number {
+    return this._y;
+  }
+  public set y(val: number) {
+    this._y = val;
+  }
+
+  protected _z = 0;
+  public get z(): number {
+    return this._z;
+  }
+  public set z(val: number) {
+    this._z = val;
+  }
+
+  protected _w = 0;
+  public get w(): number {
+    return this._w;
+  }
+  public set w(val: number) {
+    this._w = val;
+  }
+
+  /**
+   * Sets all 4 components at once, THIS MUTATES the current vector.
+   */
+  public setTo(x: number, y: number, z: number, w: number): void {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+    this.w = w;
+  }
+
+  /**
+   * Compares this vector against another and tests for equality
+   */
+  public equals(vector: Vector4, tolerance: number = Vector4.EQUALS_EPSILON): boolean {
+    return (
+      Math.abs(this.x - vector.x) <= tolerance &&
+      Math.abs(this.y - vector.y) <= tolerance &&
+      Math.abs(this.z - vector.z) <= tolerance &&
+      Math.abs(this.w - vector.w) <= tolerance
+    );
+  }
+
+  /**
+   * Distance to another vector or magnitude if omitted
+   */
+  public distance(v?: Vector4): number {
+    if (!v) {
+      return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w);
+    }
+    const deltaX = this.x - v.x;
+    const deltaY = this.y - v.y;
+    const deltaZ = this.z - v.z;
+    const deltaW = this.w - v.w;
+    return Math.sqrt(deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ + deltaW * deltaW);
+  }
+
+  public squareDistance(v?: Vector4): number {
+    if (!v) {
+      v = Vector4.Zero;
+    }
+    const deltaX = this.x - v.x;
+    const deltaY = this.y - v.y;
+    const deltaZ = this.z - v.z;
+    const deltaW = this.w - v.w;
+    return deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ + deltaW * deltaW;
+  }
+
+  /**
+   * Clamps the current vector's magnitude mutating it
+   */
+  public clampMagnitude(magnitude: number): Vector4 {
+    const size = this.magnitude;
+    const newSize = clamp(size, 0, magnitude);
+    this.magnitude = newSize;
+    return this;
+  }
+
+  /**
+   * Magnitude (length) of the Vector
+   */
+  public get magnitude(): number {
+    return this.distance();
+  }
+
+  public set magnitude(newMagnitude: number) {
+    this.normalize().scale(newMagnitude, this);
+  }
+
+  /**
+   * Normalizes a non-zero vector. Zero vectors return a new zero vector.
+   */
+  public normalize(): Vector4 {
+    const distance = this.distance();
+    if (distance === 0) {
+      return Vector4.Zero;
+    }
+    return new Vector4(this.x / distance, this.y / distance, this.z / distance, this.w / distance);
+  }
+
+  /**
+   * Returns midpoint between this and target point
+   */
+  public average(vec: Vector4): Vector4 {
+    return this.add(vec).scale(0.5);
+  }
+
+  /**
+   * Scales vector component-wise or by scalar
+   */
+  public scale(scale: Vector4, dest?: Vector4): Vector4;
+  public scale(size: number, dest?: Vector4): Vector4;
+  public scale(sizeOrScale: number | Vector4, dest?: Vector4): Vector4 {
+    const result = dest || new Vector4(0, 0, 0, 0);
+    if (sizeOrScale instanceof Vector4) {
+      result.x = this.x * sizeOrScale.x;
+      result.y = this.y * sizeOrScale.y;
+      result.z = this.z * sizeOrScale.z;
+      result.w = this.w * sizeOrScale.w;
+    } else {
+      result.x = this.x * sizeOrScale;
+      result.y = this.y * sizeOrScale;
+      result.z = this.z * sizeOrScale;
+      result.w = this.w * sizeOrScale;
+    }
+    return result;
+  }
+
+  /**
+   * Adds one vector to another
+   */
+  public add(v: Vector4, dest?: Vector4): Vector4 {
+    const result = dest || new Vector4(0, 0, 0, 0);
+    result.x = this.x + v.x;
+    result.y = this.y + v.y;
+    result.z = this.z + v.z;
+    result.w = this.w + v.w;
+    return result;
+  }
+
+  /**
+   * Subtracts a vector from another
+   */
+  public sub(v: Vector4, dest?: Vector4): Vector4 {
+    const result = dest || new Vector4(0, 0, 0, 0);
+    result.x = this.x - v.x;
+    result.y = this.y - v.y;
+    result.z = this.z - v.z;
+    result.w = this.w - v.w;
+    return result;
+  }
+
+  /**
+   * Adds one vector to this one modifying the original
+   */
+  public addEqual(v: Vector4): Vector4 {
+    this.setTo(this.x + v.x, this.y + v.y, this.z + v.z, this.w + v.w);
+    return this;
+  }
+
+  /**
+   * Subtracts a vector from this one modifying the original
+   */
+  public subEqual(v: Vector4): Vector4 {
+    this.setTo(this.x - v.x, this.y - v.y, this.z - v.z, this.w - v.w);
+    return this;
+  }
+
+  /**
+   * Scales this vector by a factor and modifies the original
+   */
+  public scaleEqual(size: number): Vector4 {
+    this.setTo(this.x * size, this.y * size, this.z * size, this.w * size);
+    return this;
+  }
+
+  /**
+   * Performs a dot product with another vector
+   */
+  public dot(v: Vector4): number {
+    return this.x * v.x + this.y * v.y + this.z * v.z + this.w * v.w;
+  }
+
+  /**
+   * Negates current vector
+   */
+  public negate(): Vector4 {
+    return this.scale(-1);
+  }
+
+  /**
+   * Transforms this vector using a 4x4 Matrix
+   */
+  public transform(matrix: Matrix, dest?: Vector4): Vector4 {
+    const result = dest ?? new Vector4(0, 0, 0, 0);
+    const d = matrix.data;
+    const x = this.x,
+      y = this.y,
+      z = this.z,
+      w = this.w;
+    result.x = d[0] * x + d[4] * y + d[8] * z + d[12] * w;
+    result.y = d[1] * x + d[5] * y + d[9] * z + d[13] * w;
+    result.z = d[2] * x + d[6] * y + d[10] * z + d[14] * w;
+    result.w = d[3] * x + d[7] * y + d[11] * z + d[15] * w;
+    return result;
+  }
+
+  /**
+   * Projects back down to 3D via perspective divide (x/w, y/w, z/w)
+   */
+  public toVector3(): Vector3 {
+    if (this.w === 0 || this.w === 1) {
+      return new Vector3(this.x, this.y, this.z);
+    }
+    return new Vector3(this.x / this.w, this.y / this.w, this.z / this.w);
+  }
+
+  /**
+   * Creates new vector that has the same values as the previous.
+   */
+  public clone(dest?: Vector4): Vector4 {
+    const v = dest ?? new Vector4(0, 0, 0, 0);
+    v.x = this.x;
+    v.y = this.y;
+    v.z = this.z;
+    v.w = this.w;
+    return v;
+  }
+
+  /**
+   * Returns a string representation of the vector.
+   */
+  public toString(fixed?: number): string {
+    if (fixed !== undefined) {
+      return `(${this.x.toFixed(fixed)}, ${this.y.toFixed(fixed)}, ${this.z.toFixed(fixed)}, ${this.w.toFixed(fixed)})`;
+    }
+    return `(${this.x}, ${this.y}, ${this.z}, ${this.w})`;
+  }
+
+  /**
+   * Linearly interpolates between current vector and target vector.
+   */
+  public lerp(target: Vector4, t: number): Vector4 {
+    t = clamp(t, 0, 1);
+    return new Vector4(
+      this.x + (target.x - this.x) * t,
+      this.y + (target.y - this.y) * t,
+      this.z + (target.z - this.z) * t,
+      this.w + (target.w - this.w) * t
+    );
+  }
+
+  /**
+   * Copies components out into an array or Float32Array
+   */
+  public toArray(dest: number[] | Float32Array = [], offset = 0): number[] | Float32Array {
+    dest[offset] = this.x;
+    dest[offset + 1] = this.y;
+    dest[offset + 2] = this.z;
+    dest[offset + 3] = this.w;
+    return dest;
+  }
+
+  /**
+   * Converts to a Float32Array suitable for WebGL uniforms
+   */
+  public toFloat32Array(): Float32Array {
+    return new Float32Array([this.x, this.y, this.z, this.w]);
+  }
+}
+
+/**
+ * Shorthand for creating new 4D Vectors
+ */
+export function vec4(x: number, y: number, z: number, w: number): Vector4 {
+  return new Vector4(x, y, z, w);
+}

--- a/src/engine/math/vector4.ts
+++ b/src/engine/math/vector4.ts
@@ -371,6 +371,8 @@ export class Vector4 implements Clonable<Vector4> {
   /**
    * Copies components out into an array or Float32Array
    */
+  public toArray(dest?: number[], offset?: number): number[];
+  public toArray(dest: Float32Array, offset?: number): Float32Array;
   public toArray(dest: number[] | Float32Array = [], offset = 0): number[] | Float32Array {
     dest[offset] = this.x;
     dest[offset + 1] = this.y;

--- a/src/spec/vitest/shader-spec.ts
+++ b/src/spec/vitest/shader-spec.ts
@@ -1265,4 +1265,82 @@ void main() {
 
     expect(sut.uniforms.u_affine).toBe(affine);
   });
+
+  it('correctly maps Vector uniforms to FLOAT_VEC2, FLOAT_VEC3, or FLOAT_VEC4 depending on uniform type', () => {
+    const sut = new ex.Shader({
+      graphicsContext,
+      vertexSource: `#version 300 es
+      in vec4 a_position;
+      uniform vec2 u_vec2;
+      uniform vec3 u_vec3;
+      uniform vec4 u_vec4;
+      void main() {
+        gl_Position = a_position + vec4(u_vec2, 0.0, 0.0) + vec4(u_vec3, 0.0) + u_vec4;
+      }`,
+      fragmentSource: `#version 300 es
+      precision mediump float;
+      out vec4 color;
+      void main() {
+        color = vec4(1.0);
+      }`
+    });
+
+    const trySetUniform2fSpy = vi.spyOn(sut, 'trySetUniformFloatVector');
+    const trySetUniformSpy = vi.spyOn(sut, 'trySetUniform');
+
+    const v = ex.vec(10, 20);
+    sut.uniforms = {
+      u_vec2: v,
+      u_vec3: v,
+      u_vec4: v
+    };
+
+    sut.compile();
+    sut.use();
+
+    expect(trySetUniform2fSpy).toHaveBeenCalledWith('u_vec2', v);
+    expect(trySetUniformSpy).toHaveBeenCalledWith('uniform3f', 'u_vec3', 10, 20, 0);
+    expect(trySetUniformSpy).toHaveBeenCalledWith('uniform4f', 'u_vec4', 10, 20, 0, 0);
+  });
+
+  it('supports setting Vector values as vec3 or vec4 explicitly', () => {
+    const sut = new ex.Shader({
+      graphicsContext,
+      vertexSource: `#version 300 es
+      in vec4 a_position;
+      uniform vec3 u_vec3;
+      uniform vec4 u_vec4;
+      void main() {
+        gl_Position = a_position + vec4(u_vec3, 0.0) + u_vec4;
+      }`,
+      fragmentSource: `#version 300 es
+      precision mediump float;
+      out vec4 color;
+      void main() {
+        color = vec4(1.0);
+      }`
+    });
+
+    sut.compile();
+    sut.use();
+
+    const uniform3fSpy = vi.spyOn(gl, 'uniform3f');
+    const uniform4fSpy = vi.spyOn(gl, 'uniform4f');
+
+    const v = ex.vec3(5, 10, 15);
+    const v4 = ex.vec4(5, 10, 15, 20);
+
+    // Test explicit vector methods directly
+    sut.setUniformFloatVector3('u_vec3', v);
+    expect(uniform3fSpy).toHaveBeenCalledWith(expect.anything(), 5, 10, 15);
+
+    sut.trySetUniformFloatVector3('u_vec3', v);
+    expect(uniform3fSpy).toHaveBeenCalledWith(expect.anything(), 5, 10, 15);
+
+    sut.setUniformFloatVector4('u_vec4', v4);
+    expect(uniform4fSpy).toHaveBeenCalledWith(expect.anything(), 5, 10, 15, 20);
+
+    sut.trySetUniformFloatVector4('u_vec4', v4);
+    expect(uniform4fSpy).toHaveBeenCalledWith(expect.anything(), 5, 10, 15, 20);
+  });
 });

--- a/src/spec/vitest/vector3-spec.ts
+++ b/src/spec/vitest/vector3-spec.ts
@@ -36,8 +36,8 @@ describe('Vector3', () => {
     expect(ex.Vector3.One.equals(new ex.Vector3(1, 1, 1))).toBeTruthy();
     expect(ex.Vector3.Right.equals(new ex.Vector3(1, 0, 0))).toBeTruthy();
     expect(ex.Vector3.Left.equals(new ex.Vector3(-1, 0, 0))).toBeTruthy();
-    expect(ex.Vector3.Up.equals(new ex.Vector3(0, 1, 0))).toBeTruthy();
-    expect(ex.Vector3.Down.equals(new ex.Vector3(0, -1, 0))).toBeTruthy();
+    expect(ex.Vector3.Up.equals(new ex.Vector3(0, -1, 0))).toBeTruthy();
+    expect(ex.Vector3.Down.equals(new ex.Vector3(0, 1, 0))).toBeTruthy();
     expect(ex.Vector3.Forward.equals(new ex.Vector3(0, 0, 1))).toBeTruthy();
     expect(ex.Vector3.Back.equals(new ex.Vector3(0, 0, -1))).toBeTruthy();
   });

--- a/src/spec/vitest/vector3-spec.ts
+++ b/src/spec/vitest/vector3-spec.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest';
+import * as ex from '@excalibur';
+
+describe('Vector3', () => {
+  it('should exist', () => {
+    expect(ex.Vector3).toBeDefined();
+  });
+
+  it('can be instantiated', () => {
+    const v = new ex.Vector3(20, 200, 50);
+    expect(v).not.toBeNull();
+  });
+
+  it('can have values set', () => {
+    const v = new ex.Vector3(20, 200, 50);
+
+    expect(v.x).toEqual(20);
+    expect(v.y).toEqual(200);
+    expect(v.z).toEqual(50);
+
+    v.setTo(200, 20, 10);
+
+    expect(v.x).toEqual(200);
+    expect(v.y).toEqual(20);
+    expect(v.z).toEqual(10);
+
+    v.setTo(0, 0, 0);
+
+    expect(v.x).toEqual(0);
+    expect(v.y).toEqual(0);
+    expect(v.z).toEqual(0);
+  });
+
+  it('has static direction and zero constants', () => {
+    expect(ex.Vector3.Zero.equals(new ex.Vector3(0, 0, 0))).toBeTruthy();
+    expect(ex.Vector3.One.equals(new ex.Vector3(1, 1, 1))).toBeTruthy();
+    expect(ex.Vector3.Right.equals(new ex.Vector3(1, 0, 0))).toBeTruthy();
+    expect(ex.Vector3.Left.equals(new ex.Vector3(-1, 0, 0))).toBeTruthy();
+    expect(ex.Vector3.Up.equals(new ex.Vector3(0, 1, 0))).toBeTruthy();
+    expect(ex.Vector3.Down.equals(new ex.Vector3(0, -1, 0))).toBeTruthy();
+    expect(ex.Vector3.Forward.equals(new ex.Vector3(0, 0, 1))).toBeTruthy();
+    expect(ex.Vector3.Back.equals(new ex.Vector3(0, 0, -1))).toBeTruthy();
+  });
+
+  it('can test against equality within tolerance', () => {
+    const v = new ex.Vector3(20, 20, 20);
+
+    expect(v.equals(v.add(new ex.Vector3(0.0005, 0.0005, 0.0005)))).toBeTruthy();
+    expect(v.equals(ex.Vector3.Zero)).not.toBeTruthy();
+  });
+
+  it('can calculate distance to origin', () => {
+    const v = new ex.Vector3(20, 0, 0);
+    const v2 = new ex.Vector3(0, -20, 0);
+    const v3 = new ex.Vector3(0, 0, 20);
+
+    expect(v.distance()).toBe(20);
+    expect(v2.distance()).toBe(20);
+    expect(v3.distance()).toBe(20);
+  });
+
+  it('can have a magnitude', () => {
+    const v = new ex.Vector3(20, 0, 0);
+    const v2 = new ex.Vector3(2, 3, 6);
+
+    expect(v.magnitude).toBe(20);
+    expect(v2.magnitude).toBe(7);
+  });
+
+  it('can have magnitude set', () => {
+    const v = new ex.Vector3(20, 0, 0);
+    const v2 = new ex.Vector3(2, 3, 6);
+
+    v.magnitude = 10;
+    v2.magnitude = 14;
+
+    expect(v.equals(new ex.Vector3(10, 0, 0))).toBeTruthy();
+    expect(v2.equals(new ex.Vector3(4, 6, 12))).toBeTruthy();
+  });
+
+  it('can calculate the distance to another vector', () => {
+    const v = new ex.Vector3(-10, 0, 0);
+    const v2 = new ex.Vector3(10, 0, 0);
+    expect(v.distance(v2)).toBe(20);
+  });
+
+  it('can calculate the distance between two vectors', () => {
+    const v1 = new ex.Vector3(-10, 0, 0);
+    const v2 = new ex.Vector3(10, 0, 0);
+    expect(ex.Vector3.distance(v1, v2)).toBe(20);
+  });
+
+  it('can be normalized to a length of 1', () => {
+    const v = new ex.Vector3(10, 0, 0);
+
+    expect(v.distance()).toBe(10);
+    expect(v.normalize().distance()).toBe(1);
+  });
+
+  it('can be scaled', () => {
+    const v = new ex.Vector3(10, 0, 0);
+
+    expect(v.distance()).toBe(10);
+    expect(v.scale(10).distance()).toBe(100);
+
+    const scaledVector = v.scale(new ex.Vector3(2, 3, 4));
+    expect(scaledVector.equals(new ex.Vector3(20, 0, 0))).toBeTruthy();
+  });
+
+  it('can be added to another', () => {
+    const v = new ex.Vector3(10, 0, 5);
+    const v2 = new ex.Vector3(0, 10, 5);
+
+    expect(v.add(v2).equals(new ex.Vector3(10, 10, 10))).toBeTruthy();
+  });
+
+  it('can be subtracted from another', () => {
+    const v = new ex.Vector3(10, 0, 5);
+    const v2 = new ex.Vector3(0, 10, 2);
+
+    expect(v.sub(v2).equals(new ex.Vector3(10, -10, 3))).toBeTruthy();
+  });
+
+  it('can be added and set at the same time', () => {
+    const v = new ex.Vector3(10, 0, 1);
+    const v2 = new ex.Vector3(0, 10, 2);
+
+    v.addEqual(v2);
+
+    expect(v.x).toBe(10);
+    expect(v.y).toBe(10);
+    expect(v.z).toBe(3);
+  });
+
+  it('can be subtracted and set at the same time', () => {
+    const v = new ex.Vector3(10, 0, 5);
+    const v2 = new ex.Vector3(0, 10, 2);
+
+    v.subEqual(v2);
+
+    expect(v.x).toBe(10);
+    expect(v.y).toBe(-10);
+    expect(v.z).toBe(3);
+  });
+
+  it('can be scaled and set at the same time', () => {
+    const v = new ex.Vector3(10, 2, 3);
+
+    v.scaleEqual(10);
+
+    expect(v.x).toBe(100);
+    expect(v.y).toBe(20);
+    expect(v.z).toBe(30);
+  });
+
+  it('can be negated', () => {
+    const v = new ex.Vector3(10, -5, 2);
+    expect(v.negate().equals(new ex.Vector3(-10, 5, -2))).toBeTruthy();
+  });
+
+  it('can be dotted with another 3d vector', () => {
+    const v = new ex.Vector3(1, 0, 0);
+    const v2 = new ex.Vector3(-1, 0, 0);
+    const v3 = new ex.Vector3(0, 1, 0);
+
+    expect(v.dot(v2)).toBeLessThan(0);
+    expect(v.dot(v2.negate())).toBeGreaterThan(0);
+    expect(v.dot(v3)).toBe(0);
+  });
+
+  it('can perform 3D cross product correctly', () => {
+    const xAxis = new ex.Vector3(1, 0, 0);
+    const yAxis = new ex.Vector3(0, 1, 0);
+
+    const zAxis = xAxis.cross(yAxis);
+    expect(zAxis.equals(new ex.Vector3(0, 0, 1))).toBeTruthy();
+
+    const dest = new ex.Vector3(0, 0, 0);
+    yAxis.cross(xAxis, dest);
+    expect(dest.equals(new ex.Vector3(0, 0, -1))).toBeTruthy();
+  });
+
+  it('can convert to and from array structures', () => {
+    const v = new ex.Vector3(1, 2, 3);
+    const arr = v.toArray();
+    expect(arr).toEqual([1, 2, 3]);
+
+    const f32 = v.toFloat32Array();
+    expect(f32).toBeInstanceOf(Float32Array);
+    expect(f32[0]).toBe(1);
+    expect(f32[1]).toBe(2);
+    expect(f32[2]).toBe(3);
+
+    const restored = ex.Vector3.fromArray([10, 20, 30, 40], 1);
+    expect(restored.equals(new ex.Vector3(20, 30, 40))).toBeTruthy();
+  });
+
+  it('can be checked for validity', () => {
+    expect(ex.Vector3.isValid(new ex.Vector3(Infinity, 0, 0))).toBe(false);
+    expect(ex.Vector3.isValid(new ex.Vector3(0, NaN, 0))).toBe(false);
+    expect(ex.Vector3.isValid(null as any)).toBe(false);
+    expect(ex.Vector3.isValid(undefined as any)).toBe(false);
+    expect(ex.Vector3.isValid(new ex.Vector3(1, 2, 3))).toBe(true);
+  });
+
+  it('can be cloned', () => {
+    const v = new ex.Vector3(1, 2, 3);
+    const c = v.clone();
+
+    expect(c.x).toBe(v.x);
+    expect(c.y).toBe(v.y);
+    expect(c.z).toBe(v.z);
+
+    v.setTo(20, 20, 20);
+
+    expect(c.x).not.toBe(v.x);
+  });
+
+  it('can be printed toString(fixed)', () => {
+    const v = new ex.Vector3(1.2345, 2.345, 3.4567);
+    expect(v.toString(2)).toBe('(1.23, 2.35, 3.46)');
+  });
+
+  it('can find the min and max between vectors', () => {
+    const v1 = new ex.Vector3(0, 5, 2);
+    const v2 = new ex.Vector3(2, 1, 8);
+
+    expect(ex.Vector3.min(v1, v2).equals(new ex.Vector3(0, 1, 2))).toBeTruthy();
+    expect(ex.Vector3.max(v1, v2).equals(new ex.Vector3(2, 5, 8))).toBeTruthy();
+  });
+
+  it('can clamp magnitude', () => {
+    const sut = new ex.Vector3(10, 0, 0);
+    sut.clampMagnitude(5);
+    expect(sut.magnitude).toBe(5);
+    expect(sut.x).toBe(5);
+  });
+
+  it('can lerp between vectors and clamp t', () => {
+    const start = new ex.Vector3(0, 0, 0);
+    const end = new ex.Vector3(10, 20, 30);
+
+    const mid = start.lerp(end, 0.5);
+    expect(mid.equals(new ex.Vector3(5, 10, 15))).toBeTruthy();
+
+    const clampedOver = start.lerp(end, 2);
+    expect(clampedOver.equals(end)).toBeTruthy();
+
+    const clampedUnder = start.lerp(end, -1);
+    expect(clampedUnder.equals(start)).toBeTruthy();
+  });
+});
+
+describe('vec3 helper', () => {
+  it('returns a new ex.Vector3 instance', () => {
+    const v1 = ex.vec3(1, 2, 3);
+    const v2 = ex.vec3(1, 2, 3);
+
+    expect(v1 instanceof ex.Vector3).toBe(true);
+    expect(v1).not.toBe(v2);
+    expect(v1.x).toBe(1);
+    expect(v1.y).toBe(2);
+    expect(v1.z).toBe(3);
+  });
+});

--- a/src/spec/vitest/vector4-spec.ts
+++ b/src/spec/vitest/vector4-spec.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import * as ex from '@excalibur';
+
+describe('Vector4', () => {
+  it('should exist', () => {
+    expect(ex.Vector4).toBeDefined();
+  });
+
+  it('can be instantiated', () => {
+    const v = new ex.Vector4(1, 2, 3, 4);
+    expect(v).not.toBeNull();
+    expect(v.x).toBe(1);
+    expect(v.y).toBe(2);
+    expect(v.z).toBe(3);
+    expect(v.w).toBe(4);
+  });
+
+  it('can have values set', () => {
+    const v = new ex.Vector4(1, 2, 3, 4);
+    v.setTo(10, 20, 30, 40);
+
+    expect(v.x).toEqual(10);
+    expect(v.y).toEqual(20);
+    expect(v.z).toEqual(30);
+    expect(v.w).toEqual(40);
+  });
+
+  it('has static constants and homogeneous constructors', () => {
+    expect(ex.Vector4.Zero.equals(new ex.Vector4(0, 0, 0, 0))).toBeTruthy();
+    expect(ex.Vector4.One.equals(new ex.Vector4(1, 1, 1, 1))).toBeTruthy();
+
+    const v3 = new ex.Vector3(2, 4, 6);
+    const point = ex.Vector4.fromPoint(v3);
+    expect(point.equals(new ex.Vector4(2, 4, 6, 1))).toBeTruthy();
+
+    const dir = ex.Vector4.fromDirection(v3);
+    expect(dir.equals(new ex.Vector4(2, 4, 6, 0))).toBeTruthy();
+  });
+
+  it('can convert to Vector3 with perspective divide', () => {
+    const p1 = new ex.Vector4(2, 4, 6, 1);
+    expect(p1.toVector3().equals(new ex.Vector3(2, 4, 6))).toBeTruthy();
+
+    const p2 = new ex.Vector4(4, 8, 12, 2);
+    expect(p2.toVector3().equals(new ex.Vector3(2, 4, 6))).toBeTruthy();
+
+    const dir = new ex.Vector4(2, 4, 6, 0);
+    expect(dir.toVector3().equals(new ex.Vector3(2, 4, 6))).toBeTruthy();
+  });
+
+  it('can transform by Matrix 4x4', () => {
+    const mat = ex.Matrix.identity();
+    mat.data[12] = 10; // Translation X
+    mat.data[13] = 20; // Translation Y
+    mat.data[14] = 30; // Translation Z
+
+    const point = ex.Vector4.fromPoint(new ex.Vector3(1, 2, 3));
+    const transformedPoint = point.transform(mat);
+    expect(transformedPoint.equals(new ex.Vector4(11, 22, 33, 1))).toBeTruthy();
+
+    const dir = ex.Vector4.fromDirection(new ex.Vector3(1, 2, 3));
+    const transformedDir = dir.transform(mat);
+    expect(transformedDir.equals(new ex.Vector4(1, 2, 3, 0))).toBeTruthy();
+  });
+
+  it('can calculate distance and magnitude', () => {
+    const v = new ex.Vector4(2, 3, 6, 0);
+    expect(v.magnitude).toBe(7);
+
+    // 3^2 + 4^2 + 12^2 + 0^2 = 9 + 16 + 144 + 0 = 169 (sqrt is 13)
+    const v2 = new ex.Vector4(3, 4, 12, 0);
+    expect(v2.distance()).toBe(13);
+  });
+
+  it('can be normalized', () => {
+    const v = new ex.Vector4(0, 0, 10, 0);
+    expect(v.normalize().equals(new ex.Vector4(0, 0, 1, 0))).toBeTruthy();
+  });
+
+  it('can be added, subtracted, scaled, and dotted', () => {
+    const v1 = new ex.Vector4(1, 2, 3, 4);
+    const v2 = new ex.Vector4(2, 3, 4, 5);
+
+    expect(v1.add(v2).equals(new ex.Vector4(3, 5, 7, 9))).toBeTruthy();
+    expect(v2.sub(v1).equals(new ex.Vector4(1, 1, 1, 1))).toBeTruthy();
+    expect(v1.scale(2).equals(new ex.Vector4(2, 4, 6, 8))).toBeTruthy();
+    expect(v1.dot(v2)).toBe(1 * 2 + 2 * 3 + 3 * 4 + 4 * 5);
+  });
+
+  it('can handle in-place mutators', () => {
+    const v = new ex.Vector4(1, 1, 1, 1);
+
+    v.addEqual(new ex.Vector4(1, 2, 3, 4));
+    expect(v.equals(new ex.Vector4(2, 3, 4, 5))).toBeTruthy();
+
+    v.subEqual(new ex.Vector4(1, 1, 1, 1));
+    expect(v.equals(new ex.Vector4(1, 2, 3, 4))).toBeTruthy();
+
+    v.scaleEqual(2);
+    expect(v.equals(new ex.Vector4(2, 4, 6, 8))).toBeTruthy();
+  });
+
+  it('can convert to array structures', () => {
+    const v = new ex.Vector4(1, 2, 3, 4);
+    expect(v.toArray()).toEqual([1, 2, 3, 4]);
+
+    const f32 = v.toFloat32Array();
+    expect(f32).toBeInstanceOf(Float32Array);
+    expect(f32[3]).toBe(4);
+
+    const restored = ex.Vector4.fromArray([1, 2, 3, 4, 5], 1);
+    expect(restored.equals(new ex.Vector4(2, 3, 4, 5))).toBeTruthy();
+  });
+
+  it('can be checked for validity', () => {
+    expect(ex.Vector4.isValid(new ex.Vector4(0, 0, 0, Infinity))).toBe(false);
+    expect(ex.Vector4.isValid(new ex.Vector4(0, NaN, 0, 0))).toBe(false);
+    expect(ex.Vector4.isValid(null as any)).toBe(false);
+    expect(ex.Vector4.isValid(new ex.Vector4(1, 2, 3, 4))).toBe(true);
+  });
+
+  it('can clone and format string', () => {
+    const v = new ex.Vector4(1, 2, 3, 4);
+    const c = v.clone();
+    expect(c.equals(v)).toBeTruthy();
+
+    v.setTo(0, 0, 0, 0);
+    expect(c.equals(v)).toBeFalsy();
+
+    const formatted = new ex.Vector4(1.234, 2.345, 3.456, 4.567);
+    expect(formatted.toString(2)).toBe('(1.23, 2.35, 3.46, 4.57)');
+  });
+
+  it('can lerp between vectors', () => {
+    const start = new ex.Vector4(0, 0, 0, 0);
+    const end = new ex.Vector4(10, 20, 30, 40);
+
+    const mid = start.lerp(end, 0.5);
+    expect(mid.equals(new ex.Vector4(5, 10, 15, 20))).toBeTruthy();
+  });
+});
+
+describe('vec4 helper', () => {
+  it('returns a new ex.Vector4 instance', () => {
+    const v1 = ex.vec4(1, 2, 3, 4);
+    const v2 = ex.vec4(1, 2, 3, 4);
+
+    expect(v1 instanceof ex.Vector4).toBe(true);
+    expect(v1).not.toBe(v2);
+    expect(v1.x).toBe(1);
+    expect(v1.y).toBe(2);
+    expect(v1.z).toBe(3);
+    expect(v1.w).toBe(4);
+  });
+});


### PR DESCRIPTION
I added Vector3 and Vector4 classes, with vec3 and vec4 aliases...
I updated Shader.ts to accept vec3 and vec4 to improve shader interface.

Added vec3 and vec4 spec tests that are aligned with existing Vector classes and specs

DID NOT TOUCH matrix.ts, maybe something to update in future

Updated Vector docs