### PR TITLE
Rename 'fcn' to 'action' in timer example

### DIFF
--- a/site/docs/12-other/11-timers.mdx
+++ b/site/docs/12-other/11-timers.mdx
@@ -14,7 +14,7 @@ Timers do not start until they are explicitly started with `.start()` and added 
 
 ```typescript
 const timer = new ex.Timer({
-  fcn: () => console.log('Every 100 ms'),
+  action: () => console.log('Every 100 ms'),
   repeats: true,
   interval: 100,
 })


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

Came across this in the documentation. 'fcn' seems to be outdated in favor of 'action', so I just wanted to suggest the change in documentation.

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/main/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->
